### PR TITLE
Slice keyed and xarray-backed formats directly in read_array

### DIFF
--- a/dascore/io/dasdae/utils.py
+++ b/dascore/io/dasdae/utils.py
@@ -15,8 +15,6 @@ import dascore as dc
 from dascore.core.attrs import PatchAttrs
 from dascore.core.coordmanager import get_coord_manager
 from dascore.core.coords import get_coord
-from dascore.core.summary import normalize_source_patch_key
-from dascore.exceptions import MissingPatchError, PatchAttributeError
 from dascore.io.core import STORED_PATCH_ID, make_scan_payload
 from dascore.io.dasdae._compat import (
     NOT_DECODED,
@@ -24,7 +22,7 @@ from dascore.io.dasdae._compat import (
     strip_legacy_coord_fields,
     translate_legacy_attrs,
 )
-from dascore.io.utils import get_exact_coord
+from dascore.io.utils import get_exact_coord, resolve_keyed_source
 from dascore.models.registry import get_model_tag, resolve_tagged_model
 from dascore.utils.array import (
     convert_bytes_to_strings,
@@ -297,29 +295,11 @@ def _get_patch_group(h5, source_patch_key=""):
     """
     Return the one waveform group a source patch key names.
 
-    Without a key, a file holding exactly one patch resolves to it. An
-    empty file raises MissingPatchError; several patches without a key,
-    or a key naming no group, raise PatchAttributeError, the types the
-    default `read_array` raises.
+    A key names a direct child of the waveform group, never an h5py path.
     """
-    key = normalize_source_patch_key(source_patch_key)
     waveforms = h5.get("waveforms", {})
-    if not len(waveforms):
-        msg = f"No patches in {h5.filename}."
-        raise MissingPatchError(msg)
-    if key:
-        # h5py reads a key as a path, so "<name>/data" or "/waveforms"
-        # would resolve to something; only a direct child by that name,
-        # which never holds a separator, is a patch
-        group = waveforms.get(key) if "/" not in key and key in waveforms else None
-        if group is None or group.name != f"{waveforms.name}/{key}":
-            msg = f"No patch named '{key}' in {h5.filename}."
-            raise PatchAttributeError(msg)
-        return group
-    if len(waveforms) > 1:
-        msg = f"{h5.filename} holds several patches; pass source_patch_key."
-        raise PatchAttributeError(msg)
-    return next(iter(waveforms.values()))
+    groups = dict(waveforms.items()) if len(waveforms) else {}
+    return resolve_keyed_source(groups, source_patch_key, where=str(h5.filename))
 
 
 def _matches_attr_filters(attrs, kwargs):

--- a/dascore/io/dasdae/utils.py
+++ b/dascore/io/dasdae/utils.py
@@ -15,6 +15,8 @@ import dascore as dc
 from dascore.core.attrs import PatchAttrs
 from dascore.core.coordmanager import get_coord_manager
 from dascore.core.coords import get_coord
+from dascore.core.summary import normalize_source_patch_key
+from dascore.exceptions import PatchAttributeError
 from dascore.io.core import STORED_PATCH_ID, make_scan_payload
 from dascore.io.dasdae._compat import (
     NOT_DECODED,
@@ -298,8 +300,11 @@ def _get_patch_group(h5, source_patch_key=""):
     A key names a direct child of the waveform group, never an h5py path.
     """
     waveforms = h5.get("waveforms", {})
-    groups = dict(waveforms.items()) if len(waveforms) else {}
-    return resolve_keyed_source(groups, source_patch_key, where=str(h5.filename))
+    key = normalize_source_patch_key(source_patch_key)
+    if "/" in key:
+        # h5py would read the key as a path; a patch is a direct child
+        raise PatchAttributeError(f"No patch named '{key}' in {h5.filename}.")
+    return resolve_keyed_source(waveforms, key, where=str(h5.filename))
 
 
 def _matches_attr_filters(attrs, kwargs):

--- a/dascore/io/dashdf5/core.py
+++ b/dascore/io/dashdf5/core.py
@@ -4,13 +4,21 @@ from __future__ import annotations
 
 from typing import Literal
 
+import numpy as np
+
 import dascore as dc
 from dascore.constants import opt_timeable_types
 from dascore.io import FiberIO, ScanPayload, make_scan_payload
-from dascore.io.utils import build_patches
+from dascore.io.utils import build_patches, slice_dataset
 from dascore.utils.hdf5 import H5Reader
+from dascore.utils.misc import raise_on_extra_kwargs
 
-from .utils import _get_cf_attrs, _get_cf_coords, _get_cf_version_str
+from .utils import (
+    _get_cf_attrs,
+    _get_cf_coords,
+    _get_cf_dims,
+    _get_cf_version_str,
+)
 
 
 class DASHDF5(FiberIO):
@@ -65,3 +73,15 @@ class DASHDF5(FiberIO):
             selection={"time": time, "channel": channel},
         )
         return dc.spool(patches)
+
+    def read_array(
+        self, resource: H5Reader, windows: dict[str, tuple[int, int]], **kwargs
+    ) -> np.ndarray:
+        """
+        Slice the ``das`` dataset directly.
+
+        The dimension order is the one the dataset's shape implies, which
+        is what `scan` reports.
+        """
+        raise_on_extra_kwargs(kwargs, "windows")
+        return slice_dataset(resource["das"], _get_cf_dims(resource), windows)

--- a/dascore/io/dashdf5/core.py
+++ b/dascore/io/dashdf5/core.py
@@ -75,7 +75,11 @@ class DASHDF5(FiberIO):
         return dc.spool(patches)
 
     def read_array(
-        self, resource: H5Reader, windows: dict[str, tuple[int, int]], **kwargs
+        self,
+        resource: H5Reader,
+        windows: dict[str, tuple[int, int]],
+        snap: bool = True,
+        **kwargs,
     ) -> np.ndarray:
         """
         Slice the ``das`` dataset directly.
@@ -83,5 +87,5 @@ class DASHDF5(FiberIO):
         The dimension order is the one the dataset's shape implies, which
         is what `scan` reports.
         """
-        raise_on_extra_kwargs(kwargs, "windows")
+        raise_on_extra_kwargs(kwargs, "windows and snap")
         return slice_dataset(resource["das"], _get_cf_dims(resource), windows)

--- a/dascore/io/dashdf5/utils.py
+++ b/dascore/io/dashdf5/utils.py
@@ -34,6 +34,9 @@ def _get_cf_version_str(hdf_fi) -> str | Literal[False]:
     return das_hdf_str[0].replace("DAS-HDF5-", "")
 
 
+_CF_DIMS = ("channel", "time")
+
+
 def _get_cf_coords(hdf_fi, minimal=False, snap=True) -> dc.core.CoordManager:
     """
     Get a coordinate manager of full file range.
@@ -72,16 +75,25 @@ def _get_cf_coords(hdf_fi, minimal=False, snap=True) -> dc.core.CoordManager:
         "y": ("channel",),
         "z": ("channel",),
     }
-    dims = ("channel", "time")
     cm = dc.core.CoordManager(
         coord_map=coords_map,
         dim_map=dim_map,
-        dims=dims,
+        dims=_CF_DIMS,
     )
-    # a bit of a hack to make sure data and coords align.
-    if cm.shape != hdf_fi["das"].shape:
+    if cm.dims != _get_cf_dims(hdf_fi):
         cm = cm.transpose()
     return cm
+
+
+def _get_cf_dims(hdf_fi) -> tuple[str, str]:
+    """
+    The stored dimension order of the ``das`` dataset.
+
+    The format does not state it, so it is read off the dataset's shape:
+    the channel-major order unless only the other one fits.
+    """
+    shape = (len(hdf_fi["channel"]), len(hdf_fi["t"]))
+    return _CF_DIMS if hdf_fi["das"].shape == shape else _CF_DIMS[::-1]
 
 
 def _get_cf_attrs(hdf_fi, coords=None, extras=None):

--- a/dascore/io/dasvader/core.py
+++ b/dascore/io/dasvader/core.py
@@ -4,16 +4,21 @@ from __future__ import annotations
 
 from typing import Literal
 
+import numpy as np
+
 import dascore as dc
 from dascore.constants import opt_timeable_types
 from dascore.io import FiberIO, ScanPayload, make_scan_payload
+from dascore.io.utils import slice_dataset
 from dascore.utils.hdf5 import H5Reader
+from dascore.utils.misc import raise_on_extra_kwargs
 
 from .utils import (
     DATA_NAMES,
     _dereference,
     _get_attr_dict,
     _get_coord_manager,
+    _get_data_and_dims,
     _get_reference_names,
     _is_dasvader_jld2,
     _read_dasvader,
@@ -83,3 +88,16 @@ class DASVaderV1(FiberIO):
         """Read a DASVader spool of patches."""
         patches = _read_dasvader(resource, time=time, distance=distance)
         return dc.spool(patches)
+
+    def read_array(
+        self, resource: H5Reader, windows: dict[str, tuple[int, int]], **kwargs
+    ) -> np.ndarray:
+        """
+        Slice the data reference's dataset directly.
+
+        Only the ``dDAS`` record, which names the reference, is read
+        besides the requested block.
+        """
+        raise_on_extra_kwargs(kwargs, "windows")
+        dataset, dims = _get_data_and_dims(resource)
+        return slice_dataset(dataset, dims, windows)

--- a/dascore/io/dasvader/core.py
+++ b/dascore/io/dasvader/core.py
@@ -9,7 +9,7 @@ import numpy as np
 import dascore as dc
 from dascore.constants import opt_timeable_types
 from dascore.io import FiberIO, ScanPayload, make_scan_payload
-from dascore.io.utils import slice_dataset
+from dascore.io.utils import resolve_keyed_source, slice_dataset
 from dascore.utils.hdf5 import H5Reader
 from dascore.utils.misc import raise_on_extra_kwargs
 
@@ -90,14 +90,21 @@ class DASVaderV1(FiberIO):
         return dc.spool(patches)
 
     def read_array(
-        self, resource: H5Reader, windows: dict[str, tuple[int, int]], **kwargs
+        self,
+        resource: H5Reader,
+        windows: dict[str, tuple[int, int]],
+        source_patch_key="",
+        **kwargs,
     ) -> np.ndarray:
         """
         Slice the data reference's dataset directly.
 
         Only the ``dDAS`` record, which names the reference, is read
-        besides the requested block.
+        besides the requested block. A file holds one patch, so the key
+        `scan` reports is empty; any other is refused.
         """
-        raise_on_extra_kwargs(kwargs, "windows")
+        raise_on_extra_kwargs(kwargs, "windows and source_patch_key")
         dataset, dims = _get_data_and_dims(resource)
+        where = str(getattr(resource, "filename", "the resource"))
+        resolve_keyed_source({"": dataset}, source_patch_key, where=where)
         return slice_dataset(dataset, dims, windows)

--- a/dascore/io/dasvader/utils.py
+++ b/dascore/io/dasvader/utils.py
@@ -158,11 +158,25 @@ def _get_coord_manager(h5, rec):
     dist = _get_distance_coord(rec)
     # The data axis is transposed based on if they are stored in "strainrate"
     # or "data" reference.
-    dims = ("distance", "time") if "data" in names else ("time", "distance")
     return dc.get_coord_manager(
         {"time": time, "distance": dist},
-        dims=dims,
+        dims=_get_dims(names),
     )
+
+
+def _get_dims(names) -> tuple[str, str]:
+    """The stored dimension order, which the data reference's name says."""
+    # The data axis is transposed based on if they are stored in
+    # "strainrate" or "data" reference.
+    return ("distance", "time") if "data" in names else ("time", "distance")
+
+
+def _get_data_and_dims(h5, rec=None):
+    """Resolve the data reference to its dataset, with its dimension order."""
+    rec = h5["dDAS"][()] if rec is None else rec
+    names = set(_get_reference_names(h5))
+    data_name = "data" if "data" in names else next(iter(DATA_NAMES & names))
+    return _dereference(h5, rec[data_name], data_name), _get_dims(names)
 
 
 # --- Reading
@@ -195,12 +209,8 @@ def _read_dasvader(h5, distance=None, time=None):
     """Read DASVader data into a Patch."""
     rec = h5["dDAS"][()]
     cm = _get_coord_manager(h5, rec)
-    # First, figure out what the data name is (this changes in different
-    # dasvader iterations), but if we get to here it has at least one.
     ref_names = set(_get_reference_names(h5))
-    data_name = "data" if "data" in ref_names else next(iter(DATA_NAMES & ref_names))
-    # data is a reference here; need to resolve it with h5 File.
-    data = _dereference(h5, rec[data_name], data_name)
+    data, _ = _get_data_and_dims(h5, rec)
     attrs = (
         _get_attr_dict(_dereference(h5, rec["atrib"], "atrib"))
         if "atrib" in ref_names

--- a/dascore/io/h5simple/core.py
+++ b/dascore/io/h5simple/core.py
@@ -64,7 +64,8 @@ class H5Simple(FiberIO):
 
         The dimensions come from the file's ``dims`` attribute, or from
         which node's length matches each axis, exactly as `read` resolves
-        them; no coordinate values are read either way.
+        them. No coordinate values are read either way, and the axis no
+        node accounts for is named without building its index.
         """
         raise_on_extra_kwargs(kwargs, "windows and snap")
         dims, data_node = _get_dims_and_data(resource)

--- a/dascore/io/h5simple/core.py
+++ b/dascore/io/h5simple/core.py
@@ -62,8 +62,9 @@ class H5Simple(FiberIO):
         """
         Slice the data node directly.
 
-        The dimensions are resolved from node shapes alone, as `read`
-        resolves them; ``snap`` only changes coordinate values.
+        The dimensions come from the file's ``dims`` attribute, or from
+        which node's length matches each axis, exactly as `read` resolves
+        them; no coordinate values are read either way.
         """
         raise_on_extra_kwargs(kwargs, "windows and snap")
         dims, data_node = _get_dims_and_data(resource)

--- a/dascore/io/h5simple/core.py
+++ b/dascore/io/h5simple/core.py
@@ -4,12 +4,19 @@ from __future__ import annotations
 
 from typing import Literal
 
+import numpy as np
+
 import dascore as dc
 from dascore.io import FiberIO, ScanPayload, make_scan_payload
-from dascore.io.utils import build_patches
+from dascore.io.utils import build_patches, slice_dataset
 from dascore.utils.hdf5 import H5Reader
+from dascore.utils.misc import raise_on_extra_kwargs
 
-from .utils import _get_attrs_coords_and_data, _is_h5simple
+from .utils import (
+    _get_attrs_coords_and_data,
+    _get_dims_and_data,
+    _is_h5simple,
+)
 
 
 class H5Simple(FiberIO):
@@ -44,6 +51,23 @@ class H5Simple(FiberIO):
         """
         attrs, cm, data = _get_attrs_coords_and_data(resource, snap)
         return dc.spool(build_patches(cm, data, attrs, selection=kwargs))
+
+    def read_array(
+        self,
+        resource: H5Reader,
+        windows: dict[str, tuple[int, int]],
+        snap: bool = True,
+        **kwargs,
+    ) -> np.ndarray:
+        """
+        Slice the data node directly.
+
+        The dimensions are resolved from node shapes alone, as `read`
+        resolves them; ``snap`` only changes coordinate values.
+        """
+        raise_on_extra_kwargs(kwargs, "windows and snap")
+        dims, data_node = _get_dims_and_data(resource)
+        return slice_dataset(data_node, dims, windows)
 
     def scan(self, resource: H5Reader, snap=True, **kwargs) -> list[ScanPayload]:
         """Get the attributes of a h5simple file."""

--- a/dascore/io/h5simple/utils.py
+++ b/dascore/io/h5simple/utils.py
@@ -51,9 +51,9 @@ def _get_coord(v, snap, name):
     return coord
 
 
-def _fill_coords(coord_shape_dict, other_nodes, data_node):
+def _name_missing_dim(coord_shape_dict, data_node) -> int:
     """
-    Fill missing coordinate with "channel".
+    Name the one axis no node accounts for "channel", and return its length.
 
     This is needed because the foresee data on pubdas only specify time;
     we have to fill in channel number.
@@ -62,8 +62,7 @@ def _fill_coords(coord_shape_dict, other_nodes, data_node):
     assert len(missing_shape) == 1, "can only fill one missing coord."
     shape = next(iter(missing_shape))
     coord_shape_dict[shape] = "channel"
-    other_nodes["channel"] = np.arange(shape)
-    return other_nodes, coord_shape_dict
+    return shape
 
 
 def _get_dims(data_node, time_node, other_nodes, dims=None):
@@ -85,11 +84,7 @@ def _get_dims(data_node, time_node, other_nodes, dims=None):
     coord_shape_dict[len(time_node)] = "time"
     # need to fill some dims
     if len(coord_shape_dict) != len(data_node.shape):
-        other_nodes, coord_shape_dict = _fill_coords(
-            coord_shape_dict,
-            other_nodes,
-            data_node,
-        )
+        _name_missing_dim(coord_shape_dict, data_node)
     return tuple(coord_shape_dict[x] for x in data_node.shape), other_nodes
 
 
@@ -97,6 +92,10 @@ def _get_coords_and_dims(data_node, time_node, other_nodes, snap=True, dims=None
     """Get dims tuple and coord dict."""
     dims, other_nodes = _get_dims(data_node, time_node, other_nodes, dims)
     other_nodes["time"] = time_node
+    # the filled axis is named but not built: only coordinates need it
+    if "channel" in dims and "channel" not in other_nodes:
+        length = data_node.shape[dims.index("channel")]
+        other_nodes["channel"] = np.arange(length)
     coords = {i: _get_coord(v, snap=snap, name=i) for i, v in other_nodes.items()}
     return dims, coords
 

--- a/dascore/io/h5simple/utils.py
+++ b/dascore/io/h5simple/utils.py
@@ -66,35 +66,43 @@ def _fill_coords(coord_shape_dict, other_nodes, data_node):
     return other_nodes, coord_shape_dict
 
 
+def _get_dims(data_node, time_node, other_nodes, dims=None):
+    """
+    Get the dims tuple, and the coord nodes any filling added.
+
+    The format does not have to state its dimensions; when it does not,
+    each is named by the node whose length matches that axis. Only node
+    shapes are read here, never their values.
+    """
+    if dims:
+        stated = tuple(dims.split(",")) if isinstance(dims, str) else tuple(dims)
+        return stated, other_nodes
+    can_guess_shape = len(data_node.shape) == len(set(data_node.shape))
+    assert can_guess_shape, "Cant determine dims; shape values not unique!"
+    assert len(time_node.shape) == 1, "time node has more than one dimension!"
+    # get a dict of {coord_name: shape} for 1d coords.
+    coord_shape_dict = {len(v): x for x, v in other_nodes.items() if len(v.shape) == 1}
+    coord_shape_dict[len(time_node)] = "time"
+    # need to fill some dims
+    if len(coord_shape_dict) != len(data_node.shape):
+        other_nodes, coord_shape_dict = _fill_coords(
+            coord_shape_dict,
+            other_nodes,
+            data_node,
+        )
+    return tuple(coord_shape_dict[x] for x in data_node.shape), other_nodes
+
+
 def _get_coords_and_dims(data_node, time_node, other_nodes, snap=True, dims=None):
     """Get dims tuple and coord dict."""
-    if dims:
-        dims = dims if not isinstance(dims, str) else dims.split(",")
-    else:  # ascertain dims from shape
-        can_guess_shape = len(data_node.shape) == len(set(data_node.shape))
-        assert can_guess_shape, "Cant determine dims; shape values not unique!"
-        assert len(time_node.shape) == 1, "time node has more than one dimension!"
-        # get a dict of {coord_name: shape} for 1d coords.
-        coord_shape_dict = {
-            len(v): x for x, v in other_nodes.items() if len(v.shape) == 1
-        }
-        coord_shape_dict[len(time_node)] = "time"
-        # need to fill some dims
-        if len(coord_shape_dict) != len(data_node.shape):
-            other_nodes, coord_shape_dict = _fill_coords(
-                coord_shape_dict,
-                other_nodes,
-                data_node,
-            )
-
-        dims = tuple(coord_shape_dict[x] for x in data_node.shape)
+    dims, other_nodes = _get_dims(data_node, time_node, other_nodes, dims)
     other_nodes["time"] = time_node
     coords = {i: _get_coord(v, snap=snap, name=i) for i, v in other_nodes.items()}
     return dims, coords
 
 
-def _get_cm_and_data(h5, snap=False, dims=None):
-    """Extract coordinate manager and data node."""
+def _get_nodes(h5):
+    """Return the file's data node, time node, and other array nodes."""
     root_nodes = {name: node for name, node in h5.items() if hasattr(node, "shape")}
     array_names = set(root_nodes)
     data_node_name = array_names & DATA_ARRAY_NAMES
@@ -104,10 +112,24 @@ def _get_cm_and_data(h5, snap=False, dims=None):
     assert len(data_node_name) == 1, f"{h5} doesn't have exactly one data node."
     assert len(time_node_name) == 1, f"{h5} doesn't have exactly one time node"
 
-    data_node = root_nodes[next(iter(data_node_name))]
-    time_node = root_nodes[next(iter(time_node_name))]
-    other_nodes = {x: root_nodes[x] for x in other_node_names}
+    return (
+        root_nodes[next(iter(data_node_name))],
+        root_nodes[next(iter(time_node_name))],
+        {x: root_nodes[x] for x in other_node_names},
+    )
 
+
+def _get_dims_and_data(h5):
+    """Return the data node's dims and the node itself, reading no values."""
+    dims_attr = unbyte(h5.attrs["dims"]) if "dims" in h5.attrs else None
+    data_node, time_node, other_nodes = _get_nodes(h5)
+    dims, _ = _get_dims(data_node, time_node, other_nodes, dims_attr)
+    return dims, data_node
+
+
+def _get_cm_and_data(h5, snap=False, dims=None):
+    """Extract coordinate manager and data node."""
+    data_node, time_node, other_nodes = _get_nodes(h5)
     dims, coords = _get_coords_and_dims(data_node, time_node, other_nodes, snap, dims)
     return dc.core.get_coord_manager(coords, dims=dims), data_node
 

--- a/dascore/io/netcdf/core.py
+++ b/dascore/io/netcdf/core.py
@@ -12,10 +12,14 @@ import dascore as dc
 from dascore.exceptions import MissingOptionalDependencyError
 from dascore.io import FiberIO
 from dascore.io.core import ScanPayload, make_scan_payload
-from dascore.io.utils import get_exact_coord
+from dascore.io.utils import (
+    get_exact_coord,
+    resolve_keyed_source,
+    windows_to_slices,
+)
 from dascore.utils.hdf5 import H5Reader, get_h5py_file
 from dascore.utils.io import patch_to_xarray, xarray_to_patch
-from dascore.utils.misc import optional_import
+from dascore.utils.misc import optional_import, raise_on_extra_kwargs
 
 from .utils import (
     XDAS_PAYLOAD_VARIABLE,
@@ -129,6 +133,32 @@ class NetCDFCFV18(FiberIO):
         if not patch.data.size:
             return dc.spool([])
         return dc.spool([patch])
+
+    def read_array(
+        self,
+        resource: H5Reader,
+        windows: dict[str, tuple[int, int]],
+        source_patch_key="",
+        **kwargs,
+    ) -> np.ndarray:
+        """
+        Slice the payload variable through xarray.
+
+        The selection goes through xarray rather than the stored dataset
+        so CF decoding (scaling, offsets, fill values) applies exactly as
+        it does in `read`.
+        """
+        raise_on_extra_kwargs(kwargs, "windows and source_patch_key")
+        with _open_xarray_dataset(resource) as dataset:
+            data_var_name = get_xarray_data_var_name(dataset)
+            resolve_keyed_source(
+                {self._get_source_patch_key(data_var_name): data_var_name},
+                source_patch_key,
+                where=str(getattr(resource, "filename", "the resource")),
+            )
+            data_array = dataset[data_var_name]
+            slices = windows_to_slices(windows, data_array.dims, data_array.shape)
+            return data_array[slices].to_numpy()
 
     def _get_write_encoding(self, **kwargs):
         """Translate explicit write options into xarray encoding hints."""

--- a/dascore/io/netcdf/core.py
+++ b/dascore/io/netcdf/core.py
@@ -139,6 +139,7 @@ class NetCDFCFV18(FiberIO):
         resource: H5Reader,
         windows: dict[str, tuple[int, int]],
         source_patch_key="",
+        snap: bool = True,
         **kwargs,
     ) -> np.ndarray:
         """
@@ -148,7 +149,7 @@ class NetCDFCFV18(FiberIO):
         so CF decoding (scaling, offsets, fill values) applies exactly as
         it does in `read`.
         """
-        raise_on_extra_kwargs(kwargs, "windows and source_patch_key")
+        raise_on_extra_kwargs(kwargs, "windows, source_patch_key and snap")
         with _open_xarray_dataset(resource) as dataset:
             data_var_name = get_xarray_data_var_name(dataset)
             resolve_keyed_source(

--- a/dascore/io/prodml/core.py
+++ b/dascore/io/prodml/core.py
@@ -88,6 +88,7 @@ class ProdMLV2_0(FiberIO):  # noqa
         resource: H5Reader,
         windows: dict[str, tuple[int, int]],
         source_patch_key="",
+        snap: bool = True,
         **kwargs,
     ) -> np.ndarray:
         """
@@ -97,7 +98,7 @@ class ProdMLV2_0(FiberIO):  # noqa
         ``Raw[0]`` or ``FbeData[0]``); a file holding several nodes needs
         one.
         """
-        raise_on_extra_kwargs(kwargs, "windows and source_patch_key")
+        raise_on_extra_kwargs(kwargs, "windows, source_patch_key and snap")
         dataset, dims = _get_data_node(resource, source_patch_key)
         return slice_dataset(dataset, dims, windows)
 

--- a/dascore/io/prodml/core.py
+++ b/dascore/io/prodml/core.py
@@ -4,12 +4,17 @@ from __future__ import annotations
 
 from typing import Literal
 
+import numpy as np
+
 import dascore as dc
 from dascore.constants import opt_timeable_types
 from dascore.io import FiberIO, ScanPayload, make_scan_payload
+from dascore.io.utils import slice_dataset
+from dascore.utils.misc import raise_on_extra_kwargs
 
 from ...utils.hdf5 import H5Reader, H5Writer
 from .utils import (
+    _get_data_node,
     _get_prodml_version_str,
     _read_prodml,
     _write_prodml,
@@ -77,6 +82,24 @@ class ProdMLV2_0(FiberIO):  # noqa
             source_patch_key=source_patch_key,
         )
         return dc.spool(patches)
+
+    def read_array(
+        self,
+        resource: H5Reader,
+        windows: dict[str, tuple[int, int]],
+        source_patch_key="",
+        **kwargs,
+    ) -> np.ndarray:
+        """
+        Slice one acquisition node's data array directly.
+
+        ``source_patch_key`` is the node name `scan` reports (for example
+        ``Raw[0]`` or ``FbeData[0]``); a file holding several nodes needs
+        one.
+        """
+        raise_on_extra_kwargs(kwargs, "windows and source_patch_key")
+        dataset, dims = _get_data_node(resource, source_patch_key)
+        return slice_dataset(dataset, dims, windows)
 
 
 class ProdMLV2_1(ProdMLV2_0):  # noqa

--- a/dascore/io/prodml/utils.py
+++ b/dascore/io/prodml/utils.py
@@ -484,15 +484,26 @@ def _write_prodml(spool, resource):
 
 
 def _get_node_dims(node_info) -> tuple[str, ...]:
-    """The stored dimension order of a data node, as `scan` reports it."""
+    """
+    The stored dimension order of a data node, as `scan` reports it.
+
+    A node states its own ``Dimensions`` where it has them; a raw node
+    states them on its data array, and a processed one which states none
+    falls back to its parent's.
+    """
     if node_info.patch_type == "raw":
         return _get_dims_from_attrs(node_info.node["RawData"].attrs)
-    return _get_dims_from_attrs(node_info.parent_node.attrs)
+    attrs = node_info.node.attrs
+    if "Dimensions" not in attrs:
+        attrs = node_info.parent_node.attrs
+    return _get_dims_from_attrs(attrs)
 
 
 def _get_data_node(h5, source_patch_key=""):
     """Return the (dataset, dims) the key names, keyed as `scan` keys them."""
-    nodes = {info.name: info for info in _yield_data_nodes(h5)}
+    # pairs, not a mapping: a file may name two nodes alike, and the
+    # default read refuses such a key rather than picking one
+    nodes = [(info.name, info) for info in _yield_data_nodes(h5)]
     info = resolve_keyed_source(nodes, source_patch_key, where=str(h5.filename))
     return _NODE_DATA_PROCESSORS[info.patch_type](info), _get_node_dims(info)
 

--- a/dascore/io/prodml/utils.py
+++ b/dascore/io/prodml/utils.py
@@ -14,7 +14,7 @@ import dascore as dc
 from dascore.constants import VALID_DATA_TYPES
 from dascore.core.coords import get_coord
 from dascore.exceptions import InvalidSpoolError, PatchError
-from dascore.io.utils import convert_attr_units, get_exact_coord
+from dascore.io.utils import convert_attr_units, get_exact_coord, resolve_keyed_source
 from dascore.models import OptionalFiniteFloat, UTF8Str
 from dascore.units import get_quantity_str
 from dascore.utils.hdf5 import encode_h5_strings
@@ -483,6 +483,20 @@ def _write_prodml(spool, resource):
     raw_time.attrs.update(time_attrs)
 
 
+def _get_node_dims(node_info) -> tuple[str, ...]:
+    """The stored dimension order of a data node, as `scan` reports it."""
+    if node_info.patch_type == "raw":
+        return _get_dims_from_attrs(node_info.node["RawData"].attrs)
+    return _get_dims_from_attrs(node_info.parent_node.attrs)
+
+
+def _get_data_node(h5, source_patch_key=""):
+    """Return the (dataset, dims) the key names, keyed as `scan` keys them."""
+    nodes = {info.name: info for info in _yield_data_nodes(h5)}
+    info = resolve_keyed_source(nodes, source_patch_key, where=str(h5.filename))
+    return _NODE_DATA_PROCESSORS[info.patch_type](info), _get_node_dims(info)
+
+
 @register_func(_NODE_ATTRS_PROCESSORS, key="raw")
 def _get_raw_node_attr_coords(node_info, d_coord, base_info, snap=True):
     """Get the raw data information."""
@@ -493,7 +507,7 @@ def _get_raw_node_attr_coords(node_info, d_coord, base_info, snap=True):
     info["_source_patch_key"] = node_info.name
     coords = dc.get_coord_manager(
         coords={"time": t_coord, "distance": d_coord},
-        dims=_get_dims_from_attrs(node_info.node["RawData"].attrs),
+        dims=_get_node_dims(node_info),
     )
     return ProdMLRawPatchAttrs(**info), coords
 
@@ -520,7 +534,7 @@ def _get_processed_node_attr_coords(node_info, d_coord, base_info, snap=True):
     distance = d_coord[ind_1 : ind_1 + count]
     coords = dc.get_coord_manager(
         coords={"time": t_coord, "distance": distance},
-        dims=_get_dims_from_attrs(node_info.parent_node.attrs),
+        dims=_get_node_dims(node_info),
     )
     return ProdMLFbePatchAttrs.from_dict(out), coords
 

--- a/dascore/io/terra15/core.py
+++ b/dascore/io/terra15/core.py
@@ -61,6 +61,7 @@ class Terra15FormatterV4(FiberIO):
         time: tuple[timeable_types, timeable_types] | None = None,
         distance: tuple[float, float] | None = None,
         snap_dims: bool = True,
+        snap: bool | None = None,
         **kwargs,
     ) -> dc.Spool:
         """
@@ -78,7 +79,11 @@ class Terra15FormatterV4(FiberIO):
             If True, ensure the coordinates are evenly sampled monotonic.
             This will cause some loss in precision but it is usually
             negligible.
+        snap
+            The name `scan` gives ``snap_dims``, so a caller can forward
+            what it gave `scan`; it wins when both are given.
         """
+        snap_dims = snap_dims if snap is None else snap
         patch = _read_terra15(resource, time, distance, snap_dims=snap_dims)
         if not patch.data.size:
             return dc.spool([])
@@ -88,7 +93,8 @@ class Terra15FormatterV4(FiberIO):
         self,
         resource: H5Reader,
         windows: dict[str, tuple[int, int]],
-        snap_dims: bool = True,
+        snap: bool = True,
+        snap_dims: bool | None = None,
         **kwargs,
     ) -> np.ndarray:
         """
@@ -96,16 +102,18 @@ class Terra15FormatterV4(FiberIO):
 
         Besides the requested block, only the time node's ends and the
         header are read (the whole time node for an unfinished file, to
-        count the rows it actually wrote). ``snap_dims`` selects the grid,
-        spelled as ``read`` spells it (``scan`` calls the same option
-        ``snap``): snapped, the rows stop at the last written sample; raw,
-        every stored row counts, as the raw time coordinate does.
+        count the rows it actually wrote). ``snap`` selects the grid, and
+        unlike other formats it decides how many rows there are: snapped,
+        they stop at the last written sample; raw, every stored row
+        counts, as the raw time coordinate does. ``read`` calls the same
+        option ``snap_dims``, so both spellings are taken.
         """
-        raise_on_extra_kwargs(kwargs, "windows and snap_dims")
+        raise_on_extra_kwargs(kwargs, "windows, snap and snap_dims")
+        snap = snap if snap_dims is None else snap_dims
         _, data_node = _get_version_data_node(resource)
         data = data_node["data"]
         time_len = data.shape[0]
-        if snap_dims:
+        if snap:
             _, _, time_len, _ = _get_scanned_time_info(data_node)
         shape = (time_len, len(_get_distance_coord(resource)))
         return slice_dataset(data, ("time", "distance"), windows, shape)

--- a/dascore/io/utils.py
+++ b/dascore/io/utils.py
@@ -193,28 +193,54 @@ def windows_to_slices(
     return tuple(out)
 
 
-def resolve_keyed_source(sources: Mapping[str, Any], key, where: str = "the resource"):
+def resolve_keyed_source(
+    sources: Mapping[str, Any] | Iterable[tuple[str, Any]],
+    key,
+    where: str = "the resource",
+):
     """
     Return the one source a ``source_patch_key`` names.
 
-    Resolves as the default `FiberIO.read_array` resolves it: an empty
-    resource is missing data, an unknown key or an ambiguous keyless one
-    cannot be resolved. ``sources`` maps each native key to whatever the
-    caller needs back.
+    Resolves a native key as the default `FiberIO.read_array` does: an
+    empty resource is missing data, and an unknown key, an ambiguous
+    keyless one, or a key naming more than one source cannot be
+    resolved. Unlike the default it takes no positional key, since a
+    format which states its own keys never synthesizes one.
+
+    ``sources`` maps each native key to whatever the caller needs back,
+    and is read lazily, so an h5py group can be passed as it is. Pass
+    ``(key, value)`` pairs instead where a resource can state one key
+    twice, so the ambiguity is seen rather than silently resolved.
     """
     key = normalize_source_patch_key(key)
-    if not sources:
-        msg = f"No patches in {where}."
-        raise MissingPatchError(msg)
-    if key:
-        if key not in sources:
-            msg = f"No patch named '{key}' in {where}."
+    if isinstance(sources, Mapping):
+        # a mapping cannot hold a name twice, so it is read as it is: an
+        # h5py group resolves a name without opening its siblings
+        if not len(sources):
+            raise MissingPatchError(f"No patches in {where}.")
+        if key:
+            if key not in sources:
+                raise PatchAttributeError(f"No patch named '{key}' in {where}.")
+            return sources[key]
+        if len(sources) > 1:
+            msg = f"{where} holds several patches; pass source_patch_key."
             raise PatchAttributeError(msg)
-        return sources[key]
-    if len(sources) > 1:
+        return next(iter(sources.values()))
+    pairs = list(sources)
+    if not pairs:
+        raise MissingPatchError(f"No patches in {where}.")
+    if key:
+        found = [value for name, value in pairs if name == key]
+        if not found:
+            raise PatchAttributeError(f"No patch named '{key}' in {where}.")
+        if len(found) > 1:
+            msg = f"{where} names '{key}' more than once; it cannot be resolved."
+            raise PatchAttributeError(msg)
+        return found[0]
+    if len(pairs) > 1:
         msg = f"{where} holds several patches; pass source_patch_key."
         raise PatchAttributeError(msg)
-    return next(iter(sources.values()))
+    return pairs[0][1]
 
 
 def slice_dataset(dataset, dims: Sequence[str], windows: Mapping[str, Any], shape=None):

--- a/dascore/io/utils.py
+++ b/dascore/io/utils.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import warnings
 from collections.abc import Iterable, Mapping, Sequence
-from typing import Any
+from typing import Any, cast
 
 import numpy as np
 
@@ -216,16 +216,17 @@ def resolve_keyed_source(
     if isinstance(sources, Mapping):
         # a mapping cannot hold a name twice, so it is read as it is: an
         # h5py group resolves a name without opening its siblings
-        if not len(sources):
+        mapping = cast("Mapping[str, Any]", sources)
+        if not len(mapping):
             raise MissingPatchError(f"No patches in {where}.")
         if key:
-            if key not in sources:
+            if key not in mapping:
                 raise PatchAttributeError(f"No patch named '{key}' in {where}.")
-            return sources[key]
-        if len(sources) > 1:
+            return mapping[key]
+        if len(mapping) > 1:
             msg = f"{where} holds several patches; pass source_patch_key."
             raise PatchAttributeError(msg)
-        return next(iter(sources.values()))
+        return next(iter(mapping.values()))
     pairs = list(sources)
     if not pairs:
         raise MissingPatchError(f"No patches in {where}.")

--- a/dascore/io/utils.py
+++ b/dascore/io/utils.py
@@ -12,7 +12,14 @@ import dascore as dc
 from dascore.constants import INVENTORY_ATTRS
 from dascore.core.coordmanager import CoordManager
 from dascore.core.coords import BaseCoord, CoordSegmented, get_coord
-from dascore.exceptions import CoordError, ParameterError, UnitError
+from dascore.core.summary import normalize_source_patch_key
+from dascore.exceptions import (
+    CoordError,
+    MissingPatchError,
+    ParameterError,
+    PatchAttributeError,
+    UnitError,
+)
 from dascore.models import ArrayLike
 from dascore.units import convert_units, get_quantity_str
 from dascore.utils.misc import _to_slice, _validate_sample_values, unbyte
@@ -184,6 +191,30 @@ def windows_to_slices(
         span = range(size)[_to_slice(windows[dim])]
         out.append(slice(span.start, max(span.stop, span.start)))
     return tuple(out)
+
+
+def resolve_keyed_source(sources: Mapping[str, Any], key, where: str = "the resource"):
+    """
+    Return the one source a ``source_patch_key`` names.
+
+    Resolves as the default `FiberIO.read_array` resolves it: an empty
+    resource is missing data, an unknown key or an ambiguous keyless one
+    cannot be resolved. ``sources`` maps each native key to whatever the
+    caller needs back.
+    """
+    key = normalize_source_patch_key(key)
+    if not sources:
+        msg = f"No patches in {where}."
+        raise MissingPatchError(msg)
+    if key:
+        if key not in sources:
+            msg = f"No patch named '{key}' in {where}."
+            raise PatchAttributeError(msg)
+        return sources[key]
+    if len(sources) > 1:
+        msg = f"{where} holds several patches; pass source_patch_key."
+        raise PatchAttributeError(msg)
+    return next(iter(sources.values()))
 
 
 def slice_dataset(dataset, dims: Sequence[str], windows: Mapping[str, Any], shape=None):

--- a/tests/test_io/test_common_io.py
+++ b/tests/test_io/test_common_io.py
@@ -594,9 +594,9 @@ class TestRead:
         io, path = io_path_tuple
         if not io.implements_read_array:
             pytest.skip(f"{io.name} inherits the default read_array")
-        params = inspect.signature(io.read_array).parameters
-        if "snap" not in params:
-            pytest.skip(f"{io.name}.read_array takes no labelling option")
+        # what scan takes, read_array must take: the caller forwards it
+        if "snap" not in inspect.signature(io.scan).parameters:
+            pytest.skip(f"{io.name}.scan takes no labelling option")
         with skip_missing():
             payloads = {x: dc.scan_payloads(path, snap=x)[0] for x in (True, False)}
         key = payloads[True].get("source_patch_key", "")

--- a/tests/test_io/test_common_io.py
+++ b/tests/test_io/test_common_io.py
@@ -609,7 +609,10 @@ class TestRead:
         io.read_array(path, {dim: (1, size - 1)}, **kwargs)
         assert reads, "the data array was never read"
         for index in reads:
-            assert isinstance(index, tuple) and slice(1, size - 1) in index, index
+            assert isinstance(index, tuple), index
+            # xarray spells the same slice with an explicit unit step
+            bounds = {(x.start, x.stop) for x in index if isinstance(x, slice)}
+            assert (1, size - 1) in bounds, index
 
     def test_slice_single_dim_both_ends(self, io_path_tuple):
         """

--- a/tests/test_io/test_dasdae/test_dasdae.py
+++ b/tests/test_io/test_dasdae/test_dasdae.py
@@ -288,6 +288,13 @@ class TestReadArray:
         expected = DASDAEV1().read_array(written_dascore_v1_random, {})
         assert np.array_equal(out, expected)
 
+    def test_path_like_key_raises(self, multi_patch_path):
+        """A key h5py would read as a path names no patch."""
+        name = dc.scan(multi_patch_path)[0].source_patch_key
+        for key in ("/waveforms", f"{name}/data", f"./{name}"):
+            with pytest.raises(PatchAttributeError, match="No patch named"):
+                DASDAEV1().read_array(multi_patch_path, {}, source_patch_key=key)
+
     def test_keyless_multi_patch_raises(self, multi_patch_path):
         """Several patches and no key cannot be resolved."""
         with pytest.raises(PatchAttributeError, match="source_patch_key"):

--- a/tests/test_io/test_dasvader/test_dasvader.py
+++ b/tests/test_io/test_dasvader/test_dasvader.py
@@ -21,6 +21,8 @@ from dascore.exceptions import (
     DependencyError,
     UnknownFiberFormatError,
 )
+from dascore.io.core import FiberIO
+from dascore.io.dasvader.core import DASVaderV1
 from dascore.io.dasvader.utils import (
     EXPECTED,
     _dereference,
@@ -364,3 +366,34 @@ class TestDASVader:
         # `is False` rather than a truthiness check: the empty intersection
         # used to be returned directly, so the answer was the empty set.
         assert _is_dasvader_jld2(_Resource()) is False
+
+    @pytest.fixture(
+        params=["dasvader_modern_path", "das_vader_strainrate_no_attrib_path"]
+    )
+    def read_array_path(self, request):
+        """Each readable layout: the `data` and `strainrate` references."""
+        return request.getfixturevalue(request.param)
+
+    def test_read_array_matches_default(self, read_array_path):
+        """The override returns what the read-and-trim default returns.
+
+        DASVader is kept out of the common IO tests, so its parity with
+        the default is checked here.
+        """
+        io = DASVaderV1()
+        patch = dc.spool(read_array_path)[0]
+        windows = {
+            dim: (1, size - 1)
+            for dim, size in zip(patch.dims, patch.shape, strict=True)
+        }
+        out = io.read_array(read_array_path, windows)
+        expected = FiberIO.read_array(io, read_array_path, windows)
+        assert out.dtype == expected.dtype
+        assert np.array_equal(out, expected)
+        assert out.shape == tuple(size - 2 for size in patch.shape)
+
+    def test_read_array_whole(self, read_array_path):
+        """No windows returns the array the patch holds."""
+        patch = dc.spool(read_array_path)[0]
+        out = DASVaderV1().read_array(read_array_path, {})
+        assert np.array_equal(out, patch.data)

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -55,6 +55,7 @@ from dascore.io.utils import (
     build_patches,
     convert_attr_units,
     get_exact_coord,
+    resolve_keyed_source,
     slice_dataset,
     windows_to_slices,
 )
@@ -2385,3 +2386,40 @@ class TestSliceDataset:
         # a window past the shortened grid clips to it, not to the file
         tail = slice_dataset(dataset, dims, {"time": (2, 50)}, short)
         assert np.array_equal(tail, dataset[2:4, :])
+
+
+class TestResolveKeyedSource:
+    """Tests for resolving which source a key names."""
+
+    def test_mapping_resolves_by_key(self):
+        """A mapping is read as it is; a lone source needs no key."""
+        assert resolve_keyed_source({"a": 1, "b": 2}, "b") == 2
+        assert resolve_keyed_source({"a": 1}, "") == 1
+
+    def test_pairs_resolve_by_key(self):
+        """Pairs resolve like a mapping when the names are distinct."""
+        assert resolve_keyed_source([("a", 1), ("b", 2)], "b") == 2
+        assert resolve_keyed_source([("a", 1)], "") == 1
+
+    def test_empty_is_missing(self):
+        """Nothing to resolve is missing data, not a bad key."""
+        for empty in ({}, []):
+            with pytest.raises(MissingPatchError, match="No patches"):
+                resolve_keyed_source(empty, "a")
+
+    def test_unknown_key(self):
+        """A key naming nothing is refused either way."""
+        for sources in ({"a": 1}, [("a", 1)]):
+            with pytest.raises(PatchAttributeError, match="No patch named"):
+                resolve_keyed_source(sources, "b")
+
+    def test_keyless_ambiguous(self):
+        """Several sources and no key cannot be resolved."""
+        for sources in ({"a": 1, "b": 2}, [("a", 1), ("b", 2)]):
+            with pytest.raises(PatchAttributeError, match="source_patch_key"):
+                resolve_keyed_source(sources, "")
+
+    def test_repeated_name_in_pairs(self):
+        """A resource naming one key twice is ambiguous, never the last one."""
+        with pytest.raises(PatchAttributeError, match="more than once"):
+            resolve_keyed_source([("a", 1), ("a", 2)], "a")

--- a/tests/test_io/test_prodml/test_prodml_source_patch_key.py
+++ b/tests/test_io/test_prodml/test_prodml_source_patch_key.py
@@ -2,9 +2,16 @@
 
 from __future__ import annotations
 
+import shutil
+
+import h5py
+import numpy as np
 import pytest
 
 import dascore as dc
+from dascore.exceptions import PatchAttributeError
+from dascore.io.core import FiberIO
+from dascore.io.prodml.core import ProdMLV2_0
 from dascore.utils.downloader import fetch
 
 
@@ -46,3 +53,68 @@ class TestProdMLSourcePatchId:
             summaries[0].get_coord_summary("time").min,
             summaries[1].get_coord_summary("time").min,
         }
+
+
+class TestReadArrayKeys:
+    """The key names which of a file's several nodes is read."""
+
+    @pytest.fixture(scope="class")
+    def prodml_fbe_path(self):
+        """A ProdML file holding several FBE nodes."""
+        return fetch("prodml_fbe_1.h5")
+
+    def test_each_key_reads_its_own_node(self, prodml_fbe_path):
+        """Every node is reachable, and none stands in for another."""
+        io = ProdMLV2_0()
+        payloads = dc.scan(prodml_fbe_path)
+        assert len(payloads) > 1
+        arrays = {}
+        for payload in payloads:
+            key = payload.source_patch_key
+            out = io.read_array(prodml_fbe_path, {}, source_patch_key=key)
+            expected = FiberIO.read_array(io, prodml_fbe_path, {}, source_patch_key=key)
+            assert np.array_equal(out, expected, equal_nan=True), key
+            arrays[key] = out
+        # the nodes share a shape, so only their values tell them apart
+        first = next(iter(arrays.values()))
+        assert any(
+            not np.array_equal(first, x, equal_nan=True) for x in arrays.values()
+        )
+
+    def test_unknown_key_raises(self, prodml_fbe_path):
+        """A key naming no node is not silently resolved to one."""
+        with pytest.raises(PatchAttributeError, match="No patch named"):
+            ProdMLV2_0().read_array(prodml_fbe_path, {}, source_patch_key="nope")
+
+    def test_keyless_multi_node_raises(self, prodml_fbe_path):
+        """Several nodes and no key cannot be resolved."""
+        with pytest.raises(PatchAttributeError, match="source_patch_key"):
+            ProdMLV2_0().read_array(prodml_fbe_path, {})
+
+
+class TestNodeDims:
+    """Where a node's stored dimension order comes from."""
+
+    @pytest.fixture
+    def fbe_without_dimensions(self, tmp_path):
+        """A copy of the FBE file whose nodes state no Dimensions."""
+        path = tmp_path / "no_dims.h5"
+        shutil.copy(fetch("prodml_fbe_1.h5"), path)
+        with h5py.File(path, "a") as h5:
+            for group in h5["Acquisition"].values():
+                for node in getattr(group, "values", dict)():
+                    for name, dataset in getattr(node, "items", dict)():
+                        if name.lower().startswith("fbedata["):
+                            dataset.attrs.pop("Dimensions", None)
+        return path
+
+    def test_missing_dimensions_falls_back(self, fbe_without_dimensions):
+        """A node stating nothing takes its parent's order, as scan does."""
+        io = ProdMLV2_0()
+        payload = dc.scan(fbe_without_dimensions)[0]
+        key = payload.source_patch_key
+        out = io.read_array(fbe_without_dimensions, {}, source_patch_key=key)
+        expected = FiberIO.read_array(
+            io, fbe_without_dimensions, {}, source_patch_key=key
+        )
+        assert out.shape == expected.shape == payload.shape


### PR DESCRIPTION
## Description

`read_array` overrides for the three formats that need more than a dataset path: ProdML, DASVader, and NetCDF-CF.

- **ProdML** holds several acquisition nodes per file, so the override resolves the one `source_patch_key` names (`Raw[0]`, `FbeData[0]`, and so on) and slices its array. `_get_node_dims` becomes the single place that reads a node's stored dimension order, shared with `scan`.
- **DASVader** stores its array behind a JLD2 object reference whose name (`data` or `strainrate`) also says the dimension order. `_get_data_and_dims` resolves both, and `read` uses it too. DASVader is kept out of the common-IO tests, so its parity with the default is tested in its own module against both layouts.
- **NetCDF-CF** selects through xarray rather than the stored dataset, so CF decoding (scaling, offsets, fill values) applies exactly as it does in `read`. Before this the reader loaded the whole variable and trimmed.

`resolve_keyed_source` in `dascore/io/utils.py` now carries the keyed-resolution error contract (missing, unknown, ambiguous) that DASDAE's reader defined; DASDAE, ProdML, and NetCDF share it. As a side effect a DASDAE key can no longer be an h5py path: a key names a direct child of the waveform group.

Stacked on #1113.

## Changelog

- added: `read_array` slices storage directly for the ProdML, DASVader, and NetCDF formats.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
