### PR TITLE
Condense public API docstrings

### DIFF
--- a/dascore/proc/align.py
+++ b/dascore/proc/align.py
@@ -270,17 +270,9 @@ def align_to_coord(
     patch
         The patch to align.
     mode : str
-        Determines the output shape of the patch. Options are:
-        "full" - Regardless of shift, all original data are preserved.
-            This can result in patches with many fill values along the
-            aligned dimension. It also allows cases where some traces do
-            not overlap at all.
-        "same" - The patch will retain its shape, however, only one trace
-            (and traces that weren't shifted) will remain complete. Parts
-            of shifted traces will be discarded.
-        "valid" - The output patch will likely be smaller than the input
-            patch, as only completely overlapped valid data are kept. This
-            means no fill_values will occur in the patch.
+        Output extent: ``"full"`` preserves all data with fill as needed,
+        ``"same"`` preserves the input shape and trims shifted edges, and
+        ``"valid"`` keeps only the region shared by every shifted trace.
     samples
         If True, the values in the alignment coordinate specify integer sample
         offsets from the original start position. If False, the values specify
@@ -305,67 +297,39 @@ def align_to_coord(
     --------
     >>> import dascore as dc
     >>> import numpy as np
-    >>> patch = dc.get_example_patch()
-    >>> # Select a smaller subset for examples
-    >>> patch = patch.select(distance=(0, 50))
-    >>>
-    >>> # Example 1: Shift along distance (channels).
-    >>> time = patch.get_coord("time")
+    >>> patch = dc.get_example_patch().select(distance=(0, 50))
     >>> distance = patch.get_array("distance")
-    >>> # Specify time shift for each channel.
-    >>> dt = np.timedelta64(1, 'ms')  # 1 millisecond
-    >>> start_times = np.arange(len(distance)) * dt
+    >>> start_times = np.arange(len(distance)) * np.timedelta64(1, "ms")
     >>> patch_shift = patch.update_coords(shift_times=("distance", start_times))
-    >>> # Traces are now shifted.
     >>> aligned_offsets = patch_shift.align_to_coord(time="shift_times", mode="full")
     >>>
-    >>> # Example 2: Round-trip alignment with reverse parameter
-    >>> # Use samples rather than value offsets.
-    >>> shifts = np.arange(len(distance))  # shifts in samples
+    >>> # Align by samples and reverse the operation.
+    >>> shifts = np.arange(len(distance))
     >>> patch_shift = patch.update_coords(my_shifts=("distance", shifts))
-    >>> # Forward alignment
     >>> aligned = patch_shift.align_to_coord(
     ...     time="my_shifts", samples=True, mode="full"
     ... )
-    >>> # Reverse to get back original (after dropping NaN padding)
     >>> reversed_patch = aligned.align_to_coord(
     ...     time="my_shifts", samples=True, mode="full", reverse=True
     ... )
-    >>> original = reversed_patch.dropna("time")
-    >>> assert original.equals(patch_shift)
+    >>> assert reversed_patch.dropna("time").equals(patch_shift)
     >>>
-    >>> # Example 3: Use 'valid' mode to extract only overlapping region
     >>> valid_aligned = patch_shift.align_to_coord(
     ...     time="my_shifts", samples=True, mode="valid"
     ... )
-    >>> # Result contains no NaN values, only the overlapping data
     >>> assert not np.isnan(valid_aligned.data).any()
 
     Notes
     -----
-    **Mode Parameter**
+    For two length-10 traces separated by five samples, the modes produce:
 
-    To understand the mode argument, consider a 2D patch with two traces,
-    an alignment dimension length of 10, and a shift of 5 samples.
+    ```text
+    full                 same          valid
+    -----aaaaaaaaaa      aaaaaaaaaa    aaaaa
+    bbbbbbbbbb-----      bbbbb-----    bbbbb
+    ```
 
-    For mode=="full" the output looks like this:
-        -----aaaaaaaaaa
-        bbbbbbbbbb-----
-    For mode=="same" the patch will look like this:
-        aaaaaaaaaa
-        bbbbb-----
-    For mode=="valid":
-        aaaaa
-        bbbbb
-    where a and b represent values in first and second trace, respectively,
-    and the - represents the fill values.
-
-    **Alignment Semantics**
-
-    All alignment operations are purely relative: shifts specify offsets from the
-    original position. When samples=True, shifts are integer sample offsets. When
-    samples=False, shifts are value offsets (e.g., timedelta64 for time dimensions)
-    relative to the start of the aligned dimension.
+    Letters represent data and dashes represent fill values.
     """
     # Validate inputs and get coordinates.
     dim_name, coord_name = _validate_alignment_inputs(patch, kwargs)

--- a/dascore/proc/basic.py
+++ b/dascore/proc/basic.py
@@ -473,14 +473,10 @@ def normalize(
     dim
         The dimension along which the normalization takes place.
     norm
-        Determines the value to divide each sample by along a given axis.
-        Options are:
-            l1 - divide each sample by the l1 of the axis.
-            l2 - divide each sample by the l2 of the axis.
-            max - divide each sample by the maximum of the absolute value of the axis.
-            bit - sample-by-sample normalization (-1/+1)
+        Divisor: axis L1 norm (``"l1"``), L2 norm (``"l2"``), maximum
+        absolute value (``"max"``), or sample magnitude (``"bit"``).
     window
-        The length of the moving window, in units of `dim` unless `samples`
+        Moving-window length, in units of `dim` unless `samples`
         is True. The window is centered on the sample it scales and is
         reflected where it runs off either end of `dim`, so every sample is
         scaled. If None, the whole slice is one window. Not supported for
@@ -490,45 +486,25 @@ def normalize(
 
     Notes
     -----
-    - A window is centered on the sample it scales, so an even window length
-      is raised to the next odd one.
+    Even window lengths are raised to the next odd number. Reflection at each
+    edge gives every input sample an output without introducing new nulls,
+    unlike [`rolling`](`dascore.Patch.rolling`), which leaves nulls where a
+    window is incomplete.
 
-    - Every sample gets a value, the ends included: where a centered window
-      runs off the end of the dimension, the coordinate is reflected about
-      its last sample to fill it (scipy's `mode="reflect"`, the same rule
-      `median_filter` and the other windowed filters use). So the output has
-      the shape it was given and holds no nulls the input did not. This is
-      not what [`rolling`](`dascore.Patch.rolling`) does: rolling returns one
-      value per window rather than one per sample, and leaves nulls where a
-      window was not full. A null edge here would delete real data -- half a
-      window off each end of every trace, which for a one second window at
-      250 Hz is an eighth of an eight second record, first arrivals included.
-
-    - The windowed norms are means rather than sums: `l2` divides by the
-      window's RMS and `l1` by its mean absolute value. Were they sums, the
-      output would scale with the window length, and the reflected windows
-      at the edges of the dimension would not line up with the interior.
-      Over a whole slice the two differ only by a constant, so the
-      unwindowed norms are left as the sums they have always been.
+    Windowed L2 and L1 norms use RMS and mean absolute value, respectively, so
+    scale does not depend on window length. Whole-slice L2 and L1 retain their
+    established sum-based definitions.
 
     Examples
     --------
     >>> import dascore as dc
     >>> patch = dc.get_example_patch()
-    >>>
-    >>> # L2 normalization along time dimension
     >>> l2_norm = patch.normalize(dim="time", norm="l2")
-    >>>
-    >>> # Max normalization along distance dimension
     >>> max_norm = patch.normalize(dim="distance", norm="max")
-    >>>
-    >>> # Bit normalization (sign only)
     >>> bit_norm = patch.normalize(dim="time", norm="bit")
     >>>
     >>> # Automatic gain control: divide by the RMS of a 1 second window.
     >>> agc = patch.normalize(dim="time", norm="l2", window=1)
-    >>>
-    >>> # The same, with the window given in samples.
     >>> agc = patch.normalize(dim="time", norm="l2", window=251, samples=True)
     """
     return Normalize(dim=dim, norm=norm, window=window, samples=samples)._apply(self)

--- a/dascore/proc/basic.py
+++ b/dascore/proc/basic.py
@@ -486,10 +486,11 @@ def normalize(
 
     Notes
     -----
-    Even window lengths are raised to the next odd number. Reflection at each
-    edge gives every input sample an output without introducing new nulls,
-    unlike [`rolling`](`dascore.Patch.rolling`), which leaves nulls where a
-    window is incomplete.
+    Even window lengths in coordinate units are raised to the next odd number;
+    with ``samples=True``, an even sample count raises `ParameterError`.
+    Reflection gives every input sample an output without introducing new
+    nulls, unlike [`rolling`](`dascore.Patch.rolling`), which leaves
+    incomplete windows null.
 
     Windowed L2 and L1 norms use RMS and mean absolute value, respectively, so
     scale does not depend on window length. Whole-slice L2 and L1 retain their

--- a/dascore/proc/coords.py
+++ b/dascore/proc/coords.py
@@ -515,77 +515,45 @@ def select(
     Examples
     --------
     >>> import numpy as np
-    >>> import dascore as dc
     >>> from dascore.examples import get_example_patch
     >>> patch = get_example_patch()
     >>>
-    >>> # select meters 50 to 300
+    >>> # Coordinate values and open bounds.
     >>> new_distance = patch.select(distance=(50, 300))
-    >>>
-    >>> # select channels less than 300
     >>> lt_dist = patch.select(distance=(..., 300))
     >>>
-    >>> # select time (1 second from start to -1 second from end)
-    >>> t1 = patch.get_coord("time").min() + dc.to_timedelta64(1)
-    >>> t2 = patch.get_coord("time").max() - dc.to_timedelta64(1)
-    >>> new_time1 = patch.select(time=(t1, t2))
+    >>> # One second from the start through one second before the end.
+    >>> new_time = patch.select(time=(1, -1), relative=True)
     >>>
-    >>> # this can be accomplished more simply using the relative keyword
-    >>> new_time2 = patch.select(time=(1, -1), relative=True)
-    >>>
-    >>> # filter 1 second from start time to 3 seconds from start time
-    >>> new_time3 = patch.select(time=(1, 3), relative=True)
-    >>>
-    >>> # filter 6 second from end time to 1 second from end time
-    >>> new_time4 = patch.select(time=(-6, -1), relative=True)
-    >>>
-    >>> # Select first 10 distance indices
+    >>> # Sample ranges and scalar sample indices.
     >>> new_distance1 = patch.select(distance=(..., 10), samples=True)
-    >>>
-    >>> # Select last time row/column
     >>> new_distance2 = patch.select(time=-1, samples=True)
     >>>
-    >>> # only include certain rows/columns based on a boolean array.
+    >>> # Boolean masks and explicit coordinate values.
     >>> time = patch.get_array("time")
-    >>> new_time_5 = patch.select(time=time>time[2])
-    >>>
-    >>> # Select only specific values along a dimension
+    >>> new_time_5 = patch.select(time=time > time[2])
     >>> distance = patch.get_array("distance")
     >>> new_distance_3 = patch.select(distance=distance[1::2])
 
     Notes
     -----
-    - It is important to remember select will not change the order of the
-      patch, only filter values. If the order of the patch should change, or
-      multiple rows/columns need to be repeated,
-      See [`Patch.order`](`dascore.Patch.order`).
+    Selection filters values without reordering or repeating them; use
+    [`Patch.order`](`dascore.Patch.order`) for those operations.
 
-    - A range of values includes both of its endpoints, but a range of
-      samples excludes its upper bound, like python's slicing. This means
-      -1 at the end of a sample range excludes the last sample, even
-      though -1 on its own selects it. Using the example patch, which has
-      300 distance channels and 2000 time samples:
+    Value ranges include both endpoints. Sample ranges are half-open like
+    Python slices, so ``-1`` as a range end excludes the final sample while
+    the scalar ``-1`` selects it:
 
       >>> import dascore as dc
       >>> patch = dc.get_example_patch()
-      >>> # Both endpoints included; 11 channels.
       >>> len(patch.select(distance=(0, 10)).get_array("distance"))
       11
-      >>> # Upper bound excluded; 10 samples.
       >>> len(patch.select(time=(0, 10), samples=True).get_array("time"))
       10
-      >>> # -1 as a range end drops the last sample.
       >>> len(patch.select(time=(0, -1), samples=True).get_array("time"))
       1999
-      >>> # But -1 on its own selects it.
       >>> len(patch.select(time=-1, samples=True).get_array("time"))
       1
-
-      A slice can be used in place of a tuple, and makes the half-open
-      behavior of sample ranges more obvious:
-
-      >>> len(patch.select(time=slice(0, -1), samples=True).get_array("time"))
-      1999
 
     """
     _check_coord_names(patch, kwargs)

--- a/dascore/proc/correlate.py
+++ b/dascore/proc/correlate.py
@@ -94,96 +94,63 @@ def correlate(
     """
     Correlate source row/columns in a 2D patch with all other row/columns.
 
-    Correlations are done in the frequency domain. This function can accept a
-    patch whose target dimension has already been transformed with the
-    [`Patch.dft`](`dascore.transform.fourier.dft`) method, otherwise the dft
-    will be performed. If the input has already been transformed,
-    [`Patch.correlation_shift`](`dascore.proc.correlate.correlate_shift`)
-    is useful to undo dft artefacts after the idft is applied.
-
-    While a 2D patch is required for input, a 3D patch is returned where the
-    3rd dimension corresponds to the source rows/columns. For the case of a
-    single source, the [`Patch.squeeze`](`dascore.Patch.squeeze`) method
-    can be helpful to remove length 1 dimensions.
+    The correlation runs in the frequency domain, transforming the target
+    dimension when needed. For an already transformed patch, apply
+    [`Patch.correlate_shift`](`dascore.proc.correlate.correlate_shift`) after
+    the inverse transform. The 2D input becomes 3D, with one new source
+    dimension; [`Patch.squeeze`](`dascore.Patch.squeeze`) removes it for a
+    single source.
 
     Parameters
     ----------
-    patch : PatchType
-        The input data patch to be cross-correlated. Must be 2-dimensional.
-        The patch can be in time or frequency domains.
-    samples : bool, optional (default = False)
-        If True, the argument specified in kwargs refers to the *sample* not
-        value along that axis. See examples for details.
+    patch
+        Two-dimensional patch in the original or frequency domain.
+    samples
+        Interpret source selectors as sample indices rather than coordinate
+        values.
     **kwargs
-        Specifies correlation dimension and the master source(s), to which
-        we want to cross-correlate all other channels/time samples. If the
-        master source is an array, the function will compute correlations for
-        all the possible pairs.
+        Source dimension mapped to one or more source values or indices.
 
     Examples
     --------
     >>> import dascore as dc
-    >>> from dascore.units import m, s
-
-    >>> # Get a patch composed of sin waves whose correlation results
-    >>> # can easily be checked.
+    >>> from dascore.units import m
     >>> patch = dc.get_example_patch(
     ...     "sin_wav",
     ...     sample_rate=100,
     ...     frequency=range(10, 20),
     ...     duration=5,
     ...     channel_count=10,
-    ... ).taper(time=0.05).set_units(distance='m')
+    ... ).taper(time=0.05).set_units(distance="m")
     >>>
-    >>> # Example 1
-    >>> # Calculate cc for all channels as receivers and
-    >>> # the 10 m channel as the master channel. Squeeze the output
-    >>> # so the returned patch is 2D.
-    >>> cc_patch = patch.correlate(distance = 10 * m).squeeze()
+    >>> # Correlate every channel with the 10 m channel.
+    >>> cc_patch = patch.correlate(distance=10 * m).squeeze()
     >>>
-    >>> # Example 2
-    >>> # Get cc within (-2,2) sec of lag for all channels as receivers
-    >>> # and the 10 m channel as the master channel. The new patch has dimensions
-    >>> # (lag_time, distance, source_distance)
+    >>> # Keep -2 through 2 seconds of lag.
     >>> cc_patch = (
-    ...     patch.correlate(distance = 10 * m)
+    ...     patch.correlate(distance=10 * m)
     ...     .select(lag_time=(-2, 2))
     ... )
     >>>
-    >>> # Example 3
-    >>> # First remove every other distance channel (less memory usage)
-    >>> # the use the new 2nd channel as the source.
+    >>> # Select a source by sample index after decimation.
     >>> cc_patch = (
     ...     patch.decimate(distance=2, filter_type=None)
     ...     .correlate(distance=1, samples=True)
     ... )
     >>>
-    >>> # Example 4
-    >>> # Correlate along time dimension (perhaps for template matching
-    >>> # applications)
     >>> cc_patch = patch.correlate(time=100, samples=True)
     >>>
-    >>> # Example 5
-    >>> # A pipeline of frequency domain correlation and an array of sources
-    >>> padded_patch = patch.pad(time="correlate")  # pad to at least 2n + 1
-    >>> dft_patch = patch.dft("time", real=True)
-    >>> # Any other pre-processing steps go here...
-    >>> # ...
-    >>> # Perform the correlation with 3 source channels
+    >>> # Correlate several sources in a frequency-domain pipeline.
+    >>> padded_patch = patch.pad(time="correlate")
+    >>> dft_patch = padded_patch.dft("time", real=True)
     >>> cc_patch = dft_patch.correlate(distance=[1, 3, 7], samples=True)
-    >>> # Perform any post-processing here
-    >>> # ...
-    >>> # Convert back to time domain, apply `correlate shift` to undo
-    >>> # fft related shifting and scaling as well as create lag coordinate.
     >>> cc_out = cc_patch.idft().correlate_shift("time")
 
     Notes
     -----
-    1 - The cross-correlation is performed in the frequency domain.
-
-    2 - The output dimension is opposite of the one specified in kwargs and
-      shares a name with the original coord except the string "lag_" is
-      prepended. For example, "lag_time".
+    Correlation runs along the dimension not named in ``kwargs``. That dimension
+    becomes a lag dimension prefixed with ``lag_``; for example, selecting a
+    ``distance`` source transforms ``time`` into ``lag_time``.
     """
     if "lag" in kwargs:
         msg = "The 'lag' parameter was removed. Select on the lag coordinate instead."

--- a/dascore/proc/mute.py
+++ b/dascore/proc/mute.py
@@ -442,86 +442,49 @@ def line_mute(
         The patch instance.
     {smooth_param}
     invert
-        If True, invert the taper such that the values outside the defined region
-        are set to 0.
+        Zero values outside rather than inside the region.
     relative
-        If True (default), values are relative to coordinate edges.
-        Positive values are offsets from start, negative from end.
+        Interpret positive values from the coordinate start and negative values
+        from its end; False uses absolute coordinate values.
     **kwargs
-        Dimension specifications as (boundary_1, boundary_2) pairs.
-        Each boundary can be:
-        - Scalar: constant value (defines plane perpendicular to dimension)
-        - Length-2 sequence: coordinates defining a straight line (2D only)
-        - None or ...: edge of coordinate (min or max)
+        One or two dimensions mapped to boundary pairs. Each boundary is a
+        scalar, a length-2 straight line (2D only), or None/``...`` for the
+        coordinate edge.
 
     Examples
     --------
     >>> import dascore as dc
-    >>>
-    >>> # An example patch full of 1s with time on y axis and distance on x.
     >>> patch = dc.get_example_patch().full(1)
-    >>>
-    >>> # Mute first 0.5s (relative to start by default)
+    >>> # Mute the first 0.5 s, or retain only the middle section.
     >>> muted = patch.line_mute(time=(0, 0.5))
-    >>>
-    >>> # Mute everything except middle section
     >>> kept = patch.line_mute(time=(0.2, -0.2), invert=True)
     >>>
-    >>> # 1D Mute with smoothed absolute units for time.
+    >>> # Smooth boundaries with an explicit unit.
     >>> muted = patch.line_mute(time=(0.2, 0.8), smooth=0.02 * dc.units.s)
     >>>
-    >>> # Classic first break mute: mute early arrivals
-    >>> # Line from (t=0, d=0) to (t=0.3, d=300) defines velocity=1000 m/s
-    >>> # The other line (defined by time=0 and distance=None) is t=0 (over all
-    >>> # distances).
+    >>> # Mute early arrivals above a 1,000 m/s line.
     >>> muted = patch.line_mute(
     ...     time=(0, [0, 0.3]),
     ...     distance=(None, [0, 300]),
     ...     smooth=0.02,
     ... )
     >>>
-    >>> # Mute late arrivals: from velocity line to a vertical line with
-    >>> # with distance=0 (over all times).
-    >>> muted = patch.line_mute(
-    ...     time=([0, 0.3], None),
-    ...     distance=([0, 300], 0),
-    ... )
-    >>>
-    >>> # Mute wedge between two velocity lines
+    >>> # Mute between two velocity lines, or invert to keep the wedge.
     >>> muted = patch.line_mute(
     ...     time=([0, 0.375], [0, 0.25]),
     ...     distance=([0, 300], [0, 300]),
     ... )
-    >>>
-    >>> # Mute wedge outside two velocity lines
-    >>> muted = patch.line_mute(
+    >>> kept = patch.line_mute(
     ...     time=([0, 0.375], [0, 0.25]),
     ...     distance=([0, 300], [0, 300]),
     ...     invert=True,
     ... )
-    >>>
-    >>> # Apply custom tapering
-    >>> ones = patch.full(1.0)
-    >>> envelope = ones.line_mute(
-    ...     time=([0, 0.375], [0, 0.25]),
-    ...     distance=([0, 300], [0, 300]),
-    ... )
-    >>> # Knock down edges with rolling mean along the time dimension.
-    >>> smooth = envelope.rolling(time=5, samples=True).mean()
-    >>> # Then multiply the two patches.
-    >>> result = patch * smooth
 
     Notes
     -----
-    - By relative=True (the default) means values are offsets from coordinate
-      edges. Use relative=False for absolute coordinate values.
-
-    - Currently, mute doesn't support more than 2 dimensions, and 2D mutes
-      require straight-line boundaries.
-
-    - For more control over boundary smoothing, use a patch with one values
-      then apply custom tapering/smoothing before multiplying with the
-      original patch. See example section for more details.
+    At most two dimensions are supported, and 2D boundaries must be straight.
+    For custom smoothing, apply the mute to an all-ones patch, smooth that
+    envelope, then multiply it by the original patch.
 
     See Also
     --------

--- a/dascore/proc/rolling.py
+++ b/dascore/proc/rolling.py
@@ -267,107 +267,39 @@ def rolling(
     patch
         The patch to apply the rolling function to.
     step
-        The window is evaluated at every step result, equivalent to slicing
-        at every step. If the step argument is not None, the result will
-        have a different shape than the input. Mutually exclusive with
-        overlap. Default None.
+        Evaluate every nth result, like slicing the output. This changes the
+        output length and is mutually exclusive with ``overlap``.
     center
-        If False, set the window labels as the right edge of the window index.
-        If True, set the window labels as the center of the window index. Default False.
+        Label each window by its center rather than its right edge.
     engine
-        Determines how the rolling operations are applied. If None, try to
-        determine which will be fastest for a given step. Options are:
-            "numpy" - which uses np.lib.stride_tricks.sliding_window_view.
-            "pandas" - which uses pandas.rolling.
-        If step < 10 samples, pandas is faster for all operations other than apply.
-        If step > 10 samples, or `apply` is the desired rolling operation, numpy
-        is probably better.
+        ``"numpy"`` uses ``sliding_window_view`` and ``"pandas"`` uses
+        ``pandas.rolling``. None selects based on the step; numpy is generally
+        preferred for ``apply`` or steps above 10 samples.
     samples
         {sample_explanation}
     overlap
-        The overlap between windows. Can be a number (assumed to be in units of
-        the rolling dimension if `samples`==False), a percent, or None. If
-        provided, step is calculated as `window - overlap`. Percent overlap is
-        always interpreted relative to the window length.
+        Window overlap in coordinate units, samples, or percent. When given,
+        ``step = window - overlap``; percentages are relative to the window.
     **kwargs
-        Used to pass dimension and window size.
-        For example `time=10` represents window size of
-        10*(default unit) along the time axis.
+        Dimension and window size, such as ``time=10``.
 
     Notes
     -----
-    Here we have included some useful notes for the rolling function.
-
-    #### Note 1: Length of the output and NaN values
-
-    Rolling is designed to behaves like Pandas [DataFrame.rolling](
+    Rolling follows Pandas [DataFrame.rolling](
     https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.rolling.html)
-    which has some important implications:
+    semantics. With no step, the output retains the input shape and incomplete
+    leading windows are NaN; use [`Patch.dropna`](`dascore.Patch.dropna`) to
+    remove them. A step downsamples that output. For example, the mean of
+    ``[0, 1, 2, 3, 4, 5]`` is:
 
-    - First, when step is not defined or set to 1, the output patch will have the
-    same shape as the input patch. The consequence of this is that NaN values
-    will appear at the start of the dimension. You can use
-    [`patch.dropna`](`dascore.Patch.dropna`) to remove the NaN values.
+    - window 2: ``[NaN, 0.5, 1.5, 2.5, 3.5, 4.5]``
+    - window 3: ``[NaN, NaN, 1, 2, 3, 4]``
+    - window 3, step 2: ``[NaN, 1, 3]``
+    - window 3, step 3: ``[NaN, 2]``
 
-    - Second, the step parameter is equivalent applying to the output along the
-    specified dimension. For example, if step=2 the output of the chosen
-    dimension will be 1/2 of the input length.
-
-    Here are a few examples to help illustrate how rolling works.
-
-    Consider a patch with a simple 1D array in the dimension "time":
-        [0, 1, 2, 3, 4, 5]
-
-    - If time = 2 * dt the output is
-        [NaN, 0.5, 1.5, 2.5, 3.5, 4.5]
-
-    - If time = 3 * dt the output is
-        [NaN, NaN, 1.0, 2.0, 3.0, 4.0]
-
-    - if time = 3 * dt and step = 2 * dt
-        [NaN, 1.0, 3.0]
-
-    - if time = 3 * dt and step = 3 * dt
-        [NaN, 2.0]
-
-
-    #### Note 2: Applying custom functions with rolling operation
-
-    When `apply` is the desired rolling operation and we are interested to use our
-    own function over a desired window, we need to define our function the way that
-    it performs the operation on the last axis of the sliced matrix
-
-    Below is an example of applying a custom zero crossing rate function (zcr_std) with
-    rolling operation for a window size of 100 samples and skipping every other samples.
-    It applies the desired operation (which is multiplying every sample to its next
-    sample to determine the zero crossings) on the last axis of the sliced
-    frame (from rolling).
-
-
-    ```python
-    import numpy as np
-    import dascore as dc
-
-
-    def zcr_std(frame, axis=-1):
-        '''Compute standard deviation of zero crossing rate using rolling function.'''
-        zero_crossings = (frame[..., :-1] * frame[..., 1:]) < 0
-        return np.std(zero_crossings, axis=axis)
-
-
-    patch = dc.get_example_patch()
-    zcr_patch = patch.rolling(time=100, step=2, samples=True).apply(zcr_std)
-
-    # Additional arguments can be passed directly to apply.
-    def percentile(frame, q, axis=-1):
-        '''Compute a rolling percentile.'''
-        return np.percentile(frame, q, axis=axis)
-
-
-    percentile_patch = patch.rolling(time=100, step=2, samples=True).apply(
-        percentile, 80
-    )
-    ```
+    ``apply`` receives the rolling dimension as the last axis of each window;
+    custom functions should reduce that axis. Extra arguments passed to
+    ``apply`` are forwarded to the function.
 
     Examples
     --------

--- a/dascore/proc/rolling.py
+++ b/dascore/proc/rolling.py
@@ -273,8 +273,10 @@ def rolling(
         Label each window by its center rather than its right edge.
     engine
         ``"numpy"`` uses ``sliding_window_view`` and ``"pandas"`` uses
-        ``pandas.rolling``. None selects based on the step; numpy is generally
-        preferred for ``apply`` or steps above 10 samples.
+        ``pandas.rolling``. None selects pandas only when the step is below 10
+        and the squeezed patch has fewer than two dimensions; otherwise it
+        selects NumPy. Explicit pandas supports at most two dimensions and
+        raises `ParameterError` above that.
     samples
         {sample_explanation}
     overlap
@@ -287,10 +289,11 @@ def rolling(
     -----
     Rolling follows Pandas [DataFrame.rolling](
     https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.rolling.html)
-    semantics. With no step, the output retains the input shape and incomplete
-    leading windows are NaN; use [`Patch.dropna`](`dascore.Patch.dropna`) to
-    remove them. A step downsamples that output. For example, the mean of
-    ``[0, 1, 2, 3, 4, 5]`` is:
+    semantics. With no step, the output retains the input shape. When
+    ``center=False``, incomplete leading windows are NaN; when
+    ``center=True``, incomplete windows at both edges are NaN. Use
+    [`Patch.dropna`](`dascore.Patch.dropna`) to remove them. A step downsamples
+    that output. For example, the mean of ``[0, 1, 2, 3, 4, 5]`` is:
 
     - window 2: ``[NaN, 0.5, 1.5, 2.5, 3.5, 4.5]``
     - window 3: ``[NaN, NaN, 1, 2, 3, 4]``

--- a/dascore/transform/fourier.py
+++ b/dascore/transform/fourier.py
@@ -242,61 +242,43 @@ def dft(
     patch
         Patch to transform.
     dim
-        A single, or multiple dimensions over which to perform dft. If
-        None, perform dft over all dimensions.
+        Dimension or dimensions to transform. None transforms all dimensions.
     real
-        Either 1) The name of the axis over which to perform a rfft, 2)
-        True, which means the last (possibly only) dimension should have an
-        rfft performed, or 3) None, meaning no rfft.
+        Dimension for a real FFT, True for the last requested dimension, or
+        None for complex FFTs along every dimension.
     pad
-        If True, pad patch before performing dft along desired dimensions to
-        the next fast length. This can avoid major slow-downs when dimension
-        lengths are prime numbers.
+        Pad each transformed dimension to its next fast FFT length.
     output
-        Spectral representation to return for each frequency bin
+        Spectral representation for each frequency bin:
         - ``'FFT'``: Complex Fourier coefficients scaled by sample spacing.
         - ``'AS'``: Amplitude spectrum in the original data units.
         - ``'PS'``: Power spectrum whose bin sum gives mean square.
         - ``'PSD'``: Spectral density whose bin-width-weighted sum gives
-                     mean square.
+          mean square.
     db
-        If True, converts the output into decibel units, if output is not FFT.
-        This applies ``20 * log10`` to ``'AS'`` and ``10 * log10`` to ``'PS'``
-        or ``'PSD'`` without a reference value.
-
+        Convert non-FFT output to decibels without a reference value: use
+        ``20 * log10`` for AS and ``10 * log10`` for PS or PSD.
 
     Notes
     -----
-    - Simply uses numpy's fft module but outputs are scaled by the sample
-      spacing along each transformed dimension and coordinates corresponding
-      to frequency bins are shifted so they remain ordered.
+    NumPy FFT output is scaled by each transformed dimension's sample spacing.
+    Frequency coordinates remain ordered, use reciprocal units, and are named
+    with an ``ft_`` prefix (for example, ``time`` becomes ``ft_time``).
 
-    - Each transformed dimension is renamed with a preceding `ft_`. e.g.,
-      `time` becomes `ft_time` (ft stands for fourier transform).
+    A non-dimensional coordinate measured on one transformed dimension is
+    removed from the output coordinates but retained for
+    [idft](`dascore.transform.fourier.idft`) to restore. One spanning multiple
+    dimensions is dropped.
 
-    - Each transformed dimension has units of 1/original units.
+    FFT data units combine the original data and transformed-dimension units;
+    other outputs are normalized as described under ``output``.
 
-    - A non-dimensional coordinate measured on a transformed dimension is
-      not a coordinate of the output -- the frequency axis is not what it
-      was measured on, and a real transform is not even the same length --
-      but it is kept for [idft](`dascore.transform.fourier.idft`) to
-      restore. One spanning more than one dimension is dropped.
+    With ``real=True``, AS, PS, and PSD do not double non-DC or non-Nyquist
+    bins for a one-sided spectrum; multiply the applicable bins when needed.
 
-    - For ``output='FFT'``, output data units are the original data units
-      multiplied by the units of each transformed dimension. Other output
-      types are normalized as described in the ``output`` parameter.
-
-    - For ``output='AS'``, ``'PS'``, or ``'PSD'`` with ``real=True``, the
-      non-DC and non-Nyquist bins have not been converted to one-sided spectra.
-      Depending on your use case, you may need to multiply non-zero bins by 2.
-
-    - If all requested dimensions are already transformed, ``dft`` returns
-      the input patch unchanged, regardless of the requested ``output``.
-
-    - Non-dimensional coordinates associated with transformed coordinates
-      will be dropped in the output.
-
-    - See the [FFT notes](`docs/notes/dft_notes.qmd`) for more details.
+    If every requested dimension is already transformed, ``dft`` returns the
+    input unchanged regardless of ``output``. See the
+    [FFT notes](`docs/notes/dft_notes.qmd`) for details.
 
     See Also
     --------
@@ -307,13 +289,9 @@ def dft(
     --------
     >>> import dascore as dc
     >>> patch = dc.get_example_patch()
-    >>> # perform dft (fft) on time axis
     >>> dft_time = patch.dft(dim="time")
-    >>> # make it a real fft (no negative frequencies)
     >>> dft_time_real = patch.dft(dim="time", real=True)
-    >>> # dft on specified dimensions, specify real dimension
     >>> dft_some_real = patch.dft(dim=("time", "distance"), real="time")
-    >>> # calculate a power spectral density along time
     >>> psd = patch.dft(dim="time", real=True, output="PSD")
     """
     output_type = output.upper()

--- a/dascore/transform/kurtosis.py
+++ b/dascore/transform/kurtosis.py
@@ -38,18 +38,10 @@ def kurtosis(
 ) -> PatchType:
     """
     Compute kurtosis along a patch dimension.
-    Background seismic noise is approximately Gaussian. A seismic arrival
-    (especially a P-wave onset) produces a transient, impulsive signal with
-    a sharply peaked amplitude distribution. Kurtosis — the normalized 4th
-    statistical moment — becomes strongly positive during such impulsive
-    arrivals.
 
-    Here, kurtosis is determined in a window whose length is given as a
-    dimension keyword argument (e.g. ``time=0.5``). We then determine
-    kurtosis of the amplitude distribution in that window.
-    Higher kurtosis thus indicates high amplitude outliers. This in turn
-    can be interpreted as a signal arrival.
-
+    Seismic arrivals are more impulsive than approximately Gaussian background
+    noise, so their windowed amplitude distribution has higher kurtosis. This
+    makes kurtosis useful for detecting arrivals, especially P-wave onsets.
 
     Parameters
     ----------
@@ -58,16 +50,12 @@ def kurtosis(
     samples
         {sample_explanation}
     recursive
-        If True, use recursive pseudo-kurtosis: Instead of computing kurtosis
-        in a sliding window (computationally expensive for continuous data),
-        @langet2014 propose a recursive formulation. This acts like an
-        exponentially weighted moving estimator, so the algorithm updates continuously
-        without storing long windows of data.
-        If False, the common kurtosis calculation is used
+        Use the recursive pseudo-kurtosis of @langet2014, an exponentially
+        weighted estimator that avoids storing sliding windows. False computes
+        ordinary windowed kurtosis.
     **kwargs
-        Used to specify the dimension and window length, e.g. ``time=0.5``
-        computes kurtosis in 0.5 second windows along the time dimension.
-        Units are also supported, e.g. ``distance=10 * dascore.units.get_unit('m')``.
+        Dimension and window length, such as ``time=0.5`` or
+        ``distance=10 * dascore.units.m``.
 
     Returns
     -------
@@ -76,55 +64,18 @@ def kurtosis(
 
     Examples
     --------
-    1) Kurtosis of example event
-    >>> import dascore as dc
-    >>>
-    >>> p = dc.examples.get_example_patch('example_event_2')
-    >>>
-    >>> k = p.kurtosis(time=0.002)
-    >>> ax = k.viz.waterfall(cmap = 'inferno')
-
-    2) To better understand how kurtosis works, we replace the data with
-    normal-distributed random data. We then amplify a block of those
-    data. The modified data has a broader tail, since more high-amplitude
-    values are in the dataset. The kurtosis picks the onset accurately.
-
     >>> import dascore as dc
     >>> import numpy as np
-    >>> import matplotlib.pyplot as plt
+    >>> patch = dc.get_example_patch("example_event_2")
+    >>> kurtosis = patch.kurtosis(time=0.002)
+    >>> _ = kurtosis.viz.waterfall(cmap="inferno")
     >>>
-    >>> p = dc.examples.get_example_patch('example_event_2')
-    >>>
-    >>> # replace event data with normal-distributed random values
+    >>> # Amplify a block of Gaussian noise to create an impulsive onset.
     >>> rng = np.random.default_rng()
-    >>> data = rng.normal(loc=0, scale=1, size=p.data.shape)
-    >>> data0 = data.copy() # original
-    >>> data[:,300:450] = data[:, 300:450]*3 #modified
-    >>>
-    >>> orig = p.update(data=data0)
-    >>> modi = p.update(data=data)
-    >>>
-    >>> # calculate kurtosis on modified data
-    >>> k = modi.kurtosis(time=0.002)
-    >>>
-    >>> fix, axs = plt.subplots(2,2, figsize=(10,6), layout='constrained')
-    >>> ax = orig.viz.waterfall(cmap = 'RdBu', ax=axs[0,0])
-    >>> _ = ax.set_title('Original')
-    >>>
-    >>> ax = modi.viz.waterfall(cmap = 'RdBu', ax=axs[0,1])
-    >>> _ = ax.set_title('Modified')
-    >>>
-    >>> ax = k.viz.waterfall(cmap = 'inferno_r', scale=[0, .4], ax=axs[1,1])
-    >>> _ = ax.set_title('Kurtosis')
-    >>>
-    >>> # plot histograms of both datasets. Note the modified has broader tail!
-    >>> _ = axs[1,0].hist(data.ravel(),  100, alpha=0.5, label='Modified', density=True)
-    >>> _ = axs[1,0].hist(data0.ravel(), 100, alpha=0.5, label='Original', density=True)
-    >>> _ = axs[1,0].legend(loc='upper right')
-    >>> _ = axs[1,0].grid('on')
-    >>> _ = axs[1,0].set_title('Amplitude Distributions')
-    >>> _ = axs[1,0].set_xlabel('Amplitude')
-    >>> _ = axs[1,0].set_ylabel('Probability of occurrence')
+    >>> data = rng.normal(size=patch.shape)
+    >>> data[:, 300:450] *= 3
+    >>> synthetic = patch.update(data=data)
+    >>> onset = synthetic.kurtosis(time=0.002)
     """
     # Imported here (not at module scope) to keep numba out of `import dascore`.
     from dascore.transform._kurtosis_kernels import (  # noqa: PLC0415

--- a/dascore/utils/patch.py
+++ b/dascore/utils/patch.py
@@ -316,81 +316,52 @@ def patch_function(
     Parameters
     ----------
     required_dims
-        A dimension name, or a sequence of them, which must be found in the
-        Patch.
+        Required dimension name or names. Missing dimensions raise
+        `PatchCoordinateError`.
     required_coords
-        A coordinate name, or a sequence of them, which must be found in the
-        Patch.
+        Required coordinate name or names. Missing coordinates raise
+        `PatchCoordinateError`.
     required_attrs
-        An attr name, a sequence of them, or a mapping of names to the values
-        the Patch must hold for them.
+        Required attribute name or names, or a mapping of names to values.
+        Missing or mismatched attributes raise `PatchAttributeError`.
     history
-        Specifies how to track history on Patch.
-            Full - Records function name and str version of input arguments.
-            method_name - Only records method name. Useful if args are long.
-            None - Function call is not recorded in history attribute.
+        ``"full"`` records the function and arguments, ``"method_name"``
+        records only its name, and None records nothing.
     validate_call
-        If True, use pydantic to validate the function call. This can save
-        quite a lot of code in validation checks, but does have some overhead.
+        Whether Pydantic validates calls. This reduces manual checks but adds
+        overhead.
         See [validate_call](https://docs.pydantic.dev/latest/api/validate_call/).
     data_type
-        Controls the output patch's ``data_type`` attr. If None, leave the
-        returned patch's ``data_type`` unchanged. Otherwise, set to specified
-        value. Use an empty string ("") to clear.
+        Output ``data_type``. None preserves it; an empty string clears it.
     version
-        The version of the operation. Bump it when the same arguments should
-        mean a different answer, so that fingerprints recorded against the
-        old behaviour do not name the new one.
+        Operation version. Bump it when the same arguments mean a different
+        result, keeping new fingerprints distinct from old ones.
 
     Examples
     --------
     >>> import dascore as dc
     >>>
-    >>> # 1. A patch method which requires dimensions (time, distance)
-    >>> @dc.patch_function(required_dims=('time', 'distance'))
+    >>> @dc.patch_function(required_dims=("time", "distance"))
     ... def do_something(patch):
-    ...     ...   # raises a PatchCoordsError if patch doesn't have time,
-    ...     #  distance
+    ...     return patch
     >>>
-    >>> # 2. A patch method which requires an attribute 'data_type' == 'DAS'
-    >>> @dc.patch_function(required_attrs={'data_type': 'DAS'})
+    >>> @dc.patch_function(required_attrs={"data_type": "DAS"})
     ... def do_another_thing(patch):
-    ...     ...  # raise PatchAttributeError if patch doesn't have attribute
-    ...     # called "data_type" or its values is not equal to "DAS".
+    ...     return patch
     >>>
-    >>> # 3. A patch method which does type checking on inputs.
-    >>> # The `Field` instance can require various data properties (like ranges)
-    >>> from typing_extensions import Annotated, Literal
     >>> from pydantic import Field
     >>> @dc.patch_function(validate_call=True)
-    ... def do_type_thing(
-    ...     patch,
-    ...     int_le_10_ge_1: int = Field(ge=1, le=10, default=1),
-    ...     option: Literal["min", "max", None] = None,
-    ... ):
-    ...     ...
+    ... def validated(patch, count: int = Field(ge=1, le=10, default=1)):
+    ...     return patch
     >>>
-    >>> # 4. A patch method which sets the output data_type.
-    >>> @dc.patch_function(data_type="strain_rate")
-    ... def do_strain_rate(patch):
-    ...     ...
-    >>>
-    >>> # 5. A patch method which clears the output data_type.
-    >>> @dc.patch_function(data_type="")
-    ... def do_unknown_quantity(patch):
-    ...     ...
-    >>>
-    >>> # 6. A patch method whose body is written to the array API standard,
-    >>> # so it runs on any array backend rather than only on numpy.
+    >>> # Array API code supports non-NumPy backends.
     >>> from dascore.utils.array_api import array_namespace
     >>> @dc.patch_function()
-    ... def do_portable_thing(patch):
+    ... def absolute(patch):
     ...     xp = array_namespace(patch.data)
     ...     return patch.new(data=xp.abs(patch.data))
     >>>
-    >>> # 7. Every patch function builds the operation it is with `.op`:
-    >>> # the same call said as a task, which can be compared,
-    >>> # fingerprinted, and written to a file.
+    >>> # ``op`` builds a comparable, serializable PatchOp.
     >>> patch = dc.get_example_patch()
     >>> op = dc.proc.normalize.op(dim="time")
     >>> assert op(patch).equals(patch.normalize(dim="time"))
@@ -398,20 +369,14 @@ def patch_function(
 
     Notes
     -----
-    - The original function can still be accessed with the raw_function
-      attribute. This may be useful for avoiding calling the patch_func
-      machinery multiple times from within another patch function.
+    ``raw_function`` exposes the undecorated function, which avoids applying
+    this machinery twice inside another patch function. ``op`` builds a
+    [PatchOp](`dascore.workflow.processor.PatchOp`) with arguments bound to the
+    signature, so positional and keyword spellings share a fingerprint.
 
-    - The decorated function also carries ``op``, which builds the
-      [PatchOp](`dascore.workflow.processor.PatchOp`) a call to it is:
-      ``dc.proc.normalize.op(dim="time")``. The call is bound against the
-      signature, so a positional and a keyword spelling of one call are one
-      operation with one fingerprint.
-
-    - If using `PatchType` or `SpoolType` type variables from the
-      [constants module](`dascore.constants`), make sure dascore is imported
-      as dc at the top of the file where the patch function is defined so
-      the forward refs can be resolved properly for type checking.
+    When annotations use `PatchType` or `SpoolType` from
+    [constants](`dascore.constants`), import dascore as ``dc`` in that module
+    so their forward references resolve.
     """
     # Handled before the wrapper is built so the rest of this function sees
     # required_dims as the dimension names it is everywhere else, not as the

--- a/dascore/viz/waterfall.py
+++ b/dascore/viz/waterfall.py
@@ -150,11 +150,9 @@ def waterfall(
     """
     Create a waterfall plot of the Patch data.
 
-    Evenly sampled dimension coordinates are rendered with ``imshow`` for
-    efficient display and image interpolation. Finite, monotonic irregular
-    coordinates are rendered with ``pcolormesh`` so cell geometry follows the
-    coordinate values. Incomplete or nonmonotonic coordinates fall back to
-    ``imshow`` with index-based or minimum/maximum extents.
+    Evenly sampled coordinates use ``imshow``. Finite, monotonic irregular
+    coordinates use ``pcolormesh`` so cells follow their coordinate values;
+    incomplete or nonmonotonic coordinates fall back to ``imshow``.
 
     Parameters
     ----------
@@ -163,84 +161,48 @@ def waterfall(
     ax
         A matplotlib object, if None create one.
     cmap
-        A matplotlib colormap string or instance. If `None`, a colormap will be
-        chosen automatically, depending on the data_type of the patch.
+        Matplotlib colormap. None selects one from the patch ``data_type``.
     scale
-        If not None, controls the saturation level of the colorbar. A single
-        number is symmetric: with `scale_type="relative"` the limits sit that
-        fraction of half the data range either side of the mean, and with
-        `scale_type="absolute"` they are -abs(scale) and abs(scale). A pair
-        of numbers gives the lower and upper limits: fractions of the data
-        range, from 0 to 1, when relative, or the values themselves when
-        absolute. Percent quantities, such as `10 * dc.units.percent`, are
-        converted to fractions.
+        Color limits. A scalar produces symmetric limits: a fraction of half
+        the data range around its mean when relative, or ``±abs(scale)`` when
+        absolute. A relative pair maps fractions from 0 to 1 onto the data
+        minimum and maximum; an absolute pair gives the limits directly.
+        Percent quantities are converted to fractions.
     scale_type
-        Controls the type of scaling specified by `scale` parameter. Options
-        are:
-            relative - scale based on half the dynamic range in patch
-            absolute - scale based on absolute values provided to `scale`
+        Interpret ``scale`` as ``"relative"`` fractions or ``"absolute"``
+        values.
     interpolation
-        A value fed to matplotlib's imshow to handle downsampling large arrays,
-        which is relevant for DAS. Usually, "antialiased" works well, but if the
-        data look smeared disabling interpolation with None might help. Other
-        options are available, see matplotlib's documentation for more details.
-        This option does not apply when irregular coordinates select the
-        ``pcolormesh`` renderer.
+        Passed to matplotlib ``imshow``. ``"antialiased"`` handles large
+        arrays well; None can help if they look smeared. Ignored by
+        ``pcolormesh``.
     interpolation_stage
-        If 'data', interpolation is carried out on the data provided by the user.
-        If 'rgba', the interpolation is carried out after the colormapping has
-        been applied (visual interpolation).
-        'auto' (default) selects a suitable interpolation stage automatically.
-        See matplotlib's imshow documentation for more details. This option
-        does not apply when ``pcolormesh`` is used.
+        ``imshow`` interpolation stage: ``"data"``, ``"rgba"``, or
+        ``"auto"``. Ignored by ``pcolormesh``.
     gap_color
-        Matplotlib color used to display gaps in irregular dimension
-        coordinates. When a color is provided, a masked row or column is
-        inserted for each detected gap and displayed with this color. The
-        default of None bridges gaps by extending adjacent cells across them
-        without expanding the data matrix. This option only applies when
-        ``pcolormesh`` is used. Existing masked or NaN data receive the same
-        color as coordinate gaps.
+        Color for gaps in irregular coordinates. A color inserts masked cells
+        at detected gaps; None bridges them with adjacent cells. Existing NaN
+        or masked data use the same color. Applies only to ``pcolormesh``.
     gap_factor
-        When ``gap_color`` is provided, coordinate intervals larger than this
-        factor times the median interval are displayed as gaps. With the
-        default ``gap_color=None``, cells bridge intervals and this parameter
-        has no visual effect. Gap detection assumes the median interval
-        represents the sampling interval, so coordinates containing contiguous
-        regions with different sampling rates may classify the more coarsely
-        sampled region as gaps. For such data, use the default
-        ``gap_color=None``, increase ``gap_factor``, or plot/resample the
-        regions separately. Must be greater than 1.
+        Intervals larger than this multiple of the median are gaps. Must exceed 1,
+        even when ``gap_color`` is None and it has no visual effect. Mixed
+        sampling rates may classify coarser regions as gaps; increase this value
+        or plot or resample those regions separately.
     log
         If True, visualize the common logarithm of the absolute values of patch data.
         To avoid log(0), the abs(array) is cast to float64 and a small value
         added.
     cbar
-        If True, plot the colorbar, else do not. This controls only colorbar
-        display; use `cmap` to control colormap selection.
+        Whether to draw a colorbar.
     show
-        If True, show the plot, else just return axis.
+        Whether to show the plot.
     label_coord
-        The name of a coordinate whose values label stretches of one of the
-        plotted dimensions, such as a label group an inventory projected onto
-        the patch with [`Patch.enrich`](`dascore.proc.inventory.enrich`). Each
-        stretch is drawn as a bar on the two spines its dimension runs along,
-        colored by its label, so no data is covered or tinted; a hairline
-        joins them wherever the value changes, faint enough to locate a
-        boundary in the data without competing with it. A legend names the
-        labels, beyond any colorbar when this call owns the figure, and inside
-        the axes when the caller supplied one, since taking room from
-        someone else's figure would move every other axes on it. String and
-        numeric coordinates state one label per distinct value. A boolean
-        coordinate states membership, so only its True stretches are marked
-        and the legend names them by the coordinate. Absent values (the empty
-        string, NaN, or False) label nothing, and leave bare spine.
-
-        Raises `ParameterError` for a coordinate which is not a set of
-        labels: one stating more than 20 distinct values, one changing more
-        than 200 times, one whose every value is absent, and one which is a
-        dimension or spans both of them. All are judged before anything is
-        drawn, so a refusal leaves no figure behind.
+        Coordinate whose values label stretches along one plotted dimension,
+        drawn on its spines without tinting the data. Its legend is outside a
+        figure created here, or in the upper-right of a supplied ``ax``. String
+        and numeric values are categories; a boolean coordinate marks only True
+        stretches. Empty strings, NaN, and False are omitted. A coordinate that
+        is a dimension, spans both dimensions, has no labels, exceeds 20 labels,
+        or changes more than 200 times raises `ParameterError` before drawing.
 
     Examples
     --------
@@ -250,61 +212,24 @@ def waterfall(
     >>> patch = dc.get_example_patch("example_event_1").normalize("time")
     >>> _ = patch.viz.waterfall()
     >>>
-    >>> # Use relative scaling with a tuple to show a specific fraction
-    >>> # of data range. Scale values of (0.1, 0.9) map to 10% and 90%
-    >>> # of the data's [min, max] range
-    >>> _ = patch.viz.waterfall(scale=0.1, scale_type="relative")
-    >>> # Likewise, percent units can be used for additional clarity
-    >>> _ = patch.viz.waterfall(scale=10*percent, scale_type="absolute")
-    >>>
-    >>> # Use relative scaling with a tuple to show the middle 80% of data range
-    >>> # Scale values of (0.1, 0.9) map to 10% and 90% of [data_min, data_max]
     >>> _ = patch.viz.waterfall(scale=(0.1, 0.9), scale_type="relative")
-    >>>
-    >>> # Use absolute scaling to set specific colorbar limits
-    >>> # This directly sets the colorbar limits to [-0.5, 0.5]
+    >>> _ = patch.viz.waterfall(scale=10 * percent)
     >>> _ = patch.viz.waterfall(scale=(-0.5, 0.5), scale_type="absolute")
-    >>>
-    >>> # Visualize data on a logarithmic scale
-    >>> # Useful for data spanning multiple orders of magnitude
     >>> _ = patch.viz.waterfall(log=True)
     >>>
-    >>> # Compare scale types: relative vs absolute
-    >>> import matplotlib.pyplot as plt
-    >>> fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(12, 4))
-    >>> # Relative: 0.5 means ±50% of dynamic range around mean
-    >>> _ = patch.viz.waterfall(scale=0.5, scale_type="relative", ax=ax1)
-    >>> _ = ax1.set_title("Relative scaling (scale=0.5)")
-    >>> # Absolute: 0.5 means colorbar limits are [-0.5, 0.5]
-    >>> _ = patch.viz.waterfall(scale=0.5, scale_type="absolute", ax=ax2)
-    >>> _ = ax2.set_title("Absolute scaling (scale=0.5)")
-    >>>
-    >>> # Mark where a label coordinate changes, such as the zones an
-    >>> # inventory places along the fiber.
     >>> from dascore.examples import inventory_patch_pair
     >>> zoned, inventory = inventory_patch_pair()
     >>> _ = zoned.enrich(inventory).viz.waterfall(label_coord="zone")
     >>>
-    >>> # Undo Y axis inversion which occurs when time is on the Y
     >>> ax = patch.viz.waterfall()
     >>> ax.invert_yaxis()
 
     Notes
     -----
-    - A Patch with an empty dimension raises `ParameterError` immediately
-      because it has no cells to render.
-
-    - The Y axis is automatically inverted if it is "time-like". This is to
-      be consistent with standard seismic plotting convention. If you don't
-      want this, simply invert the y axis of the returned axis object as
-      shown in the example section.
-
-    - Changes to default scale behavior: Until DASCore version 0.1.13, the
-      default behavior when scale=None was to scale along the entire range of
-      the data. However, very often in real data a few anomalously large or
-      small values would obscure most of the patch details. In version 0.1.13
-      the default behavior is to now use a statistical fence to avoid the
-      problem. To get the old behavior, simply set scale=1.0.
+    Empty dimensions raise `ParameterError`. Time-like Y axes are inverted by
+    seismic convention; call ``ax.invert_yaxis()`` to undo this. Since version
+    0.1.13, ``scale=None`` uses a statistical fence to limit outliers; use
+    ``scale=1.0`` for the full data range.
     """
     if 0 in patch.shape:
         msg = "Cannot plot a Patch with an empty dimension."


### PR DESCRIPTION
## Description

Audits the longest and most repetitive public API docstrings on the development branch, concentrating on ten high-traffic patch operations, transforms, utilities, and visualization methods.

The revision removes repeated parameter explanations, redundant examples, and prose that restated signatures while retaining behavioral contracts, edge cases, thresholds, units, links, and executable examples.

It also corrects a correlation example that previously transformed the unpadded patch and clarifies several details uncovered during independent review, including correlation-axis semantics and waterfall scaling behavior.

## Changelog

- changed: Public API docstrings are more concise while retaining behavioral contracts, caveats, and executable examples.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [ ] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified parameters, output behavior, processing modes, coordinate selection, scaling, validation, backend support, and visualization behavior across core operations and transforms.
  * Documented rolling-engine selection, boundary NaN behavior, normalization windows, correlation workflows, and waterfall rendering rules.
  * Simplified and reorganized examples and notes for easier reference.
  * No functional behavior or public interfaces changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->