### PR TITLE
Fix the negative-slowness index in the general tau-p kernel

### DIFF
--- a/dascore/transform/_taup_kernels.py
+++ b/dascore/transform/_taup_kernels.py
@@ -63,7 +63,7 @@ def _jit_taup_general(data, distance, dt, p_vals):
                 samp_val_neg = (
                     tau + p * (mod_distance[-1] - mod_distance[nx - 1 - ix]) / dt
                 )
-                ind_neg = int(samp_val_pos)
+                ind_neg = int(samp_val_neg)
                 if ind_pos + 1 < nt:
                     taup[ip + n_slo, tau] += (1.0 + ind_pos - samp_val_pos) * data[
                         ix, ind_pos

--- a/tests/test_transform/test_tau_p.py
+++ b/tests/test_transform/test_tau_p.py
@@ -138,11 +138,10 @@ class TestTauP:
         assert np.abs(1.0 / p_vals[p_ind] - vel) < 20
         assert np.abs((t_vals[t_ind] - t_vals[0]) / np.timedelta64(1, "s") - t0) < 0.02
 
-        dist = np.zeros(nch)
-        cumdist = 0
-        for i in range(nch):
-            dist[i] = cumdist
-            cumdist = cumdist + 1.0 + 1.0 * (i % 2 == 0)
+        # Random spacing so the increments are not their own reverse; the
+        # symmetry test below is the direct guard for the negative half.
+        rng = np.random.default_rng(0)
+        dist = np.concatenate([[0.0], np.cumsum(rng.uniform(0.5, 2.5, nch - 1))])
 
         # positive slope, non-equal distance
         vel = 1800
@@ -180,6 +179,23 @@ class TestTauP:
         _jit_taup_uniform.func(data, dx, dt, p_vals)
         distance = np.arange(10) * dt
         _jit_taup_general.func(data, distance, dt, p_vals)
+
+    def test_general_kernel_negative_half_symmetry(self):
+        """
+        The negative-slowness half of the general kernel equals the positive
+        half of the reversed problem. Non-palindromic spacing makes the two
+        halves sample different time positions.
+        """
+        rng = np.random.default_rng(0)
+        data = rng.standard_normal((12, 40))
+        dist = np.cumsum(rng.uniform(1.0, 9.0, 12))
+        p_vals = np.array([1 / 3000, 1 / 1500, 1 / 800])
+        _, fwd = _jit_taup_general.func(data, dist, 0.01, p_vals)
+        _, rev = _jit_taup_general.func(
+            data[::-1].copy(), dist[-1] - dist[::-1], 0.01, p_vals
+        )
+        n_slo = p_vals.size
+        assert np.allclose(fwd[:n_slo], rev[n_slo:][::-1])
 
     def test_time_distance_dim_order(self):
         """Patches ordered (time, distance) transform like their transpose."""


### PR DESCRIPTION
## Description

The general (unevenly sampled distance) tau-p kernel derived the negative-slowness sample index from the positive-slowness sample position: `ind_neg = int(samp_val_pos)` where `int(samp_val_neg)` was meant. The interpolation weights were still computed from `samp_val_neg`, so whenever the two positions differ the kernel mixed the wrong pair of samples with out-of-range weights. The two positions coincide exactly when the distance increments read the same forwards and backwards, which is true for uniform spacing and for the alternating 2,1,2,1 pattern the existing test used, so the defect was invisible to the suite. With random increments the old kernel misplaces the negative-slowness peak by more than a velocity bin.

This one-token fix changes only the negative-slowness half of `Patch.tau_p` for distance coordinates that are neither evenly sampled nor palindromic. Evenly sampled patches take the uniform kernel and are unchanged. The kernel has behaved this way in every release since tau-p was added in v0.1.4.

Tests: a direct symmetry test on the raw kernel (the negative half of the forward problem must equal the positive half of the reversed problem), which fails on the old code by a wide margin, and the existing uneven-distance case now uses seeded random spacing so it is no longer palindromic.

Found during the 2026-09-02 redundancy review of `dev`.

## Changelog

- fixed: `Patch.tau_p` now computes the negative-slowness half correctly for unevenly sampled distance coordinates.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected negative-slowness interpolation in tau-p transformations, improving results for the negative accumulation branch.

* **Tests**
  * Expanded coverage for non-uniform spacing and negative-slowness symmetry.
  * Improved test variability by using seeded random distance increments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->