### PR TITLE
Fix four reader defects in h5simple, AP Sensing, dashdf5 and optodas

### DIFF
--- a/dascore/io/ap_sensing/utils.py
+++ b/dascore/io/ap_sensing/utils.py
@@ -15,7 +15,7 @@ def _get_version_string(resource):
     attrs_names = set(resource.attrs)
     group_names = set(resource)
     # This file doesn't have expected attrs and groups.
-    if not attrs.issubset(attrs_names) and not groups.issubset(group_names):
+    if not attrs.issubset(attrs_names) or not groups.issubset(group_names):
         return False
     file_version = resource.attrs["FileVersion"]
     return str(_maybe_unpack(file_version))

--- a/dascore/io/ap_sensing/utils.py
+++ b/dascore/io/ap_sensing/utils.py
@@ -14,7 +14,7 @@ def _get_version_string(resource):
     groups = {"DAQ", "Interrogator", "Metadata", "ProcessingServer"}
     attrs_names = set(resource.attrs)
     group_names = set(resource)
-    # This file doesn't have expected attrs and groups.
+    # Missing either the expected attrs or the groups rules the format out.
     if not attrs.issubset(attrs_names) or not groups.issubset(group_names):
         return False
     file_version = resource.attrs["FileVersion"]

--- a/dascore/io/dashdf5/core.py
+++ b/dascore/io/dashdf5/core.py
@@ -63,11 +63,12 @@ class DASHDF5(FiberIO):
         resource: H5Reader,
         time: tuple[opt_timeable_types, opt_timeable_types] | None = None,
         channel: tuple[float | None, float | None] | None = None,
+        snap: bool = True,
         **kwargs,
     ):
         """Read a CF file and return a Patch."""
         patches = build_patches(
-            _get_cf_coords(resource),
+            _get_cf_coords(resource, snap=snap),
             resource["das"],
             _get_cf_attrs(resource),
             selection={"time": time, "channel": channel},

--- a/dascore/io/dashdf5/core.py
+++ b/dascore/io/dashdf5/core.py
@@ -66,7 +66,20 @@ class DASHDF5(FiberIO):
         snap: bool = True,
         **kwargs,
     ):
-        """Read a CF file and return a Patch."""
+        """
+        Read a CF file and return a spool of patches.
+
+        Parameters
+        ----------
+        resource
+            The open h5 object.
+        time
+            An optional tuple for filtering time.
+        channel
+            An optional tuple for filtering channel.
+        snap
+            If True, snap each coordinate to be evenly sampled.
+        """
         patches = build_patches(
             _get_cf_coords(resource, snap=snap),
             resource["das"],

--- a/dascore/io/h5simple/utils.py
+++ b/dascore/io/h5simple/utils.py
@@ -155,7 +155,7 @@ def _no_format_or_simple_specified(h5):
     attrs = h5.attrs
     attr_names = set(attrs)
     file_format = attr_names & FILE_FORMAT_ATTR_NAMES
-    format = getattr(attrs, next(iter(file_format))) if file_format else "h5simple"
+    format = unbyte(attrs[next(iter(file_format))]) if file_format else "h5simple"
     if format == "h5simple":
         return True
     return False

--- a/dascore/io/h5simple/utils.py
+++ b/dascore/io/h5simple/utils.py
@@ -8,7 +8,7 @@ import dascore as dc
 from dascore.constants import STORAGE_PROVENANCE_ATTRS
 from dascore.core import get_coord
 from dascore.io.utils import get_exact_coord
-from dascore.utils.misc import unbyte
+from dascore.utils.misc import _maybe_unpack, unbyte
 
 # --- Getting format/version
 
@@ -153,9 +153,7 @@ def _has_required_arrays(h5):
 def _no_format_or_simple_specified(h5):
     """Ensure no other format is specified, or that simpleH5 is."""
     attrs = h5.attrs
-    attr_names = set(attrs)
-    file_format = attr_names & FILE_FORMAT_ATTR_NAMES
-    format = unbyte(attrs[next(iter(file_format))]) if file_format else "h5simple"
-    if format == "h5simple":
-        return True
-    return False
+    names = set(attrs) & FILE_FORMAT_ATTR_NAMES
+    # Every name that states a format has to state this one; a file which
+    # names two disagreeing formats belongs to neither.
+    return all(unbyte(_maybe_unpack(attrs[name])) == "h5simple" for name in names)

--- a/dascore/io/optodas/core.py
+++ b/dascore/io/optodas/core.py
@@ -66,11 +66,16 @@ class OptoDASV8(FiberIO):
         resource: H5Reader,
         time: tuple[opt_timeable_types, opt_timeable_types] | None = None,
         distance: tuple[float | None, float | None] | None = None,
+        snap: bool = True,
         **kwargs,
     ) -> dc.Spool:
         """Read a OptoDAS spool of patches."""
         patches = _read_opto_das(
-            resource, time=time, distance=distance, attr_cls=OptoDASPatchAttrs
+            resource,
+            time=time,
+            distance=distance,
+            snap=snap,
+            attr_cls=OptoDASPatchAttrs,
         )
         return dc.spool(patches)
 

--- a/dascore/io/optodas/core.py
+++ b/dascore/io/optodas/core.py
@@ -69,7 +69,20 @@ class OptoDASV8(FiberIO):
         snap: bool = True,
         **kwargs,
     ) -> dc.Spool:
-        """Read a OptoDAS spool of patches."""
+        """
+        Read an OptoDAS file and return a spool of patches.
+
+        Parameters
+        ----------
+        resource
+            The open h5 object.
+        time
+            An optional tuple for filtering time.
+        distance
+            An optional tuple for filtering distance.
+        snap
+            If True, snap each coordinate to be evenly sampled.
+        """
         patches = _read_opto_das(
             resource,
             time=time,

--- a/dascore/io/optodas/utils.py
+++ b/dascore/io/optodas/utils.py
@@ -81,9 +81,9 @@ def _get_opto_das_attrs(fi, snap=True) -> tuple[dict, dascore.core.CoordManager]
     return attrs, cm
 
 
-def _read_opto_das(fi, distance=None, time=None, attr_cls=dc.PatchAttrs):
+def _read_opto_das(fi, distance=None, time=None, snap=True, attr_cls=dc.PatchAttrs):
     """Read the OptoDAS values into a patch."""
-    attrs, coords = _get_opto_das_attrs(fi)
+    attrs, coords = _get_opto_das_attrs(fi, snap=snap)
     return build_patches(
         coords,
         fi["data"],

--- a/tests/test_io/test_ap_sensing/test_ap_sensing.py
+++ b/tests/test_io/test_ap_sensing/test_ap_sensing.py
@@ -1,0 +1,29 @@
+"""Tests for the AP Sensing format."""
+
+from __future__ import annotations
+
+import h5py
+import numpy as np
+import pytest
+
+from dascore.io.ap_sensing.utils import _get_version_string
+
+
+class TestDetection:
+    """The format needs both its root attrs and its groups."""
+
+    @pytest.mark.parametrize("with_attrs", [True, False])
+    def test_partial_layout_is_not_ap_sensing(self, tmp_path, with_attrs):
+        """A file with only the attrs, or only the groups, is refused cleanly."""
+        path = tmp_path / "partial.h5"
+        with h5py.File(path, "w") as h5:
+            if with_attrs:
+                h5.attrs["AppVersion"] = "1.0"
+                h5.attrs["FileVersion"] = "10"
+                h5.attrs["OpticalChannelNumber"] = 1
+            else:
+                for name in ("DAQ", "Interrogator", "Metadata", "ProcessingServer"):
+                    h5.create_group(name)
+            h5["DAS"] = np.zeros((2, 2))
+        with h5py.File(path, "r") as h5:
+            assert _get_version_string(h5) is False

--- a/tests/test_io/test_ap_sensing/test_ap_sensing.py
+++ b/tests/test_io/test_ap_sensing/test_ap_sensing.py
@@ -14,7 +14,10 @@ class TestDetection:
 
     @pytest.mark.parametrize("with_attrs", [True, False])
     def test_partial_layout_is_not_ap_sensing(self, tmp_path, with_attrs):
-        """A file with only the attrs, or only the groups, is refused cleanly."""
+        """
+        Half a layout is not the format; detection used to claim a file
+        unless both halves were missing.
+        """
         path = tmp_path / "partial.h5"
         with h5py.File(path, "w") as h5:
             if with_attrs:

--- a/tests/test_io/test_dashdf5/test_dashdf5.py
+++ b/tests/test_io/test_dashdf5/test_dashdf5.py
@@ -14,7 +14,10 @@ class TestSnap:
 
     @pytest.fixture(scope="class")
     def jittered_path(self, tmp_path_factory):
-        """A minimal DASHDF5 file whose time axis has a small jitter."""
+        """
+        A minimal DASHDF5 file whose time samples shift by a microsecond
+        halfway through, so snapping changes the values.
+        """
         path = tmp_path_factory.mktemp("dashdf5") / "jitter.h5"
         time = np.arange(20) * 0.001 + 1e9
         time[10:] += 1e-6
@@ -32,7 +35,10 @@ class TestSnap:
         return path
 
     def test_read_honours_snap(self, jittered_path):
-        """An exact read carries the same time values as an exact scan."""
+        """
+        With snap=False read returns the file's own time values, as scan
+        does; read used to snap them anyway.
+        """
         scanned = dc.scan_payloads(jittered_path, snap=False)[0]["coords"]
         patch = dc.read(jittered_path, snap=False)[0]
         np.testing.assert_array_equal(

--- a/tests/test_io/test_dashdf5/test_dashdf5.py
+++ b/tests/test_io/test_dashdf5/test_dashdf5.py
@@ -1,0 +1,40 @@
+"""Tests for the DASHDF5 format."""
+
+from __future__ import annotations
+
+import h5py
+import numpy as np
+import pytest
+
+import dascore as dc
+
+
+class TestSnap:
+    """Read and scan must agree on whether coordinates are snapped."""
+
+    @pytest.fixture(scope="class")
+    def jittered_path(self, tmp_path_factory):
+        """A minimal DASHDF5 file whose time axis has a small jitter."""
+        path = tmp_path_factory.mktemp("dashdf5") / "jitter.h5"
+        time = np.arange(20) * 0.001 + 1e9
+        time[10:] += 1e-6
+        with h5py.File(path, "w") as h5:
+            h5.attrs["Conventions"] = np.array(
+                ["CF-1.7", "DAS-HDF5-1.0"], dtype=h5py.string_dtype()
+            )
+            h5["channel"] = np.arange(4)
+            h5["trace"] = np.arange(20)
+            h5["t"] = time
+            for name in "xyz":
+                h5[name] = np.arange(4, dtype=float)
+                h5[name].attrs["units"] = "m"
+            h5["das"] = np.zeros((4, 20), dtype="float32")
+        return path
+
+    def test_read_honours_snap(self, jittered_path):
+        """An exact read carries the same time values as an exact scan."""
+        scanned = dc.scan_payloads(jittered_path, snap=False)[0]["coords"]
+        patch = dc.read(jittered_path, snap=False)[0]
+        np.testing.assert_array_equal(
+            scanned.get_coord("time").values, patch.get_coord("time").values
+        )

--- a/tests/test_io/test_h5simple/test_h5simple.py
+++ b/tests/test_io/test_h5simple/test_h5simple.py
@@ -9,6 +9,7 @@ import pytest
 
 import dascore as dc
 from dascore.constants import STORAGE_PROVENANCE_ATTRS
+from dascore.exceptions import UnknownFiberFormatError
 from dascore.utils.downloader import fetch
 
 
@@ -58,3 +59,22 @@ class TestH5Simple:
         assert not read_names & set(STORAGE_PROVENANCE_ATTRS)
         # Stripping it in only one of the two is how they came to disagree.
         assert read_names == scan_names
+
+    @pytest.mark.parametrize("name", ["__format__", "format", "file_format"])
+    def test_declared_format_is_recognized(self, h5simple_path, tmp_path, name):
+        """A root attr naming the format opts the file in, not out."""
+        path = tmp_path / f"{name}.h5"
+        shutil.copy(h5simple_path, path)
+        with h5py.File(path, "r+") as h5:
+            h5.attrs[name] = "h5simple"
+        assert dc.get_format(path) == ("H5Simple", "1")
+        assert isinstance(dc.read(path)[0], dc.Patch)
+
+    def test_other_declared_format_is_rejected(self, h5simple_path, tmp_path):
+        """A root attr naming another format still rules h5simple out."""
+        path = tmp_path / "other.h5"
+        shutil.copy(h5simple_path, path)
+        with h5py.File(path, "r+") as h5:
+            h5.attrs["format"] = "other"
+        with pytest.raises(UnknownFiberFormatError):
+            dc.get_format(path)

--- a/tests/test_io/test_h5simple/test_h5simple.py
+++ b/tests/test_io/test_h5simple/test_h5simple.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import shutil
 
 import h5py
+import numpy as np
 import pytest
 
 import dascore as dc
@@ -61,14 +62,29 @@ class TestH5Simple:
         assert read_names == scan_names
 
     @pytest.mark.parametrize("name", ["__format__", "format", "file_format"])
-    def test_declared_format_is_recognized(self, h5simple_path, tmp_path, name):
-        """A root attr naming the format opts the file in, not out."""
-        path = tmp_path / f"{name}.h5"
+    @pytest.mark.parametrize("value", ["h5simple", np.bytes_(b"h5simple")])
+    def test_declared_format_is_recognized(self, h5simple_path, tmp_path, name, value):
+        """A root attr naming the format opts the file in, not out.
+
+        Files written through PyTables carry bytes rather than str, which
+        is why the value is decoded rather than compared as it is stored.
+        """
+        path = tmp_path / f"{name}_{type(value).__name__}.h5"
         shutil.copy(h5simple_path, path)
         with h5py.File(path, "r+") as h5:
-            h5.attrs[name] = "h5simple"
+            h5.attrs[name] = value
         assert dc.get_format(path) == ("H5Simple", "1")
         assert isinstance(dc.read(path)[0], dc.Patch)
+
+    def test_disagreeing_declared_formats_are_rejected(self, h5simple_path, tmp_path):
+        """Two root attrs naming different formats rule the file out."""
+        path = tmp_path / "disagree.h5"
+        shutil.copy(h5simple_path, path)
+        with h5py.File(path, "r+") as h5:
+            h5.attrs["format"] = "h5simple"
+            h5.attrs["__format__"] = "other"
+        with pytest.raises(UnknownFiberFormatError):
+            dc.get_format(path)
 
     def test_other_declared_format_is_rejected(self, h5simple_path, tmp_path):
         """A root attr naming another format still rules h5simple out."""


### PR DESCRIPTION
## Description

Four small reader defects found during the 2026-09-02 redundancy review of `dev`. Each is independent; they share a PR because each is a line or two plus a test.

**h5simple refused files that named it.** The detector read the declared-format root attr with `getattr` on the h5py attribute manager, so `__format__` returned the manager's own `__format__` method and `format`/`file_format` raised `AttributeError`, which the sniffer swallows into "not this format". A file carrying any of the three names was therefore unreadable, even with an explicit `file_format="h5simple"` hint. The value is now read out of the attrs mapping, unpacked and decoded, since a file written through PyTables stores bytes. Every name that states a format must state this one, rather than an arbitrary member of the set being picked.

**AP Sensing claimed half-matching files.** The guard rejected only files missing both the expected root attrs and the expected groups, so a file with the attrs alone was claimed and then failed with a `KeyError` that the sniffer hid. The real example file has both and is unaffected.

**dashdf5 and optodas dropped `snap` in `read`.** Both honour it in `scan`, so an exact scan and an exact read of the same file disagreed on coordinates. `read` now takes `snap` and passes it to the same coordinate builder `scan` uses. This also activates the value comparison in the common-format contract test, which keys on `snap` being in the `read` signature.

Verified before fixing: each defect was reproduced by an independent reviewer against the real example files.

## Changelog

- fixed: `H5Simple` files which declare their format in a root attribute are now recognized rather than refused.
- fixed: AP Sensing detection no longer claims a file that has only half of the expected layout.
- fixed: `dc.read` now honours `snap` for the `DASHDF5` and `OptoDAS` formats, as `dc.scan` already did.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added control over coordinate snapping when reading DASHDF5 and OptoDAS files.
  * Reading now returns coordinate values consistent with the selected snapping behavior.

* **Bug Fixes**
  * Improved detection of AP Sensing files with incomplete layouts.
  * Improved H5Simple format validation, including conflicting or unsupported format declarations.

* **Tests**
  * Added coverage for snapping behavior and stricter file-format detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->