### PR TITLE
Sniff a single file's format once when opening a spool

### DIFF
--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -2174,6 +2174,22 @@ class Spool(NodeRepr, NamespaceOwner):
         Create a spool over a single (multi-patch capable) fiber file.
 
         The file is scanned once; patches load lazily per row.
+
+        Parameters
+        ----------
+        path
+            The file to open.
+        file_format
+            The format name, sniffed from the file when not given.
+        file_version
+            The format version, sniffed from the file when not given.
+
+        Notes
+        -----
+        A format and version given together are believed rather than
+        checked against the file, as `dc.read` and `dc.scan` believe them.
+        Naming the wrong format therefore yields whatever that reader
+        makes of the file, which is usually an empty spool.
         """
         path = path if isinstance(path, UPath) else Path(path)
         if not path.exists() or path.is_dir():
@@ -2182,9 +2198,10 @@ class Spool(NodeRepr, NamespaceOwner):
         from dascore.io.index.catalog import PatchCatalog  # noqa: PLC0415
 
         if file_format and file_version:
-            # Both callers already know the format, and sniffing it again
-            # opens the file a second time; for a remote source that is a
-            # round trip. Resolve the reader to canonicalize the names.
+            # Both internal callers already know the format, and sniffing
+            # it again opens the file a second time; for a remote source
+            # that is a round trip. Resolving the reader canonicalizes the
+            # names and still rejects a pair no reader claims.
             fiber_io = dc.io.FiberIO.manager.get_fiberio(
                 format=file_format, version=file_version
             )
@@ -2259,9 +2276,9 @@ class Spool(NodeRepr, NamespaceOwner):
                 format=self._file_format, version=self._file_version
             )
             getattr(formatter, "index", lambda _: None)(self._file_path)
-            refreshed = self.from_file(
-                self._file_path, self._file_format, self._file_version
-            )
+            # Sniffed rather than reused: noticing that the file changed is
+            # what update is for, and it may now hold another version.
+            refreshed = self.from_file(self._file_path)
             # from_file builds a spool from the file alone, but an attached
             # inventory is the caller's state rather than the file's, and
             # re-reading the file is no reason to stop enriching.

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -2181,7 +2181,16 @@ class Spool(NodeRepr, NamespaceOwner):
             raise FileNotFoundError(msg)
         from dascore.io.index.catalog import PatchCatalog  # noqa: PLC0415
 
-        _format, _version = dc.get_format(path, file_format, file_version)
+        if file_format and file_version:
+            # Both callers already know the format, and sniffing it again
+            # opens the file a second time; for a remote source that is a
+            # round trip. Resolve the reader to canonicalize the names.
+            fiber_io = dc.io.FiberIO.manager.get_fiberio(
+                format=file_format, version=file_version
+            )
+            _format, _version = fiber_io.name, fiber_io.version
+        else:
+            _format, _version = dc.get_format(path, file_format, file_version)
         out = cls()
         out._catalog = PatchCatalog.from_file(
             path, file_format=_format, file_version=_version

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -962,7 +962,9 @@ class TestGetSpool:
         with mock.patch.object(
             manager, "_get_format", wraps=manager._get_format
         ) as probe:
-            dc.spool(terra15_das_example_path)
+            # Inside the block: a spool which sniffs while it builds rows
+            # lazily would otherwise slip past the count.
+            assert len(dc.spool(terra15_das_example_path))
         assert probe.call_count == 1
 
     def test_from_file_with_known_format_does_not_probe(self, terra15_das_example_path):
@@ -972,20 +974,21 @@ class TestGetSpool:
         with mock.patch.object(
             manager, "_get_format", wraps=manager._get_format
         ) as probe:
-            spool = Spool.from_file(terra15_das_example_path, fmt, ver)
+            assert len(Spool.from_file(terra15_das_example_path, fmt, ver))
         assert probe.call_count == 0
-        assert len(spool)
 
-    def test_update_rereads_a_rewritten_version(self, tmp_path):
-        """A file rewritten in another version is re-sniffed, not assumed."""
+    def test_update_rereads_a_rewritten_format(self, tmp_path):
+        """A file rewritten in another format is re-sniffed, not assumed."""
         path = tmp_path / "patch.h5"
         patch = dc.get_example_patch()
         patch.io.write(path, "dasdae")
         spool = dc.spool(path)
         assert len(spool) == 1
         path.unlink()
-        patch.io.write(path, "dasdae")
-        assert len(spool.update()) == 1
+        patch.io.write(path, "pickle")
+        updated = spool.update()
+        assert len(updated) == 1
+        assert updated[0].equals(patch)
 
     def test_stated_format_is_believed(self, terra15_das_example_path):
         """

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -949,6 +949,32 @@ class TestGetSpool:
         assert isinstance(out2, BaseSpool)
         assert len(out1) == len(out2)
 
+    def test_single_file_format_probed_once(self, terra15_das_example_path):
+        """
+        Opening one file sniffs its format once.
+
+        from_file re-sniffed a format its caller had already resolved,
+        which opens the file again; for a remote source that is a second
+        round trip.
+        """
+        manager = dc.io.FiberIO.manager
+        with mock.patch.object(
+            manager, "_get_format", wraps=manager._get_format
+        ) as probe:
+            dc.spool(terra15_das_example_path)
+        assert probe.call_count == 1
+
+    def test_from_file_with_known_format_does_not_probe(self, terra15_das_example_path):
+        """A caller which states the format is believed."""
+        fmt, ver = dc.get_format(terra15_das_example_path)
+        manager = dc.io.FiberIO.manager
+        with mock.patch.object(
+            manager, "_get_format", wraps=manager._get_format
+        ) as probe:
+            spool = Spool.from_file(terra15_das_example_path, fmt, ver)
+        assert probe.call_count == 0
+        assert len(spool)
+
     def test_non_existent_file_raises(self):
         """A path that doesn't exist should raise."""
         with pytest.raises(Exception, match="get spool from"):

--- a/tests/test_core/test_spool.py
+++ b/tests/test_core/test_spool.py
@@ -29,6 +29,7 @@ from dascore.exceptions import (
     MissingPatchError,
     ParameterError,
     UnknownExampleError,
+    UnknownFiberFormatError,
 )
 from dascore.io.index.planned import PlanResolver
 from dascore.io.segy import SegyV1_0
@@ -974,6 +975,30 @@ class TestGetSpool:
             spool = Spool.from_file(terra15_das_example_path, fmt, ver)
         assert probe.call_count == 0
         assert len(spool)
+
+    def test_update_rereads_a_rewritten_version(self, tmp_path):
+        """A file rewritten in another version is re-sniffed, not assumed."""
+        path = tmp_path / "patch.h5"
+        patch = dc.get_example_patch()
+        patch.io.write(path, "dasdae")
+        spool = dc.spool(path)
+        assert len(spool) == 1
+        path.unlink()
+        patch.io.write(path, "dasdae")
+        assert len(spool.update()) == 1
+
+    def test_stated_format_is_believed(self, terra15_das_example_path):
+        """
+        A stated format is used as given, as dc.read and dc.scan use it.
+
+        Naming a format the file is not therefore yields what that reader
+        makes of the file rather than an error, which is the contract the
+        other two entry points already have.
+        """
+        spool = Spool.from_file(terra15_das_example_path, "DASDAE", "1")
+        assert len(spool) == 0
+        with pytest.raises(UnknownFiberFormatError):
+            Spool.from_file(terra15_das_example_path, "not_a_format", "1")
 
     def test_non_existent_file_raises(self):
         """A path that doesn't exist should raise."""


### PR DESCRIPTION
## Description

`dc.spool(path)` on a single file sniffed the file's format twice. `_spool_from_str` detects the format, resolves the reader, and then hands both names to `Spool.from_file`, which detected them again from scratch. Detection opens the file and runs a reader's `get_format`, so every single-file spool paid a second open, and for a remote source that is a second round trip.

`from_file` now resolves the reader from the names it was given, which canonicalizes them and still rejects a format and version no reader claims, and only sniffs when a name is missing. `dc.read` and `dc.scan` already guard the same way.

Two consequences worth stating, both settled during review:

- A stated format and version are now believed rather than checked against the file, which is the contract `dc.read` and `dc.scan` already have. Naming the wrong format yields whatever that reader makes of the file. This is documented on `from_file` and pinned by a test.
- `Spool.update` used to re-detect the version as a side effect of that second sniff, and noticing that the file changed is exactly what `update` is for. It now sniffs the file itself rather than reusing the names captured when the spool was opened, so the probe count there is unchanged at one.

Found during the 2026-09-02 redundancy review of `dev`.

## Changelog

- changed: `dc.spool` on a single file detects its format once rather than twice, which saves an open (a round trip, for a remote file).

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
