### PR TITLE
Read one glob dialect everywhere

### DIFF
--- a/dascore/core/_spool_inventory.py
+++ b/dascore/core/_spool_inventory.py
@@ -534,8 +534,8 @@ def glob_filter(include, exclude):
     The patterns are matched against each value written as a string, so
     one vocabulary covers every kind a group can hold: `"hole_*"` reads a
     categorical group, and a membership group is `"True"` and `"False"`.
-    Globs mean what they mean everywhere else here, which is what SQLite
-    means by them rather than what `fnmatch` does.
+    Globs are SQLite's here as everywhere in DASCore; `glob_to_regex`
+    translates them and says why not `fnmatch`.
     """
     patterns = tuple(
         None if spec is None else [glob_to_regex(str(x)) for x in iterate(spec)]

--- a/dascore/core/_spool_inventory.py
+++ b/dascore/core/_spool_inventory.py
@@ -55,7 +55,7 @@ from dascore.exceptions import (
 from dascore.models import values_equal
 from dascore.units import convert_units, get_quantity_str
 from dascore.utils.intervals import interval_masks, value_kind
-from dascore.utils.misc import iterate, validate_acquisition_key
+from dascore.utils.misc import glob_to_regex, iterate, validate_acquisition_key
 from dascore.utils.time import to_datetime64
 
 # One vocabulary for both fiber verbs. What the quiet option leaves
@@ -537,8 +537,6 @@ def glob_filter(include, exclude):
     Globs mean what they mean everywhere else here, which is what SQLite
     means by them rather than what `fnmatch` does.
     """
-    from dascore.io.index.query import glob_to_regex  # noqa: PLC0415
-
     patterns = tuple(
         None if spec is None else [glob_to_regex(str(x)) for x in iterate(spec)]
         for spec in (include, exclude)

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -7,7 +7,6 @@ current coord-family and string-coordinate design notes.
 from __future__ import annotations
 
 import abc
-import fnmatch
 import hashlib
 import itertools
 import json
@@ -70,6 +69,7 @@ from dascore.utils.misc import (
     all_close,
     all_diffs_close_enough,
     cached_method,
+    glob_to_regex,
     is_strictly_monotonic,
     iterate,
     sanitize_range_param,
@@ -2969,7 +2969,7 @@ class CoordString(BaseCoord):
             mask = np.array([bool(args.search(value)) for value in self.values])
             return self._select_by_value_array(self.values[mask])
         if isinstance(args, str) and ("*" in args or "?" in args):
-            pattern = re.compile(fnmatch.translate(args))
+            pattern = glob_to_regex(args)
             mask = np.array([bool(pattern.match(value)) for value in self.values])
             return self._select_by_value_array(self.values[mask])
         values = np.asarray([args])

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -2968,7 +2968,7 @@ class CoordString(BaseCoord):
         if isinstance(args, re.Pattern):
             mask = np.array([bool(args.search(value)) for value in self.values])
             return self._select_by_value_array(self.values[mask])
-        if isinstance(args, str) and ("*" in args or "?" in args):
+        if isinstance(args, str) and any(char in args for char in "*?["):
             pattern = glob_to_regex(args)
             mask = np.array([bool(pattern.match(value)) for value in self.values])
             return self._select_by_value_array(self.values[mask])

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -2894,8 +2894,8 @@ class CoordString(BaseCoord):
 
     See ['Coordinate Internals'](`docs/notes/coordinate_internals.qmd`) for the
     constraints that make string coords differ from numeric and time-like
-    coords. Plain string selectors use exact matching unless they contain `*`
-    or `?`, in which case they are treated as unix-style wildcard patterns.
+    coords. Plain string selectors use exact matching unless they contain `*`,
+    `?` or `[`, in which case they are read as globs, as SQLite reads them.
     Compiled regular expressions are also supported as explicit pattern
     selectors.
     """

--- a/dascore/core/spool.py
+++ b/dascore/core/spool.py
@@ -440,9 +440,10 @@ class Spool(NodeRepr, NamespaceOwner):
         """
         Sub-select parts of the spool.
 
-        Can be used to specify dimension ranges, or unix-style matches
-        on string attributes. Bare keyword names resolve against
-        attributes first, then coordinates; unknown names raise.
+        Can be used to specify dimension ranges, or glob matches on
+        string attributes, read as SQLite's GLOB reads them. Bare keyword
+        names resolve against attributes first, then coordinates; unknown
+        names raise.
 
         Parameters
         ----------

--- a/dascore/io/index/query.py
+++ b/dascore/io/index/query.py
@@ -24,7 +24,7 @@ from dascore.exceptions import InvalidSpoolQueryError, ParameterError, UnitError
 from dascore.io.index.ingest import typed_value
 from dascore.io.index.schema import glob_expr, quote
 from dascore.units import convert_units
-from dascore.utils.misc import is_range
+from dascore.utils.misc import glob_to_regex, is_range
 from dascore.utils.pd import resolve_selector_namespaces
 
 _GLOB_CHARS = frozenset("*?[")
@@ -323,79 +323,6 @@ def build_attr_clause(
     val = _to_target_unit(typed, units.get(kind), name)
     where.add(f"{col(kind)} = ?", val)
     return None
-
-
-def glob_to_regex(pattern: str) -> re.Pattern:
-    """
-    Translate a glob to the regex which matches what SQLite's GLOB does.
-
-    SQLite is the authority on what a glob selector means, since that is
-    what the index applies, and it is not `fnmatch`: a character class is
-    negated with `[^...]`, where fnmatch spells that `[!...]` and reads a
-    leading `!` as a literal. Translating here rather than reaching for
-    fnmatch is what keeps one pattern from selecting opposite halves of a
-    spool depending on which side answered it. An unterminated class
-    matches nothing, as it does in SQLite; a class a regex cannot express
-    at all (a reversed range, which SQLite reads leniently) matches
-    nothing here rather than being guessed at.
-    """
-    out, index, size = [], 0, len(pattern)
-    while index < size:
-        char = pattern[index]
-        if char in "*?":
-            out.append(".*" if char == "*" else ".")
-        elif char == "[":
-            # A class may open with '^' to negate and may hold ']' as its
-            # first member; the class ends at the next ']' after those.
-            end = index + 1 + pattern[index + 1 : index + 2].count("^")
-            end += pattern[end : end + 1].count("]")
-            end = pattern.find("]", end)
-            if end < 0:
-                return _MATCHES_NOTHING
-            body = pattern[index + 1 : end]
-            negate, body = body.startswith("^"), body.removeprefix("^")
-            # A ']' opening a class is one of its members, and SQLite takes
-            # it as a plain one: it is not the low end of a range, so the
-            # dash which may follow it is a member too.
-            leading = ""
-            if body.startswith("]"):
-                leading, body = re.escape("]"), body[1:]
-            out.append(f"[{'^' if negate else ''}{leading}{_class_body(body)}]")
-            index = end
-        else:
-            out.append(re.escape(char))
-        index += 1
-    # DOTALL, since SQLite's wildcards cross a newline like any other byte.
-    return re.compile("".join(out) + r"\Z", re.DOTALL)
-
-
-# A pattern which matches nothing, for a glob SQLite would not read.
-_MATCHES_NOTHING = re.compile(r"(?!)")
-
-
-def _class_body(body: str) -> str:
-    """
-    Escape the members of a glob character class for a regex one.
-
-    Ranges stay ranges, since a glob class means them, with each endpoint
-    escaped on its own — escaping the body wholesale would turn the dash
-    of a range into a member. A range's low endpoint is also emitted as a
-    member: SQLite tests it before testing the range, so `[z-a]` matches
-    `z` where the reversed range alone matches nothing.
-    """
-    out, index, size = [], 0, len(body)
-    while index < size:
-        low = body[index]
-        if index + 2 < size and body[index + 1] == "-":
-            high = body[index + 2]
-            out.append(re.escape(low))
-            if low <= high:
-                out.append(f"{re.escape(low)}-{re.escape(high)}")
-            index += 3
-            continue
-        out.append(re.escape(low))
-        index += 1
-    return "".join(out)
 
 
 def evaluate_attr_predicate(values, name: str, value, units=None) -> np.ndarray:

--- a/dascore/utils/misc.py
+++ b/dascore/utils/misc.py
@@ -1558,8 +1558,10 @@ def glob_to_regex(pattern: str) -> re.Pattern:
     return re.compile(r"(?s)" + "".join(out) + r"\Z")
 
 
-# A pattern which matches nothing, for a glob SQLite would not read.
-_MATCHES_NOTHING = re.compile(r"(?!)")
+# A pattern which matches nothing, for a glob SQLite would not read. An
+# empty character class rather than a failing lookahead, because pandas
+# hands the pattern text to a regex engine without lookahead support.
+_MATCHES_NOTHING = re.compile(r"(?s)[^\s\S]\Z")
 
 
 def _class_body(body: str) -> str:

--- a/dascore/utils/misc.py
+++ b/dascore/utils/misc.py
@@ -1516,15 +1516,15 @@ def glob_to_regex(pattern: str) -> re.Pattern:
     """
     Translate a glob to the regex which matches what SQLite's GLOB does.
 
-    SQLite is the authority on what a glob selector means, since that is
-    what the index applies, and it is not `fnmatch`: a character class is
-    negated with `[^...]`, where fnmatch spells that `[!...]` and reads a
-    leading `!` as a literal. Translating here rather than reaching for
-    fnmatch is what keeps one pattern from selecting opposite halves of a
-    spool depending on which side answered it. An unterminated class
-    matches nothing, as it does in SQLite; a class a regex cannot express
-    at all (a reversed range, which SQLite reads leniently) matches
-    nothing here rather than being guessed at.
+    Every glob DASCore reads -- a spool query, a dataframe filter, a
+    string coordinate -- means what SQLite's GLOB means, since the index
+    answers some of those queries in SQL and one pattern must not mean two
+    things depending on which side answers it. SQLite is not `fnmatch`: a
+    class is negated with `[^...]`, where fnmatch spells that `[!...]` and
+    reads a leading `!` as a literal. An unterminated class matches
+    nothing, as it does in SQLite; a class a regex cannot express at all
+    (a reversed range, which SQLite reads leniently) matches nothing here
+    rather than being guessed at.
     """
     out, index, size = [], 0, len(pattern)
     while index < size:
@@ -1552,9 +1552,9 @@ def glob_to_regex(pattern: str) -> re.Pattern:
         else:
             out.append(re.escape(char))
         index += 1
-    # The DOTALL flag is written into the pattern, since SQLite's wildcards
-    # cross a newline like any other byte and pandas rejects a compiled
-    # pattern whose flags it did not set itself.
+    # SQLite's wildcards cross a newline like any other byte. The flag goes
+    # inline, not into re.compile, so it survives a caller that hands the
+    # pattern text on to something else.
     return re.compile(r"(?s)" + "".join(out) + r"\Z")
 
 

--- a/dascore/utils/misc.py
+++ b/dascore/utils/misc.py
@@ -1509,3 +1509,79 @@ def validate_acquisition_key(value: str) -> str:
         )
         raise InvalidInventoryError(msg)
     return value
+
+
+@cache
+def glob_to_regex(pattern: str) -> re.Pattern:
+    """
+    Translate a glob to the regex which matches what SQLite's GLOB does.
+
+    SQLite is the authority on what a glob selector means, since that is
+    what the index applies, and it is not `fnmatch`: a character class is
+    negated with `[^...]`, where fnmatch spells that `[!...]` and reads a
+    leading `!` as a literal. Translating here rather than reaching for
+    fnmatch is what keeps one pattern from selecting opposite halves of a
+    spool depending on which side answered it. An unterminated class
+    matches nothing, as it does in SQLite; a class a regex cannot express
+    at all (a reversed range, which SQLite reads leniently) matches
+    nothing here rather than being guessed at.
+    """
+    out, index, size = [], 0, len(pattern)
+    while index < size:
+        char = pattern[index]
+        if char in "*?":
+            out.append(".*" if char == "*" else ".")
+        elif char == "[":
+            # A class may open with '^' to negate and may hold ']' as its
+            # first member; the class ends at the next ']' after those.
+            end = index + 1 + pattern[index + 1 : index + 2].count("^")
+            end += pattern[end : end + 1].count("]")
+            end = pattern.find("]", end)
+            if end < 0:
+                return _MATCHES_NOTHING
+            body = pattern[index + 1 : end]
+            negate, body = body.startswith("^"), body.removeprefix("^")
+            # A ']' opening a class is one of its members, and SQLite takes
+            # it as a plain one: it is not the low end of a range, so the
+            # dash which may follow it is a member too.
+            leading = ""
+            if body.startswith("]"):
+                leading, body = re.escape("]"), body[1:]
+            out.append(f"[{'^' if negate else ''}{leading}{_class_body(body)}]")
+            index = end
+        else:
+            out.append(re.escape(char))
+        index += 1
+    # The DOTALL flag is written into the pattern, since SQLite's wildcards
+    # cross a newline like any other byte and pandas rejects a compiled
+    # pattern whose flags it did not set itself.
+    return re.compile(r"(?s)" + "".join(out) + r"\Z")
+
+
+# A pattern which matches nothing, for a glob SQLite would not read.
+_MATCHES_NOTHING = re.compile(r"(?!)")
+
+
+def _class_body(body: str) -> str:
+    """
+    Escape the members of a glob character class for a regex one.
+
+    Ranges stay ranges, since a glob class means them, with each endpoint
+    escaped on its own — escaping the body wholesale would turn the dash
+    of a range into a member. A range's low endpoint is also emitted as a
+    member: SQLite tests it before testing the range, so `[z-a]` matches
+    `z` where the reversed range alone matches nothing.
+    """
+    out, index, size = [], 0, len(body)
+    while index < size:
+        low = body[index]
+        if index + 2 < size and body[index + 1] == "-":
+            high = body[index + 2]
+            out.append(re.escape(low))
+            if low <= high:
+                out.append(f"{re.escape(low)}-{re.escape(high)}")
+            index += 3
+            continue
+        out.append(re.escape(low))
+        index += 1
+    return "".join(out)

--- a/dascore/utils/pd.py
+++ b/dascore/utils/pd.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import fnmatch
 from collections import defaultdict
 from collections.abc import Collection, Generator, Iterator, Mapping, Sequence
+from functools import cache
 from typing import TypeVar, cast
 
 import numpy as np
@@ -14,6 +16,7 @@ import dascore as dc
 from dascore.constants import PatchType, namespace_select_type
 from dascore.core.attrs import PatchAttrs
 from dascore.exceptions import InvalidSpoolQueryError, ParameterError
+from dascore.utils.deprecate import deprecate
 from dascore.utils.misc import (
     glob_to_regex,
     is_range,
@@ -146,6 +149,20 @@ def present_columns(df: pd.DataFrame) -> pd.DataFrame:
     for present in PRESENTERS:
         df = present(df)
     return df
+
+
+@deprecate(
+    info=(
+        "get_regex is deprecated. Use dascore.utils.misc.glob_to_regex, "
+        "which reads a glob the way the index does: a character class is "
+        "negated with [^...] rather than fnmatch's [!...]."
+    ),
+    removed_in="0.2.0",
+)
+@cache
+def get_regex(seed_str):
+    """Compile, and cache regex for str queries."""
+    return fnmatch.translate(seed_str)  # translate to re
 
 
 def relative_offset(gmin, gmax, value):
@@ -435,6 +452,8 @@ def _filter_equality(query_dict, df, bool_index):
     for key, val in query_dict.items():
         if isinstance(val, str):
             regex = glob_to_regex(val)
+            # pandas refuses a compiled pattern with flags of its own; the
+            # source string carries the inline DOTALL.
             new = df[key].str.match(regex.pattern).values
             bool_index = np.logical_and(bool_index, new)
         else:

--- a/dascore/utils/pd.py
+++ b/dascore/utils/pd.py
@@ -2,10 +2,8 @@
 
 from __future__ import annotations
 
-import fnmatch
 from collections import defaultdict
 from collections.abc import Collection, Generator, Iterator, Mapping, Sequence
-from functools import cache
 from typing import TypeVar, cast
 
 import numpy as np
@@ -16,7 +14,12 @@ import dascore as dc
 from dascore.constants import PatchType, namespace_select_type
 from dascore.core.attrs import PatchAttrs
 from dascore.exceptions import InvalidSpoolQueryError, ParameterError
-from dascore.utils.misc import is_range, order_range_tuple, sanitize_range_param
+from dascore.utils.misc import (
+    glob_to_regex,
+    is_range,
+    order_range_tuple,
+    sanitize_range_param,
+)
 from dascore.utils.time import to_datetime64, to_timedelta64
 
 _RowType = TypeVar("_RowType")
@@ -143,12 +146,6 @@ def present_columns(df: pd.DataFrame) -> pd.DataFrame:
     for present in PRESENTERS:
         df = present(df)
     return df
-
-
-@cache
-def get_regex(seed_str):
-    """Compile, and cache regex for str queries."""
-    return fnmatch.translate(seed_str)  # translate to re
 
 
 def relative_offset(gmin, gmax, value):
@@ -437,8 +434,8 @@ def _filter_equality(query_dict, df, bool_index):
     # filter on non-collection queries
     for key, val in query_dict.items():
         if isinstance(val, str):
-            regex = get_regex(val)
-            new = df[key].str.match(regex).values
+            regex = glob_to_regex(val)
+            new = df[key].str.match(regex.pattern).values
             bool_index = np.logical_and(bool_index, new)
         else:
             new = (df[key] == val).values

--- a/dascore/utils/pd.py
+++ b/dascore/utils/pd.py
@@ -667,8 +667,9 @@ def filter_df(
 
         Any condition to check against columns of df. Can be a single value
         or a collection of values (to check isin on columns). Str arguments
-        can also use unix style matching. Additionally, queries of the form
-        {column_name}_min or {column_name}_max can be used, provided columns
+        can also be globs, read as SQLite's GLOB reads them. Additionally,
+        queries of the form {column_name}_min or {column_name}_max can be
+        used, provided columns
         with the same name don't already exist.
 
     Returns

--- a/docs/tutorial/spool.qmd
+++ b/docs/tutorial/spool.qmd
@@ -130,7 +130,7 @@ sources = diverse.select(acquisition_key={"DAS2.R2D1..RAW", "DAS3.R2D1..RAW"})
 tagged = diverse.select(tag="some*")
 ```
 
-Coordinate selections both discard patches outside the range and trim intersecting patches. Attribute selections only filter rows. Collections, Unix-style globs, and compiled regular expressions are accepted for string metadata.
+Coordinate selections both discard patches outside the range and trim intersecting patches. Attribute selections only filter rows. Collections, globs, and compiled regular expressions are accepted for string metadata. A glob means what SQLite's `GLOB` means, since that is what the index applies: `*` and `?` are wildcards, `[abc]` is a character class, and `[^abc]` negates one.
 
 ```{python}
 import re

--- a/tests/test_core/test_coords.py
+++ b/tests/test_core/test_coords.py
@@ -2627,6 +2627,19 @@ class TestStringCoords:
         assert isinstance(indexer, np.ndarray)
         assert np.array_equal(indexer, np.array([True, True, False, False]))
 
+    def test_wildcard_select_character_class(self):
+        """
+        A class picks the characters it holds, negated with a caret.
+
+        Selection read fnmatch here and SQLite everywhere else, so a class
+        was spelled one way on a coordinate and the other on a spool.
+        """
+        coord = get_coord(data=np.array(["ch_1", "ch_2", "ch_3"]))
+        out, _ = coord.select("ch_[12]")
+        assert np.array_equal(out.values, np.array(["ch_1", "ch_2"]))
+        out, _ = coord.select("ch_[^12]")
+        assert np.array_equal(out.values, np.array(["ch_3"]))
+
     def test_wildcard_select_no_match_returns_empty(self, string_coord):
         """Wildcard selectors with no matches should return an empty coord."""
         out, indexer = string_coord.select("z*")

--- a/tests/test_utils/test_pd.py
+++ b/tests/test_utils/test_pd.py
@@ -117,6 +117,16 @@ class TestFilterDfBasic:
         out = filter_df(example_df, last_name="Miller[")
         assert not set(example_df[out].last_name)
 
+    def test_wildcard_crosses_a_newline(self, example_df):
+        """A wildcard crosses a newline, as SQLite's does.
+
+        The flag saying so travels in the pattern text, since that is what
+        reaches pandas.
+        """
+        df = example_df.assign(last_name=["Mill\ner", *example_df["last_name"][1:]])
+        out = filter_df(df, last_name="Mill*")
+        assert "Mill\ner" in set(df[out].last_name)
+
     def test_str_sequence(self, example_df):
         """Test str sequences find values in sequence."""
         out = filter_df(example_df, last_name={"Miller", "Jacobson"})

--- a/tests/test_utils/test_pd.py
+++ b/tests/test_utils/test_pd.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import re
+
 import numpy as np
 import pandas as pd
 import pydantic
@@ -16,6 +18,7 @@ from dascore.utils.pd import (
     fill_defaults_from_pydantic,
     filter_df,
     get_interval_columns,
+    get_regex,
     list_ser_to_str,
     patch_to_dataframe,
     relative_ranges_to_absolute,
@@ -126,6 +129,12 @@ class TestFilterDfBasic:
         df = example_df.assign(last_name=["Mill\ner", *example_df["last_name"][1:]])
         out = filter_df(df, last_name="Mill*")
         assert "Mill\ner" in set(df[out].last_name)
+
+    def test_deprecated_translator_still_reads_fnmatch(self):
+        """The old translator warns and keeps its own dialect until removal."""
+        with pytest.warns(DeprecationWarning, match="get_regex"):
+            regex = get_regex("a[!b]*")
+        assert re.match(regex, "ac")
 
     def test_str_sequence(self, example_df):
         """Test str sequences find values in sequence."""

--- a/tests/test_utils/test_pd.py
+++ b/tests/test_utils/test_pd.py
@@ -96,11 +96,11 @@ class TestFilterDfBasic:
 
     def test_character_class_uses_sqlite_spelling(self, example_df):
         """
-        A class is negated with `[^...]`, as the index reads it.
+        Globs use SQLite's class spelling, the one the index applies.
 
-        `filter_df` reached for fnmatch, which spells the negation `[!...]`
-        and reads a leading `^` as a member, so the same pattern selected
-        opposite halves depending on whether a frame or the index answered.
+        `[^...]` negates, so `M[^a]*` keeps both Ms; `!` is a plain member,
+        so `M[!a]*` asks for a name starting `M!` or `Ma` and this frame
+        has none. fnmatch reads both the other way round.
         """
         out = filter_df(example_df, last_name="M[^a]*")
         assert {"Miller", "Milner"} == set(example_df[out].last_name)

--- a/tests/test_utils/test_pd.py
+++ b/tests/test_utils/test_pd.py
@@ -94,6 +94,19 @@ class TestFilterDfBasic:
         out = filter_df(example_df, first_name="J???")
         assert {"Jake"} == set(example_df[out].first_name)
 
+    def test_character_class_uses_sqlite_spelling(self, example_df):
+        """
+        A class is negated with `[^...]`, as the index reads it.
+
+        `filter_df` reached for fnmatch, which spells the negation `[!...]`
+        and reads a leading `^` as a member, so the same pattern selected
+        opposite halves depending on whether a frame or the index answered.
+        """
+        out = filter_df(example_df, last_name="M[^a]*")
+        assert {"Miller", "Milner"} == set(example_df[out].last_name)
+        out = filter_df(example_df, last_name="M[!a]*")
+        assert not set(example_df[out].last_name)
+
     def test_str_sequence(self, example_df):
         """Test str sequences find values in sequence."""
         out = filter_df(example_df, last_name={"Miller", "Jacobson"})

--- a/tests/test_utils/test_pd.py
+++ b/tests/test_utils/test_pd.py
@@ -107,6 +107,16 @@ class TestFilterDfBasic:
         out = filter_df(example_df, last_name="M[!a]*")
         assert not set(example_df[out].last_name)
 
+    def test_unreadable_glob_matches_nothing(self, example_df):
+        """
+        A glob SQLite would refuse selects nothing rather than raising.
+
+        The never-match pattern has to be one every regex engine reads:
+        pandas hands the text to an engine without lookahead support.
+        """
+        out = filter_df(example_df, last_name="Miller[")
+        assert not set(example_df[out].last_name)
+
     def test_str_sequence(self, example_df):
         """Test str sequences find values in sequence."""
         out = filter_df(example_df, last_name={"Miller", "Jacobson"})


### PR DESCRIPTION
## Description

DASCore read a glob two ways. `filter_df` and string coordinate selection translated with `fnmatch`, where a character class is negated `[!x]` and a leading `^` is an ordinary member. The index translated with a SQLite-shaped translator, where `[^x]` negates and `!` is ordinary. The same pattern therefore selected different rows depending on which side answered: `dc.read(dasdae_file, tag="a[!b]*")` took the fnmatch side while `dc.spool(...).select(tag=...)` took the index side, and they disagreed.

SQLite wins, because the index applies the pattern in SQL and cannot be talked out of its own dialect. The translator moves to `dascore.utils.misc`, which both callers can already import, and `filter_df` and `CoordString.select` now use it. Dropping the old cycle also lets `_spool_inventory` import it at module top rather than inside a function.

Points settled during review:

- `get_regex` is public on `master`, so it stays as a deprecated wrapper over the `fnmatch` it always used rather than vanishing under a caller.
- String coordinate selection treats `[` as a glob character now, as every other path does. A label containing a literal `[` was already unselectable through a spool; it now behaves the same on a coordinate.
- The never-match pattern for a glob SQLite would refuse is spelled as an empty character class, not a failing lookahead: pandas hands the pattern text to a regex engine without lookahead support, so the lookahead form raised where it should have matched nothing.
- The flag saying a wildcard crosses a newline travels inside the pattern text, since pandas refuses a compiled pattern carrying flags it did not set.
- Docstrings and the spool tutorial said "unix-style", which is the fnmatch reading; they now name SQLite's and show the class spelling.

Found during the 2026-09-02 redundancy review of `dev`.

## Changelog

- changed **breaking**: string metadata globs are read as SQLite reads them everywhere, so a character class is negated with `[^...]` rather than fnmatch's `[!...]`. This affects `dc.read` with attribute filters and string coordinate selection; spool selection already behaved this way.
- deprecated: `dascore.utils.pd.get_regex`. Use `dascore.utils.misc.glob_to_regex`.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
