### PR TITLE
Draw waterfall image cells around their samples

### DIFF
--- a/dascore/utils/plotting.py
+++ b/dascore/utils/plotting.py
@@ -197,15 +197,27 @@ def _cell_edge_limits(low, high, size):
     """
     Widen sample-centre limits to the outer edges of the cells.
 
-    An image extent gives the outer edges of the image, so handing it the
-    first and last coordinate values would draw every sample half a cell
-    from where it belongs and squeeze the image into one cell less than it
-    has. The mesh path already draws cells around their centres, and this
-    is what keeps the two renderers agreeing.
+    An image extent gives the image's outer edges, so the first and last
+    coordinate values would put every sample half a cell off and make the
+    image one cell narrower than the patch. Widening by half a cell lands
+    on the edges `get_gap_edges` gives the mesh, so both renderers cover
+    the same ground. A lone sample has no step to halve, so its limits
+    pass through.
     """
     if size < 2:
         return [low, high]
+    if np.asarray(low).dtype.kind in "mM":
+        # In nanoseconds, since a coarser unit divides as an integer and a
+        # second-resolution axis would round its half step down to nothing.
+        span = (high - low).astype("timedelta64[ns]")
+        half_cell = span / (2 * (size - 1))
+        return [low - half_cell, high + half_cell]
+    # In float, since a narrow integer dtype wraps on the subtraction and a
+    # coordinate spanning most of the float range overflows it.
+    low, high = float(low), float(high)
     half_cell = (high - low) / (2 * (size - 1))
+    if not np.isfinite(half_cell):
+        return [low, high]
     return [low - half_cell, high + half_cell]
 
 

--- a/dascore/utils/plotting.py
+++ b/dascore/utils/plotting.py
@@ -193,20 +193,6 @@ def _maybe_invert_yaxis(ax, patch, dim, ascending=True):
         ax.invert_yaxis()
 
 
-def _in_a_fixed_unit(low, high, dtype):
-    """
-    Restate a calendar-unit pair in seconds.
-
-    A year and a month have no fixed length, so arithmetic on them is
-    done in an average one; the dates they name are exact, and seconds
-    measure the distance between those.
-    """
-    if np.datetime_data(dtype)[0] not in {"Y", "M"}:
-        return low, high
-    fixed = "datetime64[s]" if dtype.kind == "M" else "timedelta64[s]"
-    return low.astype(fixed), high.astype(fixed)
-
-
 def _cell_edge_limits(low, high, size):
     """
     Widen sample-centre limits to the outer edges of the cells.
@@ -216,24 +202,12 @@ def _cell_edge_limits(low, high, size):
     image one cell narrower than the patch. Widening by half a cell lands
     on the edges `get_gap_edges` gives the mesh, so both renderers cover
     the same ground. A lone sample has no step to halve, so its limits
-    pass through.
+    pass through, as does a span with no room left for another half cell.
     """
     if size < 2:
         return [low, high]
-    dtype = np.asarray(low).dtype
-    if dtype.kind in "mM":
-        low, high = _in_a_fixed_unit(low, high, dtype)
-        span = high - low
-        half_cell = span / (2 * (size - 1))
-        # A coarse unit divides as an integer, so a second-resolution axis
-        # would round its half step down to nothing; refine only then,
-        # since a span which survives the division is too long to state in
-        # nanoseconds without overflowing them.
-        if half_cell.astype("int64") == 0:
-            half_cell = span.astype("timedelta64[ns]") / (2 * (size - 1))
-        return [low - half_cell, high + half_cell]
-    # In float, since a narrow integer dtype wraps on the subtraction and a
-    # coordinate spanning most of the float range overflows it.
+    # In float, which is what the axis is drawn in: an integer dtype wraps
+    # on the subtraction, and a time unit divides a half step away.
     low, high = float(low), float(high)
     half_cell = (high - low) / (2 * (size - 1))
     if not np.isfinite(half_cell):
@@ -281,10 +255,16 @@ def _get_extents(dims_r, coords):
         if np.isnan(array_min) or np.isnan(array_max):
             array_min = 0
             array_max = len(array) - 1
-        lims[dim] += _cell_edge_limits(array_min, array_max, len(array))
+        lims[dim] += [array_min, array_max]
     # find datetime coords and convert to numpy mtimes
     _convert_datetimes(coords, lims)
     _convert_timedeltas(coords, lims)
+    # Widened after the conversion, where a half step is a fraction of a
+    # day rather than a whole number of whatever unit the coord states.
+    for dim in dims_r:
+        array = coords.get_array(dim) if hasattr(coords, "get_array") else coords[dim]
+        low, high = lims[dim]
+        lims[dim] = _cell_edge_limits(low, high, len(array))
     out = [x for dim in dims_r for x in lims[dim]]
     return out
 

--- a/dascore/utils/plotting.py
+++ b/dascore/utils/plotting.py
@@ -193,6 +193,22 @@ def _maybe_invert_yaxis(ax, patch, dim, ascending=True):
         ax.invert_yaxis()
 
 
+def _cell_edge_limits(low, high, size):
+    """
+    Widen sample-centre limits to the outer edges of the cells.
+
+    An image extent gives the outer edges of the image, so handing it the
+    first and last coordinate values would draw every sample half a cell
+    from where it belongs and squeeze the image into one cell less than it
+    has. The mesh path already draws cells around their centres, and this
+    is what keeps the two renderers agreeing.
+    """
+    if size < 2:
+        return [low, high]
+    half_cell = (high - low) / (2 * (size - 1))
+    return [low - half_cell, high + half_cell]
+
+
 def _get_extents(dims_r, coords):
     """Get the extents used for each dimension."""
 
@@ -233,7 +249,7 @@ def _get_extents(dims_r, coords):
         if np.isnan(array_min) or np.isnan(array_max):
             array_min = 0
             array_max = len(array) - 1
-        lims[dim] += [array_min, array_max]
+        lims[dim] += _cell_edge_limits(array_min, array_max, len(array))
     # find datetime coords and convert to numpy mtimes
     _convert_datetimes(coords, lims)
     _convert_timedeltas(coords, lims)

--- a/dascore/utils/plotting.py
+++ b/dascore/utils/plotting.py
@@ -193,6 +193,20 @@ def _maybe_invert_yaxis(ax, patch, dim, ascending=True):
         ax.invert_yaxis()
 
 
+def _in_a_fixed_unit(low, high, dtype):
+    """
+    Restate a calendar-unit pair in seconds.
+
+    A year and a month have no fixed length, so arithmetic on them is
+    done in an average one; the dates they name are exact, and seconds
+    measure the distance between those.
+    """
+    if np.datetime_data(dtype)[0] not in {"Y", "M"}:
+        return low, high
+    fixed = "datetime64[s]" if dtype.kind == "M" else "timedelta64[s]"
+    return low.astype(fixed), high.astype(fixed)
+
+
 def _cell_edge_limits(low, high, size):
     """
     Widen sample-centre limits to the outer edges of the cells.
@@ -206,11 +220,17 @@ def _cell_edge_limits(low, high, size):
     """
     if size < 2:
         return [low, high]
-    if np.asarray(low).dtype.kind in "mM":
-        # In nanoseconds, since a coarser unit divides as an integer and a
-        # second-resolution axis would round its half step down to nothing.
-        span = (high - low).astype("timedelta64[ns]")
+    dtype = np.asarray(low).dtype
+    if dtype.kind in "mM":
+        low, high = _in_a_fixed_unit(low, high, dtype)
+        span = high - low
         half_cell = span / (2 * (size - 1))
+        # A coarse unit divides as an integer, so a second-resolution axis
+        # would round its half step down to nothing; refine only then,
+        # since a span which survives the division is too long to state in
+        # nanoseconds without overflowing them.
+        if half_cell.astype("int64") == 0:
+            half_cell = span.astype("timedelta64[ns]") / (2 * (size - 1))
         return [low - half_cell, high + half_cell]
     # In float, since a narrow integer dtype wraps on the subtraction and a
     # coordinate spanning most of the float range overflows it.

--- a/tests/test_viz/test_waterfall.py
+++ b/tests/test_viz/test_waterfall.py
@@ -16,6 +16,7 @@ import dascore as dc
 from dascore.examples import inventory_patch_pair
 from dascore.exceptions import ParameterError
 from dascore.units import get_quantity_str, percent
+from dascore.utils.gaps import get_gap_edges
 from dascore.utils.misc import suppress_warnings
 from dascore.utils.time import is_datetime64, to_timedelta64
 from dascore.viz._labels import BAR_GID, MAX_LABELS, MAX_RUNS, SEAM_GID
@@ -96,6 +97,42 @@ class TestWaterfall:
         ax = random_patch.viz.waterfall(cbar=False)
         assert isinstance(ax.images[0], AxesImage)
         assert not any(isinstance(x, QuadMesh) for x in ax.collections)
+
+    def test_image_cells_are_centred_on_their_samples(self):
+        """
+        The image spans the same ground the mesh would.
+
+        The extent gives the outer edges of the image, so passing the
+        first and last sample values put every cell half a step off and
+        made the image one cell narrower than the patch.
+        """
+        coords = {
+            "distance": 10.0 + 2.0 * np.arange(5),
+            "time": 100.0 + 0.5 * np.arange(8),
+        }
+        patch = dc.Patch(
+            data=np.zeros((5, 8)), coords=coords, dims=("distance", "time")
+        )
+        ax = patch.viz.waterfall(cbar=False)
+        x_low, x_high, y_low, y_high = ax.images[0].get_extent()
+        time_edges = get_gap_edges(coords["time"])[0]
+        distance_edges = get_gap_edges(coords["distance"])[0]
+        assert (x_low, x_high) == pytest.approx((time_edges[0], time_edges[-1]))
+        assert (y_low, y_high) == pytest.approx((distance_edges[0], distance_edges[-1]))
+        # One cell per sample, each a full step wide.
+        assert (x_high - x_low) / 8 == pytest.approx(0.5)
+        assert (y_high - y_low) / 5 == pytest.approx(2.0)
+
+    def test_image_cells_are_centred_on_their_samples_in_time(self, random_patch):
+        """A datetime axis is padded by half a sample too."""
+        ax = random_patch.viz.waterfall(cbar=False)
+        coord = random_patch.get_coord("time")
+        x_low = ax.images[0].get_extent()[0]
+        first = mdates.date2num(dc.to_datetime64(np.asarray(coord)[0]))
+        half_step = coord.step / np.timedelta64(1, "s") / 2
+        # Absolute tolerance: a day number carries a microsecond of noise,
+        # which a relative one on a two millisecond step cannot absorb.
+        assert (first - x_low) * 24 * 60 * 60 == pytest.approx(half_step, abs=1e-6)
 
     def test_irregular_timedelta_coordinates_use_mesh(self, timedelta_patch):
         """Irregular timedelta coordinates are converted to seconds for meshes."""
@@ -532,8 +569,6 @@ def _span_color(ax, axis, low, high):
 class TestLabelCoord:
     """Tests for marking the stretches a label coordinate covers."""
 
-    # Deliberately not size // 2, the one index where the extent's cell
-    # edge and the midpoint between two coordinate values coincide.
     split_fraction = 3
 
     @pytest.fixture(scope="class")
@@ -584,10 +619,10 @@ class TestLabelCoord:
     def _edge(self, patch, dim, index):
         """Where the image put the edge between two samples of a dimension."""
         coord = patch.get_coord(dim)
-        low, high = np.asarray(coord).min(), np.asarray(coord).max()
+        edge = get_gap_edges(np.asarray(coord))[0][index]
         if is_datetime64(coord.dtype):
-            low, high = (mdates.date2num(dc.to_datetime64(x)) for x in (low, high))
-        return float(low) + (float(high) - float(low)) * index / len(coord)
+            return float(mdates.date2num(dc.to_datetime64(edge)))
+        return float(edge)
 
     def test_each_label_gets_a_bar_on_both_spines(self, zone_patch):
         """Every stretch is marked on the two spines it runs between."""
@@ -673,15 +708,15 @@ class TestLabelCoord:
         assert _legend_labels(ax) == ["south", "north"]
 
     def test_bar_ends_on_the_image_cell_edge(self, zone_patch):
-        """The bar ends on the cell edge, not the coordinate midpoint."""
+        """The bar ends on the cell edge, which is the coordinate midpoint."""
         ax = zone_patch.viz.waterfall(label_coord="zone")
         coord = np.asarray(zone_patch.get_coord("distance"))
         split = len(coord) // self.split_fraction
         midpoint = (coord[split - 1] + coord[split]) / 2
         drawn = _spans(ax, "y")[0][1]
         assert drawn == pytest.approx(self._edge(zone_patch, "distance", split))
-        # The two genuinely differ here, so the test can tell them apart.
-        assert drawn != pytest.approx(midpoint)
+        # An image cell is centred on its sample, so its edge is the midpoint.
+        assert drawn == pytest.approx(midpoint)
 
     def test_label_on_time_runs_along_the_other_spines(self, phase_patch):
         """A coordinate over time is marked on the bottom and top."""

--- a/tests/test_viz/test_waterfall.py
+++ b/tests/test_viz/test_waterfall.py
@@ -18,7 +18,7 @@ from dascore.exceptions import ParameterError
 from dascore.units import get_quantity_str, percent
 from dascore.utils.gaps import get_gap_edges
 from dascore.utils.misc import suppress_warnings
-from dascore.utils.plotting import _cell_edge_limits
+from dascore.utils.plotting import _cell_edge_limits, _get_extents
 from dascore.utils.time import is_datetime64, to_timedelta64
 from dascore.viz._labels import BAR_GID, MAX_LABELS, MAX_RUNS, SEAM_GID
 from dascore.viz._lanes import string_colors
@@ -160,26 +160,31 @@ class TestWaterfall:
         assert _cell_edge_limits(low, high, size) == expected
 
     @pytest.mark.parametrize(
-        "low,high,size",
+        "step,size",
         [
+            # A half step of a second and a half, which no whole number of
+            # seconds is.
+            (np.timedelta64(3, "s"), 4),
             # Three centuries, which is more nanoseconds than there are.
-            (np.datetime64("1800-01-01", "s"), np.datetime64("2100-01-01", "s"), 1000),
-            # Two months, which are not two average months long.
-            (np.datetime64("2020-01", "M"), np.datetime64("2020-03", "M"), 3),
+            (np.timedelta64(110, "D"), 1000),
         ],
     )
-    def test_cell_edge_limits_on_awkward_time_units(self, low, high, size):
-        """A span too long for nanoseconds, and one in calendar units."""
-        one_second = np.timedelta64(1, "s")
-        # The dates are exact whatever unit names them, so the seconds
-        # between them are the oracle.
-        seconds = (high.astype("datetime64[s]") - low.astype("datetime64[s]")) / (
-            one_second
-        )
-        expected_half = seconds / (2 * (size - 1))
-        first, last = _cell_edge_limits(low, high, size)
-        assert (low - first) / one_second == pytest.approx(expected_half, abs=1)
-        assert last - high == low - first
+    def test_extent_half_step_on_awkward_time_spans(self, step, size):
+        """The padding is half a step whatever unit the step needs."""
+        start = np.datetime64("1800-01-01", "s")
+        time = start + np.arange(size) * step
+        low = _get_extents(("time",), {"time": time})[0]
+        first = mdates.date2num(dc.to_datetime64(time[0]))
+        half_step = step / np.timedelta64(2, "s")
+        assert (first - low) * 24 * 60 * 60 == pytest.approx(half_step, rel=1e-6)
+
+    def test_extent_half_step_in_calendar_units(self):
+        """A month is padded by half of the months it actually spans."""
+        time = np.datetime64("2020-01", "M") + np.arange(3)
+        low = _get_extents(("time",), {"time": time})[0]
+        first = mdates.date2num(dc.to_datetime64(time[0]))
+        # January to March is sixty days, so half a step is fifteen.
+        assert first - low == pytest.approx(15.0)
 
     def test_irregular_timedelta_coordinates_use_mesh(self, timedelta_patch):
         """Irregular timedelta coordinates are converted to seconds for meshes."""

--- a/tests/test_viz/test_waterfall.py
+++ b/tests/test_viz/test_waterfall.py
@@ -18,6 +18,7 @@ from dascore.exceptions import ParameterError
 from dascore.units import get_quantity_str, percent
 from dascore.utils.gaps import get_gap_edges
 from dascore.utils.misc import suppress_warnings
+from dascore.utils.plotting import _cell_edge_limits
 from dascore.utils.time import is_datetime64, to_timedelta64
 from dascore.viz._labels import BAR_GID, MAX_LABELS, MAX_RUNS, SEAM_GID
 from dascore.viz._lanes import string_colors
@@ -140,6 +141,23 @@ class TestWaterfall:
         x_low = ax.images[0].get_extent()[0]
         first = mdates.date2num(dc.to_datetime64(time[0]))
         assert (first - x_low) * 24 * 60 * 60 == pytest.approx(0.5, abs=1e-6)
+
+    @pytest.mark.parametrize(
+        "low,high,size,expected",
+        [
+            (10.0, 10.0, 1, [10.0, 10.0]),
+            (-1e308, 1e308, 3, [-1e308, 1e308]),
+            (10.0, 18.0, 5, [9.0, 19.0]),
+        ],
+    )
+    def test_cell_edge_limits(self, low, high, size, expected):
+        """
+        A span with no width to share passes through.
+
+        One sample has no step to halve, and a span filling the float
+        range has no room for another half cell.
+        """
+        assert _cell_edge_limits(low, high, size) == expected
 
     def test_irregular_timedelta_coordinates_use_mesh(self, timedelta_patch):
         """Irregular timedelta coordinates are converted to seconds for meshes."""

--- a/tests/test_viz/test_waterfall.py
+++ b/tests/test_viz/test_waterfall.py
@@ -159,6 +159,28 @@ class TestWaterfall:
         """
         assert _cell_edge_limits(low, high, size) == expected
 
+    @pytest.mark.parametrize(
+        "low,high,size",
+        [
+            # Three centuries, which is more nanoseconds than there are.
+            (np.datetime64("1800-01-01", "s"), np.datetime64("2100-01-01", "s"), 1000),
+            # Two months, which are not two average months long.
+            (np.datetime64("2020-01", "M"), np.datetime64("2020-03", "M"), 3),
+        ],
+    )
+    def test_cell_edge_limits_on_awkward_time_units(self, low, high, size):
+        """A span too long for nanoseconds, and one in calendar units."""
+        one_second = np.timedelta64(1, "s")
+        # The dates are exact whatever unit names them, so the seconds
+        # between them are the oracle.
+        seconds = (high.astype("datetime64[s]") - low.astype("datetime64[s]")) / (
+            one_second
+        )
+        expected_half = seconds / (2 * (size - 1))
+        first, last = _cell_edge_limits(low, high, size)
+        assert (low - first) / one_second == pytest.approx(expected_half, abs=1)
+        assert last - high == low - first
+
     def test_irregular_timedelta_coordinates_use_mesh(self, timedelta_patch):
         """Irregular timedelta coordinates are converted to seconds for meshes."""
         values = np.asarray(timedelta_patch.get_coord("time")).copy()

--- a/tests/test_viz/test_waterfall.py
+++ b/tests/test_viz/test_waterfall.py
@@ -99,13 +99,7 @@ class TestWaterfall:
         assert not any(isinstance(x, QuadMesh) for x in ax.collections)
 
     def test_image_cells_are_centred_on_their_samples(self):
-        """
-        The image spans the same ground the mesh would.
-
-        The extent gives the outer edges of the image, so passing the
-        first and last sample values put every cell half a step off and
-        made the image one cell narrower than the patch.
-        """
+        """The image extent matches the mesh's cell edges, one step per sample."""
         coords = {
             "distance": 10.0 + 2.0 * np.arange(5),
             "time": 100.0 + 0.5 * np.arange(8),
@@ -124,15 +118,28 @@ class TestWaterfall:
         assert (y_high - y_low) / 5 == pytest.approx(2.0)
 
     def test_image_cells_are_centred_on_their_samples_in_time(self, random_patch):
-        """A datetime axis is padded by half a sample too."""
+        """A datetime axis is padded by half a step too."""
         ax = random_patch.viz.waterfall(cbar=False)
         coord = random_patch.get_coord("time")
         x_low = ax.images[0].get_extent()[0]
         first = mdates.date2num(dc.to_datetime64(np.asarray(coord)[0]))
         half_step = coord.step / np.timedelta64(1, "s") / 2
         # Absolute tolerance: a day number carries a microsecond of noise,
-        # which a relative one on a two millisecond step cannot absorb.
+        # which a relative one on this 2 ms half step cannot absorb.
         assert (first - x_low) * 24 * 60 * 60 == pytest.approx(half_step, abs=1e-6)
+
+    def test_coarse_datetime_axis_is_padded(self):
+        """A second-resolution axis is padded by half a step, not by zero."""
+        time = np.datetime64("2020-01-01", "s") + np.arange(10) * np.timedelta64(1, "s")
+        patch = dc.Patch(
+            data=np.zeros((4, 10)),
+            coords={"distance": np.arange(4.0), "time": time},
+            dims=("distance", "time"),
+        )
+        ax = patch.viz.waterfall(cbar=False)
+        x_low = ax.images[0].get_extent()[0]
+        first = mdates.date2num(dc.to_datetime64(time[0]))
+        assert (first - x_low) * 24 * 60 * 60 == pytest.approx(0.5, abs=1e-6)
 
     def test_irregular_timedelta_coordinates_use_mesh(self, timedelta_patch):
         """Irregular timedelta coordinates are converted to seconds for meshes."""
@@ -708,14 +715,13 @@ class TestLabelCoord:
         assert _legend_labels(ax) == ["south", "north"]
 
     def test_bar_ends_on_the_image_cell_edge(self, zone_patch):
-        """The bar ends on the cell edge, which is the coordinate midpoint."""
+        """The bar ends on the cell edge, which is the sample midpoint."""
         ax = zone_patch.viz.waterfall(label_coord="zone")
         coord = np.asarray(zone_patch.get_coord("distance"))
         split = len(coord) // self.split_fraction
         midpoint = (coord[split - 1] + coord[split]) / 2
         drawn = _spans(ax, "y")[0][1]
         assert drawn == pytest.approx(self._edge(zone_patch, "distance", split))
-        # An image cell is centred on its sample, so its edge is the midpoint.
         assert drawn == pytest.approx(midpoint)
 
     def test_label_on_time_runs_along_the_other_spines(self, phase_patch):
@@ -724,9 +730,12 @@ class TestLabelCoord:
         size = phase_patch.coords.coord_size("time")
         split = size // self.split_fraction
         edges = [self._edge(phase_patch, "time", x) for x in (0, split, size)]
+        # Absolute, in day numbers: a relative tolerance on a number near
+        # 2e4 spans minutes, and the whole axis here is seconds long.
+        day = pytest.approx
         assert _spans(ax, "x") == [
-            (pytest.approx(edges[0]), pytest.approx(edges[1])),
-            (pytest.approx(edges[1]), pytest.approx(edges[2])),
+            (day(edges[0], abs=1e-9), day(edges[1], abs=1e-9)),
+            (day(edges[1], abs=1e-9), day(edges[2], abs=1e-9)),
         ]
         assert sorted(x[2] for x in _bars(ax, "x")) == [0.0, 0.0, 1.0, 1.0]
 


### PR DESCRIPTION
## Description

The waterfall's image renderer put its cells in the wrong place. An `imshow` extent gives the outer edges of the image, and `_get_extents` passed the first and last coordinate values, which are cell centres. The image was therefore one cell narrower than the patch, and each sample sat up to half a step from where it belongs: the ends were off by half a step, the middle was right, and every cell was `(N-1)/N` of a step wide.

The mesh renderer draws cells around their centres, so the same patch drawn the two ways did not line up. Each limit is now widened by half a cell, which lands on the edges `get_gap_edges` gives the mesh.

The label bars read their edges back from the extent, so they follow the image. The tests that pinned the old geometry did so through a helper of their own that re-derived the same wrong formula; that helper now reads the mesh's cell edges, which is an independent implementation rather than the code under test.

Points settled during review:

- A half step of a second-resolution datetime axis divided as an integer and came out zero, so the widening silently did nothing there. The span is taken in nanoseconds.
- A narrow integer coordinate wrapped on the subtraction and a coordinate spanning most of the float range overflowed it, so numeric limits are widened in float and a non-finite span passes through unwidened.
- An existing datetime label test compared day numbers with a relative tolerance, which spans minutes on an axis that is seconds long; it passed against the unfixed code and is now absolute.

Every image axis moves outward by half a step, so docs figures re-render very slightly wider. Nothing outside `tests/test_viz` asserts on the old numbers.

Found during the 2026-09-02 redundancy review of `dev`, and independently in the coordinate-origin survey for #706.

## Changelog

- fixed: waterfall plots drawn as an image now centre each cell on its sample, matching the mesh renderer; the image was half a step off at each end and one cell narrower than the patch.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected waterfall plot extents so image cells are centered on their samples.
  * Improved handling of datetime and timedelta axes, including half-step padding and calendar-based units.
  * Corrected label-bar endpoints and edge calculations for degenerate or irregular time ranges.

* **Tests**
  * Added coverage for cell-edge positioning, datetime axes, and challenging time-unit scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->