### PR TITLE
Read one scalar out of an HDF5 dataset, whatever its shape

### DIFF
--- a/dascore/io/optodas/utils.py
+++ b/dascore/io/optodas/utils.py
@@ -6,8 +6,7 @@ import dascore as dc
 import dascore.core
 from dascore.core.coords import get_coord
 from dascore.io.utils import build_patches, get_exact_coord
-from dascore.utils.hdf5 import unpack_scalar_h5_dataset
-from dascore.utils.misc import unbyte
+from dascore.utils.misc import _maybe_unpack, unbyte
 
 # --- Getting format/version
 
@@ -36,14 +35,14 @@ def _get_coord_manager(fi, snap=True):
     coords = {}
     for index, (dim, unit) in enumerate(zip(dims, units)):
         crange = header["dimensionRanges"][f"dimension{index}"]
-        step = unpack_scalar_h5_dataset(crange["unitScale"])
+        step = _maybe_unpack(crange["unitScale"])
 
         # Special case for time.
         if dim == "time":
             step = dc.to_timedelta64(step)
-            t1 = dc.to_datetime64(unpack_scalar_h5_dataset(header["time"]))
-            start = t1 + unpack_scalar_h5_dataset(crange["min"]) * step
-            stop = t1 + (unpack_scalar_h5_dataset(crange["max"]) + 1) * step
+            t1 = dc.to_datetime64(_maybe_unpack(header["time"]))
+            start = t1 + _maybe_unpack(crange["min"]) * step
+            stop = t1 + (_maybe_unpack(crange["max"]) + 1) * step
             coord = get_coord(min=start, max=stop, step=step, units=unit)
         else:  # and distance
             # The channels are ints so we multiply by step to get distance.
@@ -69,7 +68,7 @@ def _get_attr_dict(header):
     for head_name, attr_name in attr_map.items():
         value = header[head_name]
         if hasattr(value, "shape"):
-            value = unpack_scalar_h5_dataset(value)
+            value = _maybe_unpack(value)
         out[attr_name] = unbyte(value)
     return out
 

--- a/dascore/io/optodas/utils.py
+++ b/dascore/io/optodas/utils.py
@@ -74,7 +74,7 @@ def _get_attr_dict(header):
     for head_name, attr_name in attr_map.items():
         value = header[head_name]
         if hasattr(value, "shape"):
-            value = _maybe_unpack(value)
+            value = _scalar(value)
         out[attr_name] = unbyte(value)
     return out
 

--- a/dascore/io/optodas/utils.py
+++ b/dascore/io/optodas/utils.py
@@ -27,6 +27,12 @@ def _get_opto_das_version_str(hdf_fi) -> str:
     return version_str
 
 
+def _scalar(node):
+    """Read a header field which holds exactly one value."""
+    assert node.size == 1, f"expected one value, got {node.size}"
+    return _maybe_unpack(node)
+
+
 def _get_coord_manager(fi, snap=True):
     """Get the distance ranges and spacing."""
     header = fi["header"]
@@ -35,14 +41,14 @@ def _get_coord_manager(fi, snap=True):
     coords = {}
     for index, (dim, unit) in enumerate(zip(dims, units)):
         crange = header["dimensionRanges"][f"dimension{index}"]
-        step = _maybe_unpack(crange["unitScale"])
+        step = _scalar(crange["unitScale"])
 
         # Special case for time.
         if dim == "time":
             step = dc.to_timedelta64(step)
-            t1 = dc.to_datetime64(_maybe_unpack(header["time"]))
-            start = t1 + _maybe_unpack(crange["min"]) * step
-            stop = t1 + (_maybe_unpack(crange["max"]) + 1) * step
+            t1 = dc.to_datetime64(_scalar(header["time"]))
+            start = t1 + _scalar(crange["min"]) * step
+            stop = t1 + (_scalar(crange["max"]) + 1) * step
             coord = get_coord(min=start, max=stop, step=step, units=unit)
         else:  # and distance
             # The channels are ints so we multiply by step to get distance.

--- a/dascore/utils/hdf5.py
+++ b/dascore/utils/hdf5.py
@@ -452,18 +452,6 @@ class H5Writer(H5Reader):
         return super().get_handle(resource)
 
 
-def unpack_scalar_h5_dataset(dataset):
-    """
-    Unpack a scalar H5Py dataset.
-    """
-    assert dataset.size == 1
-    # This gets weird because datasets can be of shape () or (1,).
-    value = dataset[()]
-    if isinstance(value, np.ndarray):
-        value = value[0]
-    return value
-
-
 def h5_matches_structure(h5file: H5pyFile, structure: Sequence[str]):
     """
     Check if an H5 file matches a spec given by a structure.

--- a/dascore/utils/hdf5.py
+++ b/dascore/utils/hdf5.py
@@ -19,6 +19,7 @@ from h5py import File as H5pyFile
 from dascore.compat import UPath
 from dascore.config import get_config
 from dascore.constants import http_protocols, remote_hdf5_tuned_protocols
+from dascore.utils.deprecate import deprecate
 from dascore.utils.misc import (
     _maybe_make_parent_directory,
     _maybe_unpack,
@@ -450,6 +451,26 @@ class H5Writer(H5Reader):
         if isinstance(resource, UPath):
             return cls._RemoteH5Writer(resource, cls.mode)
         return super().get_handle(resource)
+
+
+@deprecate(
+    info=(
+        "unpack_scalar_h5_dataset is deprecated. Use "
+        "dascore.utils.misc._maybe_unpack, which reads a scalar out of a "
+        "dataset of either shape and leaves anything else alone."
+    ),
+    removed_in="0.2.0",
+)
+def unpack_scalar_h5_dataset(dataset):
+    """
+    Unpack a scalar H5Py dataset.
+    """
+    assert dataset.size == 1
+    # This gets weird because datasets can be of shape () or (1,).
+    value = dataset[()]
+    if isinstance(value, np.ndarray):
+        value = value[0]
+    return value
 
 
 def h5_matches_structure(h5file: H5pyFile, structure: Sequence[str]):

--- a/dascore/utils/misc.py
+++ b/dascore/utils/misc.py
@@ -723,12 +723,20 @@ def maybe_get_items(
 
 
 def _maybe_unpack(maybe_array):
-    """Unpack a single-element array-like object, else return input unchanged."""
-    size = getattr(maybe_array, "size", 0)
-    shape = getattr(maybe_array, "shape", ())
-    if size == 1 and shape:
-        maybe_array = maybe_array[0]
-    return maybe_array
+    """
+    Unpack a single-element array-like object, else return input unchanged.
+
+    A zero-dimensional container counts as single-element: an HDF5 scalar
+    dataset is stored that way, and returning the dataset itself leaves the
+    caller stringifying a handle. A numpy scalar is already unpacked and
+    cannot be indexed, and a string scalar refuses `[()]` besides.
+    """
+    if getattr(maybe_array, "size", 0) != 1 or isinstance(maybe_array, np.generic):
+        return maybe_array
+    if not hasattr(maybe_array, "shape"):
+        return maybe_array
+    value = maybe_array[()]
+    return value.flat[0] if isinstance(value, np.ndarray) else value
 
 
 @cache

--- a/dascore/utils/misc.py
+++ b/dascore/utils/misc.py
@@ -735,10 +735,16 @@ def _maybe_unpack(maybe_array):
         return maybe_array
     if not hasattr(maybe_array, "shape"):
         return maybe_array
-    # Through numpy, since the empty-tuple index a dataset wants is a label
-    # lookup on a pandas object and the [0] a pandas object wants is not
-    # what a zero-dimensional dataset understands.
-    return np.asarray(maybe_array).flat[0]
+    # A pandas object reads the empty-tuple index as a label rather than as
+    # "the whole of me", so it is asked by position.
+    if isinstance(maybe_array, pd.Series | pd.Index):
+        return maybe_array.to_numpy().flat[0]
+    value = maybe_array[()]
+    # An entry may itself hold an array, whole, and that array is the value;
+    # only a wrapper around one value is worth stripping.
+    if isinstance(value, np.ndarray) and value.size == 1:
+        value = value.flat[0]
+    return value
 
 
 @cache

--- a/dascore/utils/misc.py
+++ b/dascore/utils/misc.py
@@ -735,8 +735,10 @@ def _maybe_unpack(maybe_array):
         return maybe_array
     if not hasattr(maybe_array, "shape"):
         return maybe_array
-    value = maybe_array[()]
-    return value.flat[0] if isinstance(value, np.ndarray) else value
+    # Through numpy, since the empty-tuple index a dataset wants is a label
+    # lookup on a pandas object and the [0] a pandas object wants is not
+    # what a zero-dimensional dataset understands.
+    return np.asarray(maybe_array).flat[0]
 
 
 @cache

--- a/tests/test_utils/test_hdf_utils.py
+++ b/tests/test_utils/test_hdf_utils.py
@@ -16,6 +16,7 @@ from dascore.utils.hdf5 import (
     extract_h5_attrs,
     get_h5py_file,
     h5_matches_structure,
+    unpack_scalar_h5_dataset,
 )
 
 
@@ -132,3 +133,19 @@ class TestExtractH5Attrs:
         }
         with pytest.raises(KeyError):
             extract_h5_attrs(h5_example_file, map_name)
+
+
+class TestUnpackScalarH5Dataset:
+    """The old scalar reader warns and keeps working until it is removed."""
+
+    def test_warns_and_reads(self, tmp_path):
+        """It still reads a scalar, and says where to go instead."""
+        path = tmp_path / "scalar.h5"
+        with h5py.File(path, "w") as h5:
+            h5.create_dataset("value", data=5.0)
+            h5.create_dataset("wrapped", data=[5.0])
+        with h5py.File(path, "r") as h5:
+            with pytest.warns(DeprecationWarning, match="unpack_scalar_h5_dataset"):
+                assert unpack_scalar_h5_dataset(h5["value"]) == 5.0
+            with pytest.warns(DeprecationWarning, match="unpack_scalar_h5_dataset"):
+                assert unpack_scalar_h5_dataset(h5["wrapped"]) == 5.0

--- a/tests/test_utils/test_misc.py
+++ b/tests/test_utils/test_misc.py
@@ -23,6 +23,7 @@ from dascore.utils.misc import (
     _get_install_name,
     _iter_filesystem,
     _locked,
+    _maybe_unpack,
     _spool_map,
     all_diffs_close_enough,
     cached_method,
@@ -1270,3 +1271,41 @@ class TestRaiseOnExtraKwargs:
         """The message names the offending arguments and what is accepted."""
         with pytest.raises(ParameterError, match=r"\['b', 'z'\].*only a and b"):
             raise_on_extra_kwargs({"z": 1, "b": 2}, "a and b")
+
+
+class TestMaybeUnpack:
+    """Tests for reading a single value out of whatever holds it."""
+
+    @pytest.fixture(scope="class")
+    def h5_path(self, tmp_path_factory):
+        """A file holding scalar datasets of each awkward shape."""
+        h5py = pytest.importorskip("h5py")
+        path = tmp_path_factory.mktemp("maybe_unpack") / "scalars.h5"
+        with h5py.File(path, "w") as h5:
+            h5.create_dataset("zero_d", data=5.0)
+            h5.create_dataset("one_d", data=[5.0])
+            h5.create_dataset("text", data="hello")
+            h5.create_dataset("many", data=[1.0, 2.0, 3.0])
+        return path
+
+    def test_scalar_datasets_unpack(self, h5_path):
+        """A dataset of shape () holds a value, not an array."""
+        h5py = pytest.importorskip("h5py")
+        with h5py.File(h5_path, "r") as h5:
+            assert _maybe_unpack(h5["zero_d"]) == 5.0
+            assert _maybe_unpack(h5["one_d"]) == 5.0
+            assert _maybe_unpack(h5["text"]) == b"hello"
+            assert _maybe_unpack(h5["many"]) is not None
+
+    def test_zero_dimensional_array_unpacks(self):
+        """A 0-d array is a value with an array around it."""
+        out = _maybe_unpack(np.array(5.0))
+        assert not isinstance(out, np.ndarray)
+        assert out == 5.0
+
+    @pytest.mark.parametrize(
+        "value", [np.float64(1.0), np.str_("a"), np.bytes_(b"a"), 1.0, "a"]
+    )
+    def test_scalars_pass_through(self, value):
+        """An unpacked value is returned as it is; a string cannot be indexed."""
+        assert _maybe_unpack(value) is value

--- a/tests/test_utils/test_misc.py
+++ b/tests/test_utils/test_misc.py
@@ -10,6 +10,7 @@ import warnings
 from io import BytesIO
 from pathlib import Path
 from threading import Lock
+from types import SimpleNamespace
 
 import numpy as np
 import pandas as pd
@@ -1295,7 +1296,7 @@ class TestMaybeUnpack:
             assert _maybe_unpack(h5["zero_d"]) == 5.0
             assert _maybe_unpack(h5["one_d"]) == 5.0
             assert _maybe_unpack(h5["text"]) == b"hello"
-            assert _maybe_unpack(h5["many"]) is not None
+            assert _maybe_unpack(h5["many"]).shape == (3,)
 
     def test_zero_dimensional_array_unpacks(self):
         """A 0-d array is a value with an array around it."""
@@ -1303,9 +1304,7 @@ class TestMaybeUnpack:
         assert not isinstance(out, np.ndarray)
         assert out == 5.0
 
-    @pytest.mark.parametrize(
-        "value", [np.float64(1.0), np.str_("a"), np.bytes_(b"a"), 1.0, "a"]
-    )
+    @pytest.mark.parametrize("value", [np.float64(1.0), np.str_("a"), np.bytes_(b"a")])
     def test_scalars_pass_through(self, value):
         """An unpacked value is returned as it is; a string cannot be indexed."""
         assert _maybe_unpack(value) is value
@@ -1314,3 +1313,14 @@ class TestMaybeUnpack:
     def test_pandas_single_element(self, value):
         """A one-element pandas object holds a value like any other."""
         assert _maybe_unpack(value) == 42
+
+    def test_sized_object_without_a_shape(self):
+        """Something claiming one element but no shape is left alone."""
+        value = SimpleNamespace(size=1)
+        assert _maybe_unpack(value) is value
+
+    def test_entry_holding_an_array_keeps_it_whole(self):
+        """A single entry which is itself an array is that array."""
+        value = np.empty((), dtype=object)
+        value[()] = np.array([1.0, 2.0])
+        assert np.array_equal(_maybe_unpack(value), np.array([1.0, 2.0]))

--- a/tests/test_utils/test_misc.py
+++ b/tests/test_utils/test_misc.py
@@ -1309,3 +1309,8 @@ class TestMaybeUnpack:
     def test_scalars_pass_through(self, value):
         """An unpacked value is returned as it is; a string cannot be indexed."""
         assert _maybe_unpack(value) is value
+
+    @pytest.mark.parametrize("value", [pd.Series([42]), pd.Index([42])])
+    def test_pandas_single_element(self, value):
+        """A one-element pandas object holds a value like any other."""
+        assert _maybe_unpack(value) == 42


### PR DESCRIPTION
## Description

DASCore had two functions for reading one value out of an HDF5 scalar, and they disagreed. `_maybe_unpack` asked for a non-empty shape, so a dataset of shape `()` fell through and the caller got the dataset handle rather than its value. `unpack_scalar_h5_dataset` handled that case. OptoDAS stores every scalar with shape `()` and used the second; AP Sensing uses the first and escapes the defect only because its scalars happen to be stored with shape `(1,)`.

`_maybe_unpack` now handles the zero-dimensional case and OptoDAS uses it. Unpacking goes through numpy, since the empty-tuple index a dataset wants is a label lookup on a pandas object. A numpy scalar is returned untouched: it is already unpacked, and a string scalar refuses to be indexed at all.

`unpack_scalar_h5_dataset` is a public name on `master`, so it stays as a deprecation rather than disappearing under a caller. Its size assertion moved to the OptoDAS call sites that want it, where a header field must hold exactly one value.

No reader's output changes: every scalar reaching the helper today is stored with shape `(1,)` or is already a numpy scalar.

Found during the 2026-09-02 redundancy review of `dev`.

## Changelog

- fixed: reading an HDF5 scalar stored with no dimensions now yields the value rather than the dataset.
- deprecated: `dascore.utils.hdf5.unpack_scalar_h5_dataset`. Use `dascore.utils.misc._maybe_unpack`.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
