### PR TITLE
Select before reading in the Febus MTX and NetCDF readers

### DIFF
--- a/dascore/io/febus/g1utils.py
+++ b/dascore/io/febus/g1utils.py
@@ -287,14 +287,14 @@ def _get_mtx_coords(resource, dims=_MTX_DIMS, snap=True):
 
 def _get_mtx_patch(resource, attr_cls, attrs=None, select_kwargs=None):
     """Read a Febus MTX HDF5 file into a patch."""
-    coords = _get_mtx_coords(resource)
-    attrs = _get_mtx_attrs(resource) if attrs is None else attrs
-    select_kwargs = {} if select_kwargs is None else select_kwargs
-    data = np.asarray(resource["mtx"])
-    coords, data = coords.select(array=data, **select_kwargs)
-    if 0 in coords.shape:
-        return None
-    return dc.Patch(data=data, coords=coords, attrs=attr_cls(**attrs))
+    return _get_g1_h5_patch(
+        resource,
+        attr_cls=attr_cls,
+        data_name="mtx",
+        attrs=_get_mtx_attrs(resource) if attrs is None else attrs,
+        coords=_get_mtx_coords(resource),
+        select_kwargs=select_kwargs,
+    )
 
 
 def _bsl_version(resource) -> str | bool:

--- a/dascore/io/netcdf/core.py
+++ b/dascore/io/netcdf/core.py
@@ -18,7 +18,7 @@ from dascore.io.utils import (
     windows_to_slices,
 )
 from dascore.utils.hdf5 import H5Reader, get_h5py_file
-from dascore.utils.io import patch_to_xarray, xarray_to_patch
+from dascore.utils.io import patch_to_xarray
 from dascore.utils.misc import optional_import, raise_on_extra_kwargs
 
 from .utils import (
@@ -127,9 +127,9 @@ class NetCDFCFV18(FiberIO):
         """Read a NetCDF-4 file into a Spool, streaming remote resources."""
         with _open_xarray_dataset(resource) as dataset:
             data_var_name = get_xarray_data_var_name(dataset)
-            data_array = dataset[data_var_name].load()
-            patch = self._patch_from_dataset(dataset, data_var_name, data_array)
-        patch = self._select_from_kwargs(patch, kwargs)
+            # Unloaded, so a selection reads only the samples it keeps.
+            data_array = dataset[data_var_name]
+            patch = self._patch_from_dataset(dataset, data_var_name, data_array, kwargs)
         if not patch.data.size:
             return dc.spool([])
         return dc.spool([patch])
@@ -266,30 +266,42 @@ class NetCDFCFV18(FiberIO):
             return dc.get_coord_manager(coords=coords, dims=dims)
         return get_coord_manager_for_coordless_data_var(dataset, dims=dims, shape=shape)
 
-    def _patch_from_dataset(self, dataset, data_var_name, data_array):
-        """Build one patch from an xarray dataset and selected data variable."""
+    def _patch_from_dataset(self, dataset, data_var_name, data_array, kwargs=None):
+        """
+        Build one patch from an xarray dataset and its data variable.
+
+        The coordinates are read whole and the selection is applied to
+        them, so the payload is sliced before it is loaded and a file
+        which states no coordinates still numbers its samples from where
+        they sit in the file rather than from the start of the slice.
+        """
         source_patch_key = self._get_source_patch_key(data_var_name)
         attrs = dict(data_array.attrs) | {"_source_patch_key": source_patch_key}
-        if data_array.coords:
-            return xarray_to_patch(data_array).update(attrs=attrs)
         coords = self._coord_manager_from_data_array(
             dataset,
             data_array,
-            coords={},
+            coords={
+                name: (coord.dims, coord.values)
+                for name, coord in data_array.coords.items()
+            },
             dims=data_array.dims,
             shape=data_array.shape,
         )
+        coords, data = self._select_coords(coords, data_array, kwargs or {})
         return dc.Patch(
-            data=data_array.data,
+            data=np.asarray(data),
             coords=coords,
             dims=data_array.dims,
             attrs=attrs,
         )
 
-    def _select_from_kwargs(self, patch: dc.Patch, kwargs: dict) -> dc.Patch:
-        """Apply coordinate selection kwargs to one loaded patch."""
-        coord_kwargs = {k: v for k, v in kwargs.items() if k in patch.coords.coord_map}
-        return patch.select(**coord_kwargs) if coord_kwargs else patch
+    @staticmethod
+    def _select_coords(coords, data_array, kwargs: dict):
+        """Trim the coordinates and the payload together, before loading."""
+        coord_kwargs = {k: v for k, v in kwargs.items() if k in coords.coord_map}
+        if not coord_kwargs:
+            return coords, data_array
+        return coords.select(array=data_array, **coord_kwargs)
 
     def _validate_and_extract_patch(self, spool: dc.Patch | dc.Spool) -> dc.Patch:
         """Validate write input and return the single supported patch."""

--- a/tests/test_io/test_febus/test_febusg1.py
+++ b/tests/test_io/test_febus/test_febusg1.py
@@ -14,8 +14,8 @@ import numpy as np
 import pytest
 
 import dascore as dc
-from dascore.io.febus.core import FebusG1CSV1, FebusMTXH5V1
-from dascore.io.febus.g1utils import _is_g1_file
+from dascore.io.febus.core import FebusG1CSV1, FebusMTXAttrs, FebusMTXH5V1
+from dascore.io.febus.g1utils import _get_mtx_patch, _is_g1_file
 from dascore.utils.downloader import fetch
 
 g1_files = (
@@ -177,6 +177,50 @@ class TestG1MTXH5:
         assert len(time_selected.get_coord("temperature")) == time_selected.shape[0]
         assert fiber.read(mtx_h5_path, distance=(60, 70))[0].shape[1] == 11
         assert len(fiber.read(mtx_h5_path, frequency=(99999, ...))) == 0
+
+    def test_selection_does_not_read_the_whole_array(self, mtx_h5_path):
+        """A trimmed read touches only the samples it keeps."""
+        read = []
+
+        class _CountingDataset:
+            """Stand in for the stored array and record what is asked of it."""
+
+            def __init__(self, dataset):
+                self._dataset = dataset
+
+            def __getattr__(self, name):
+                return getattr(self._dataset, name)
+
+            def __getitem__(self, item):
+                out = self._dataset[item]
+                read.append(np.size(out))
+                return out
+
+            def __array__(self, *args, **kwargs):
+                read.append(self._dataset.size)
+                return np.asarray(self._dataset, *args, **kwargs)
+
+        class _CountingFile:
+            """An open file which hands out the counting array."""
+
+            def __init__(self, h5):
+                self._h5 = h5
+
+            def __getattr__(self, name):
+                return getattr(self._h5, name)
+
+            def __getitem__(self, item):
+                out = self._h5[item]
+                return _CountingDataset(out) if item == "mtx" else out
+
+        with h5py.File(mtx_h5_path, "r") as h5:
+            stored_size = h5["mtx"].size
+            patch = _get_mtx_patch(
+                _CountingFile(h5),
+                attr_cls=FebusMTXAttrs,
+                select_kwargs={"distance": (60, 70)},
+            )
+        assert max(read) == patch.data.size < stored_size
 
     def test_mtx_must_be_three_dimensional(self, tmp_path):
         """Non-3D MTX datasets should fail with explicit validation."""

--- a/tests/test_io/test_netcdf/test_netcdf.py
+++ b/tests/test_io/test_netcdf/test_netcdf.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib
 import importlib.util
+import tracemalloc
 from typing import ClassVar
 
 import h5py
@@ -810,3 +811,73 @@ class TestWriteRequiresHDF5Backend:
         with pytest.raises(MissingOptionalDependencyError, match="h5netcdf"):
             dc.write(random_patch, tmp_path / "refused.nc", "netcdf_cf")
         assert not (tmp_path / "refused.nc").exists()
+
+
+class TestSelectiveRead:
+    """A selection is applied before the payload is loaded."""
+
+    @pytest.fixture(scope="class")
+    def chunked_path(self, tmp_path_factory):
+        """A file large enough that loading all of it is measurable."""
+        xr = pytest.importorskip("xarray")
+        engine = _require_xarray_netcdf_engine()
+        path = tmp_path_factory.mktemp("netcdf_selective") / "chunked.nc"
+        dataset = xr.Dataset(
+            {"v": (("time", "distance"), np.zeros((5000, 400), "float32"))},
+            coords={"time": np.arange(5000.0), "distance": np.arange(400.0)},
+            attrs={"Conventions": "CF-1.8"},
+        )
+        # Chunked, as a file worth selecting from is: a contiguous layout
+        # has to touch every page of the fast axis whatever it is asked for.
+        dataset.to_netcdf(
+            path, engine=engine, encoding={"v": {"chunksizes": (100, 250)}}
+        )
+        return path
+
+    @pytest.fixture(scope="class")
+    def coordless_path(self, tmp_path_factory):
+        """A file which states no coordinates, as XDAS writes them."""
+        xr = pytest.importorskip("xarray")
+        engine = _require_xarray_netcdf_engine()
+        path = tmp_path_factory.mktemp("netcdf_coordless") / "coordless.nc"
+        data = np.arange(100 * 20, dtype="float32").reshape(100, 20)
+        dataset = xr.Dataset(
+            {"v": (("time", "distance"), data)}, attrs={"Conventions": "CF-1.8"}
+        )
+        dataset.to_netcdf(path, engine=engine)
+        return path
+
+    def _read_peak(self, path, **kwargs):
+        """Return the high-water mark of one read, in bytes."""
+        tracemalloc.start()
+        try:
+            dc.read(path, **kwargs)
+            return tracemalloc.get_traced_memory()[1]
+        finally:
+            tracemalloc.stop()
+
+    def test_selection_loads_only_what_it_keeps(self, chunked_path):
+        """Reading twenty of five thousand samples costs twenty samples."""
+        whole = self._read_peak(chunked_path)
+        part = self._read_peak(chunked_path, time=(0, 20))
+        assert part < whole / 4
+
+    def test_coordless_selection_keeps_its_place(self, coordless_path):
+        """
+        A sample keeps the number it has in the file.
+
+        With no coordinates stated, they are numbered from the file's own
+        shape, so trimming before they are built would restart them at
+        the beginning of the slice.
+        """
+        whole = dc.read(coordless_path)[0]
+        part = dc.read(coordless_path, time=(10, 20))[0]
+        assert part.get_coord("time").values[0] == 10
+        assert np.array_equal(part.data, whole.select(time=(10, 20)).data)
+
+    def test_selection_matches_selecting_afterwards(self, coordless_path):
+        """Selecting during the read gives what selecting after it gives."""
+        whole = dc.read(coordless_path)[0]
+        for kwargs in ({"time": (10, 20)}, {"distance": (2, 5)}):
+            part = dc.read(coordless_path, **kwargs)[0]
+            assert part.equals(whole.select(**kwargs))


### PR DESCRIPTION
## Description

Two readers loaded the whole stored array and then trimmed it, so asking for a slice cost the whole file.

The Febus MTX reader materialised `mtx` before selecting. Its sibling `_get_bsl_patch` already delegates to a helper that hands the stored node to the selection and reads only what survives; `_get_mtx_patch` now does the same. On the example file, reading two of sixty-eight time samples goes from reading 3.4 MB to 348 KB.

The NetCDF reader called `.load()` on the payload variable before applying the caller's selection. It now applies the selection to the unloaded variable. Reading twenty of five thousand samples from a chunked file drops from about 12 MB of peak allocation to 0.3 MB.

One trap the NetCDF change had to avoid: for a file that states no coordinates, they are numbered from the file's own shape, so trimming the variable before building them would restart the numbering at the start of the slice. The coordinates are therefore built from the whole file, as before, and the selection is applied to them and to the variable together. A test covers that, since the naive form passes every other test.

Both claims were reproduced and measured by an independent reviewer before the fix, and the same reviewer confirmed the Windows path check flagged alongside them is not reachable, so it is left alone.

## Changelog

- fixed: reading part of a Febus MTX or NetCDF file no longer loads the whole array first.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
