### PR TITLE
Remove five pieces of code nothing calls

### DIFF
--- a/dascore/io/index/query.py
+++ b/dascore/io/index/query.py
@@ -526,61 +526,57 @@ def build_coord_clause(
         "dur": ("min_ns", "max_ns"),
         "num": ("min_num", "max_num"),
         "str": ("min_str", "max_str"),
-        None: (None, None),
     }[kind]
     conditions = ["pc.coord_name = ?"]
     params: list = [name]
-    if kind is not None:
-        if kind in ("time", "dur"):
-            # absolute queries match absolute coords, durations relative.
-            conditions.append("cd.is_relative = ?")
-            params.append(kind == "dur")
-            kind_match = "time"
-        else:
-            kind_match = kind
-        conditions.append("cd.value_kind = ?")
-        params.append(kind_match)
-        # lo bounds the coord max (overlap), hi bounds the coord min.
-        # typed_values holds the coerced non-open bounds in (lo, hi) order,
-        # so each side pairs with its TypedValue (which knows the bound's
-        # own units) here.
-        sides = []
-        for bound, bound_col, op in ((lo, max_col, ">="), (hi, min_col, "<=")):
-            if bound is None:
-                continue
-            sides.append((bound, typed_values[len(sides)], bound_col, op))
-        if compatible_units is None:
-            # A bare range means each definition's native units: one plain
-            # predicate against the envelopes, which are stored in the
-            # coordinate's original units.
-            for bound, _typed, bound_col, op in sides:
-                conditions.append(f"cd.{bound_col} {op} ?")
-                params.append(bound)
-        elif not compatible_units:
-            conditions.append("cd.units IS NULL")
-        else:
-            # A unit-bearing range converts itself once per distinct
-            # compatible stored unit into an OR branch; a bare bound in a
-            # mixed range stays native per branch, exactly how the
-            # residual's per-bound _CanonicalRange reads it at load.
-            # NULL-unit defs stay unconstrained candidates: unitless
-            # values cannot be proven dimensionally incompatible.
-            branches = ["cd.units IS NULL"]
-            for unit in sorted(compatible_units):
-                sub_clauses = ["cd.units = ?"]
-                sub_params: list = [unit]
-                for bound, typed, bound_col, op in sides:
-                    if typed.units is None:
-                        val = bound
-                    else:
-                        val = convert_units(
-                            bound, to_units=unit, from_units=typed.units
-                        )
-                    sub_clauses.append(f"cd.{bound_col} {op} ?")
-                    sub_params.append(val)
-                branches.append("(" + " AND ".join(sub_clauses) + ")")
-                params.extend(sub_params)
-            conditions.append("(" + " OR ".join(branches) + ")")
+    if kind in ("time", "dur"):
+        # absolute queries match absolute coords, durations relative.
+        conditions.append("cd.is_relative = ?")
+        params.append(kind == "dur")
+        kind_match = "time"
+    else:
+        kind_match = kind
+    conditions.append("cd.value_kind = ?")
+    params.append(kind_match)
+    # lo bounds the coord max (overlap), hi bounds the coord min.
+    # typed_values holds the coerced non-open bounds in (lo, hi) order,
+    # so each side pairs with its TypedValue (which knows the bound's
+    # own units) here.
+    sides = []
+    for bound, bound_col, op in ((lo, max_col, ">="), (hi, min_col, "<=")):
+        if bound is None:
+            continue
+        sides.append((bound, typed_values[len(sides)], bound_col, op))
+    if compatible_units is None:
+        # A bare range means each definition's native units: one plain
+        # predicate against the envelopes, which are stored in the
+        # coordinate's original units.
+        for bound, _typed, bound_col, op in sides:
+            conditions.append(f"cd.{bound_col} {op} ?")
+            params.append(bound)
+    elif not compatible_units:
+        conditions.append("cd.units IS NULL")
+    else:
+        # A unit-bearing range converts itself once per distinct
+        # compatible stored unit into an OR branch; a bare bound in a
+        # mixed range stays native per branch, exactly how the
+        # residual's per-bound _CanonicalRange reads it at load.
+        # NULL-unit defs stay unconstrained candidates: unitless
+        # values cannot be proven dimensionally incompatible.
+        branches = ["cd.units IS NULL"]
+        for unit in sorted(compatible_units):
+            sub_clauses = ["cd.units = ?"]
+            sub_params: list = [unit]
+            for bound, typed, bound_col, op in sides:
+                if typed.units is None:
+                    val = bound
+                else:
+                    val = convert_units(bound, to_units=unit, from_units=typed.units)
+                sub_clauses.append(f"cd.{bound_col} {op} ?")
+                sub_params.append(val)
+            branches.append("(" + " AND ".join(sub_clauses) + ")")
+            params.extend(sub_params)
+        conditions.append("(" + " OR ".join(branches) + ")")
     # A semi-join the engine can evaluate once (idx_pcoords_name) beats a
     # correlated EXISTS probed per patch row (~2.5x on a 200k-source index).
     where.add(

--- a/dascore/utils/hdf5.py
+++ b/dascore/utils/hdf5.py
@@ -29,7 +29,6 @@ from dascore.utils.remote_io import (
     _FallbackFileObj,
     _get_cached_local_file,
     ensure_local_file,
-    get_local_handle,
     is_no_range_http_error,
     pause_gc,
     resume_gc,
@@ -355,15 +354,6 @@ class H5Reader(_H5CasterBase):
         )
 
 
-class LocalH5Reader(H5Reader):
-    """An h5py reader which first materializes remote resources locally."""
-
-    @classmethod
-    def get_handle(cls, resource):
-        """Get a local-file-backed h5py handle."""
-        return get_local_handle(resource, super().get_handle)
-
-
 class H5Writer(H5Reader):
     """A thin wrapper around h5py for writing files."""
 
@@ -426,10 +416,6 @@ class H5Writer(H5Reader):
             self._handle.close()
             self._temp_path.unlink(missing_ok=True)
             self._closed = True
-
-        def _abort(self):
-            """Backward-compatible alias for abort()."""
-            self.abort()
 
         def __enter__(self):
             return self

--- a/dascore/utils/pd.py
+++ b/dascore/utils/pd.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import fnmatch
 from collections import defaultdict
-from collections.abc import Collection, Generator, Iterator, Mapping, Sequence
+from collections.abc import Collection, Generator, Iterator, Mapping
 from functools import cache
 from typing import TypeVar, cast
 
@@ -765,24 +765,6 @@ def list_ser_to_str(ser: pd.Series) -> pd.Series:
         for x in ser.values
     ]
     return pd.Series(values, index=ser.index, dtype=object)
-
-
-def _model_list_to_df(mod_list: Sequence[dc.PatchAttrs], exclude=None) -> pd.DataFrame:
-    """
-    Get a dataframe from a sequence of pydantic models.
-
-    Optionally, exclude certain columns
-    """
-    records = []
-    for item in mod_list:
-        if hasattr(item, "flat_dump"):
-            records.append(item.flat_dump(exclude=exclude))
-        else:
-            records.append(item.summary.flat_dump(exclude=exclude))
-    df = pd.DataFrame(records)
-    if "dims" in df.columns:
-        df["dims"] = list_ser_to_str(df["dims"])
-    return df
 
 
 def _column_or_value(df, col, value):

--- a/dascore/utils/time.py
+++ b/dascore/utils/time.py
@@ -33,38 +33,6 @@ def _float_array_to_ns(array):
     return np.rint(array * 1_000_000_000).astype(np.int64)
 
 
-def _saturate_time(value, amount, sign: int = 1):
-    """Add/subtract a timedelta to a time-like value, saturating at int64 bounds.
-
-    Numpy silently wraps datetime64/timedelta64 overflow rather than raising,
-    so the arithmetic is performed with Python ints (via object arrays) and
-    clipped back into the valid int64 range.
-    """
-    is_dt = is_datetime64(value)
-    is_td = is_timedelta64(value)
-    if not (is_dt or is_td):
-        msg = f"type {type(value)} is not supported"
-        raise NotImplementedError(msg)
-    value = to_datetime64(value) if is_dt else to_timedelta64(value)
-    dtype = "datetime64[ns]" if is_dt else "timedelta64[ns]"
-    limits = np.iinfo(np.int64)
-    lower, upper = int(limits.min) + 1, int(limits.max)
-    value_ns = np.asarray(to_int(value)).astype(object)
-    amount_ns = np.asarray(sign * to_int(to_timedelta64(amount))).astype(object)
-    out = np.clip(value_ns + amount_ns, lower, upper)
-    return np.asarray(out).astype(np.int64).astype(dtype)[()]
-
-
-def saturate_add(value, amount):
-    """Add a timedelta to a time-like value, saturating at int64 bounds."""
-    return _saturate_time(value, amount)
-
-
-def saturate_subtract(value, amount):
-    """Subtract a timedelta from a time-like value, saturating at int64 bounds."""
-    return _saturate_time(value, amount, sign=-1)
-
-
 @singledispatch
 def to_datetime64(obj: timeable_types | np.ndarray):
     """

--- a/scripts/_baselines/api_urls.tsv
+++ b/scripts/_baselines/api_urls.tsv
@@ -4850,8 +4850,6 @@ dascore.utils.hdf5.H5Reader	/api/dascore/utils/hdf5/H5Reader.qmd
 dascore.utils.hdf5.H5Reader.get_handle	/api/dascore/utils/hdf5/H5Reader/get_handle.qmd
 dascore.utils.hdf5.H5Writer	/api/dascore/utils/hdf5/H5Writer.qmd
 dascore.utils.hdf5.H5Writer.get_handle	/api/dascore/utils/hdf5/H5Writer/get_handle.qmd
-dascore.utils.hdf5.LocalH5Reader	/api/dascore/utils/hdf5/LocalH5Reader.qmd
-dascore.utils.hdf5.LocalH5Reader.get_handle	/api/dascore/utils/hdf5/LocalH5Reader/get_handle.qmd
 dascore.utils.hdf5.encode_h5_strings	/api/dascore/utils/hdf5/encode_h5_strings.qmd
 dascore.utils.hdf5.ensure_local_file	/api/dascore/utils/remote_io/ensure_local_file.qmd
 dascore.utils.hdf5.extract_h5_attrs	/api/dascore/utils/hdf5/extract_h5_attrs.qmd
@@ -5208,8 +5206,6 @@ dascore.utils.time.UnitError	/api/dascore/exceptions/UnitError.qmd
 dascore.utils.time.dtype_time_like	/api/dascore/utils/time/dtype_time_like.qmd
 dascore.utils.time.is_datetime64	/api/dascore/utils/time/is_datetime64.qmd
 dascore.utils.time.is_timedelta64	/api/dascore/utils/time/is_timedelta64.qmd
-dascore.utils.time.saturate_add	/api/dascore/utils/time/saturate_add.qmd
-dascore.utils.time.saturate_subtract	/api/dascore/utils/time/saturate_subtract.qmd
 dascore.utils.time.to_datetime64	/api/dascore/utils/time/to_datetime64.qmd
 dascore.utils.time.to_float	/api/dascore/utils/time/to_float.qmd
 dascore.utils.time.to_int	/api/dascore/utils/time/to_int.qmd
@@ -7677,10 +7673,6 @@ docs/api/dascore/utils/hdf5/H5Writer	/api/dascore/utils/hdf5/H5Writer.qmd
 docs/api/dascore/utils/hdf5/H5Writer.qmd	/api/dascore/utils/hdf5/H5Writer.qmd
 docs/api/dascore/utils/hdf5/H5Writer/get_handle	/api/dascore/utils/hdf5/H5Writer/get_handle.qmd
 docs/api/dascore/utils/hdf5/H5Writer/get_handle.qmd	/api/dascore/utils/hdf5/H5Writer/get_handle.qmd
-docs/api/dascore/utils/hdf5/LocalH5Reader	/api/dascore/utils/hdf5/LocalH5Reader.qmd
-docs/api/dascore/utils/hdf5/LocalH5Reader.qmd	/api/dascore/utils/hdf5/LocalH5Reader.qmd
-docs/api/dascore/utils/hdf5/LocalH5Reader/get_handle	/api/dascore/utils/hdf5/LocalH5Reader/get_handle.qmd
-docs/api/dascore/utils/hdf5/LocalH5Reader/get_handle.qmd	/api/dascore/utils/hdf5/LocalH5Reader/get_handle.qmd
 docs/api/dascore/utils/hdf5/encode_h5_strings	/api/dascore/utils/hdf5/encode_h5_strings.qmd
 docs/api/dascore/utils/hdf5/encode_h5_strings.qmd	/api/dascore/utils/hdf5/encode_h5_strings.qmd
 docs/api/dascore/utils/hdf5/extract_h5_attrs	/api/dascore/utils/hdf5/extract_h5_attrs.qmd
@@ -8069,10 +8061,6 @@ docs/api/dascore/utils/time/is_datetime64	/api/dascore/utils/time/is_datetime64.
 docs/api/dascore/utils/time/is_datetime64.qmd	/api/dascore/utils/time/is_datetime64.qmd
 docs/api/dascore/utils/time/is_timedelta64	/api/dascore/utils/time/is_timedelta64.qmd
 docs/api/dascore/utils/time/is_timedelta64.qmd	/api/dascore/utils/time/is_timedelta64.qmd
-docs/api/dascore/utils/time/saturate_add	/api/dascore/utils/time/saturate_add.qmd
-docs/api/dascore/utils/time/saturate_add.qmd	/api/dascore/utils/time/saturate_add.qmd
-docs/api/dascore/utils/time/saturate_subtract	/api/dascore/utils/time/saturate_subtract.qmd
-docs/api/dascore/utils/time/saturate_subtract.qmd	/api/dascore/utils/time/saturate_subtract.qmd
 docs/api/dascore/utils/time/to_datetime64	/api/dascore/utils/time/to_datetime64.qmd
 docs/api/dascore/utils/time/to_datetime64.qmd	/api/dascore/utils/time/to_datetime64.qmd
 docs/api/dascore/utils/time/to_float	/api/dascore/utils/time/to_float.qmd

--- a/tests/test_utils/test_io_utils.py
+++ b/tests/test_utils/test_io_utils.py
@@ -21,7 +21,6 @@ from dascore.exceptions import PatchConversionError, RemoteCacheError
 from dascore.utils.hdf5 import (
     H5Reader,
     H5Writer,
-    LocalH5Reader,
     open_h5_resource,
 )
 from dascore.utils.io import (
@@ -317,18 +316,6 @@ class TestGetHandleFromResource:
             handle.close()
             assert raw.id.valid == 0
 
-    def test_local_h5_reader_materializes_local_path(self, tmp_path):
-        """Ensure LocalH5Reader can open a local path through its adapter."""
-        path = tmp_path / "local_h5_reader.h5"
-        with h5py.File(path, "w") as handle:
-            handle.create_dataset("data", data=[1, 2, 3])
-        handle = LocalH5Reader.get_handle(path)
-        try:
-            assert type(handle).__name__ == "_ManagedH5pyFile"
-            assert list(handle["data"][:]) == [1, 2, 3]
-        finally:
-            handle.close()
-
     def test_h5_reader_wraps_local_path(self, tmp_path):
         """Local path opens should use the same managed HDF5 handle type."""
         path = tmp_path / "managed_local.h5"
@@ -599,8 +586,8 @@ class TestGetHandleFromResource:
         path = UPath("memory://dascore/upath-write-abort-twice.h5")
         handle = H5Writer.get_handle(path)
         handle.create_dataset("data", data=[1, 2, 3])
-        handle._abort()
-        handle._abort()
+        handle.abort()
+        handle.abort()
         assert not path.exists()
 
     def test_not_implemented(self):

--- a/tests/test_utils/test_pd.py
+++ b/tests/test_utils/test_pd.py
@@ -10,7 +10,6 @@ import pytest
 import dascore as dc
 from dascore.exceptions import InvalidSpoolQueryError, ParameterError
 from dascore.utils.pd import (
-    _model_list_to_df,
     adjust_segments,
     dataframe_to_patch,
     fill_defaults_from_pydantic,
@@ -141,27 +140,6 @@ class TestFilterDfBasic:
         con = (ser >= 20) & (ser <= 30)
         out = filter_df(example_df, age_min=20, age_max=30)
         assert all(con == out)
-
-
-class TestModelListToDf:
-    """Tests for flattening patch-like objects to dataframes."""
-
-    def test_uses_flat_dump_and_serializes_dims(self, random_patch):
-        """Patch-like objects with flat_dump should convert into dataframes."""
-        df = _model_list_to_df([random_patch], exclude={"history"})
-        assert len(df) == 1
-        assert df.loc[0, "dims"] == ",".join(random_patch.dims)
-
-    def test_uses_summary_fallback_when_item_has_no_flat_dump(self, random_patch):
-        """Objects with only .summary should still convert cleanly."""
-
-        class SummaryOnly:
-            def __init__(self, summary):
-                self.summary = summary
-
-        df = _model_list_to_df([SummaryOnly(random_patch.summary)], exclude={"history"})
-        assert len(df) == 1
-        assert df.loc[0, "dims"] == ",".join(random_patch.dims)
 
 
 class TestListSerToStr:

--- a/tests/test_utils/test_time.py
+++ b/tests/test_utils/test_time.py
@@ -21,8 +21,6 @@ except ImportError:
 from dascore.utils.time import (
     is_datetime64,
     is_timedelta64,
-    saturate_add,
-    saturate_subtract,
     to_datetime64,
     to_float,
     to_int,
@@ -573,63 +571,6 @@ class TestToInt:
         array = np.empty(0, dtype="datetime64[ns]")
         out = to_int(array)
         assert np.issubdtype(out.dtype, np.integer)
-
-
-class TestSaturateTime:
-    """Tests for saturating datetime and timedelta operations."""
-
-    class _OverflowingAdd:
-        """Object which forces the saturating fallback path."""
-
-        def __add__(self, other):
-            raise OverflowError
-
-        def __sub__(self, other):
-            raise OverflowError
-
-    def test_datetime_add_saturates_upper_bound(self):
-        """Adding past datetime64 max should clamp to max."""
-        limits = np.iinfo(np.int64)
-        dt = np.array(int(limits.max) - 1).astype("datetime64[ns]")
-        out = saturate_add(dt, np.timedelta64(5, "ns"))
-        expected = np.array(int(limits.max)).astype("datetime64[ns]")
-        assert out == expected
-
-    def test_datetime_subtract_saturates_lower_bound(self):
-        """Subtracting past datetime64 min should clamp to min."""
-        limits = np.iinfo(np.int64)
-        dt = np.array(int(limits.min) + 1).astype("datetime64[ns]")
-        out = saturate_subtract(dt, np.timedelta64(5, "ns"))
-        expected = np.array(int(limits.min) + 1).astype("datetime64[ns]")
-        assert out == expected
-
-    def test_datetime_ops_preserve_normal_values(self):
-        """Normal datetime arithmetic should match numpy time arithmetic."""
-        dt = np.datetime64("2020-01-01", "ns")
-        delta = np.timedelta64(5, "s")
-        assert saturate_add(dt, delta) == dt + delta
-        assert saturate_subtract(dt, delta) == dt - delta
-
-    def test_timedelta_ops_saturate(self):
-        """Timedelta64 values should also saturate at int64 bounds."""
-        limits = np.iinfo(np.int64)
-        td = np.array(int(limits.max) - 1).astype("timedelta64[ns]")
-        out = saturate_add(td, np.timedelta64(5, "ns"))
-        expected = np.array(int(limits.max)).astype("timedelta64[ns]")
-        assert out == expected
-
-    def test_datetime_array_saturates(self):
-        """Arrays should saturate overflowing entries and preserve normal ones."""
-        limits = np.iinfo(np.int64)
-        dt = np.array([int(limits.max) - 1, 0]).astype("datetime64[ns]")
-        out = saturate_add(dt, np.timedelta64(5, "ns"))
-        expected = np.array([int(limits.max), 5]).astype("datetime64[ns]")
-        assert np.all(out == expected)
-
-    def test_unsupported_type_raises_after_overflow(self):
-        """Unsupported values should still raise from the fallback path."""
-        with pytest.raises(NotImplementedError):
-            saturate_add(self._OverflowingAdd(), np.timedelta64(5, "ns"))
 
 
 class TestIsDateTime:


### PR DESCRIPTION
## Description

Five pieces of code nothing calls, removed. The 2026-09-02 redundancy review proposed a much longer list; an independent pass checked every name against the last release as well as against `dev`, and most of them failed that second test. A name with no caller here may still be one the released package hands out, so only names dead on both sides are removed:

- `saturate_add`, `saturate_subtract` and the helper behind them, which clip time arithmetic at the int64 bounds for nobody.
- `_RemoteH5Writer._abort`, an alias for `abort()` whose docstring called it backward-compatible although no released version has it. The one test using it now calls `abort()`, which is what production checks for.
- `LocalH5Reader`, a resource annotation no reader annotates with. The handle helper it wrapped is still used by two other readers and stays.
- `_model_list_to_df`, whose one caller went when the index stopped building frames out of models.
- The `None` branch of `build_coord_clause`'s column table, which cannot be reached: `_range_bounds` raises before it can return a kind of `None`.

The rest of the proposed list is left alone. Most of it is live on `master` and would need deprecating rather than deleting; several items turned out to have callers here after all, including `_require_root`, `indexer.ext`, `_ensure_attr_columns`, `_directory_format` and the `_FetcherProxy` that produces the released `fetcher` object.

Four doc URLs leave the frozen API baseline with the symbols they named. Nothing else in the baseline moves, and `scripts/_api_urls.py check --strict` passes.

## Changelog

- removed: `dascore.utils.time.saturate_add` and `saturate_subtract`, and `dascore.utils.hdf5.LocalH5Reader`. None of them is used, and none appears in the last release.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
