### PR TITLE
Preserve TDMS sample order across complete chunks

### DIFF
--- a/dascore/io/tdms/utils.py
+++ b/dascore/io/tdms/utils.py
@@ -309,8 +309,9 @@ def _get_segment_data(fileinfo, nch, dmap, nso, rdo):
         buffer=dmap,
         offset=rdo,
     )
-    # Rotate the axes to [chunk_size, nblk, nch]
-    raw_data = np.rollaxis(raw_data, 2)
+    # Flatten chunks in time order, keeping samples within each chunk
+    # together and channels on the final axis.
+    raw_data = raw_data.transpose(0, 2, 1)
     data_node = np.reshape(raw_data, (n_complete_blk * fileinfo["chunk_size"], nch))
     if n_complete_blk != seg_length / fileinfo["chunk_size"]:
         # If the last chunk isn't full there is some data left

--- a/tests/test_io/test_tdms/test_tdms_utils.py
+++ b/tests/test_io/test_tdms/test_tdms_utils.py
@@ -166,6 +166,8 @@ class TestSampleOrder:
             payload = expected.tobytes()
         path = tmp_path / "samples.raw"
         path.write_bytes(payload)
+        # A finite declared end describes a closed segment. Its partial
+        # chunk, if any, has the same remaining sample count per channel.
         fileinfo = {
             "decimated": decimated,
             "chunk_size": chunk_size,

--- a/tests/test_io/test_tdms/test_tdms_utils.py
+++ b/tests/test_io/test_tdms/test_tdms_utils.py
@@ -144,6 +144,44 @@ class TestTDMSUtils:
         assert channel_length == 2
 
 
+class TestSampleOrder:
+    """Raw chunks must become chronological samples, including windowed reads."""
+
+    @pytest.mark.parametrize("shape", [(6, 1), (6, 2), (7, 2)])
+    @pytest.mark.parametrize("decimated", [True, False])
+    @pytest.mark.parametrize("bounds", [(0, None), (1, 5)])
+    def test_chunk_order(self, tmp_path, shape, decimated, bounds):
+        """Full chunks and a partial tail retain time and channel identities."""
+        expected = np.arange(np.prod(shape), dtype=np.float32).reshape(shape)
+        chunk_size = 2
+        if decimated:
+            # Storage writes each channel's samples in one chunk before
+            # moving to the next channel, then starts the next time chunk.
+            payload = b"".join(
+                expected[start : start + chunk_size, channel].tobytes()
+                for start in range(0, shape[0], chunk_size)
+                for channel in range(shape[1])
+            )
+        else:
+            payload = expected.tobytes()
+        path = tmp_path / "samples.raw"
+        path.write_bytes(payload)
+        fileinfo = {
+            "decimated": decimated,
+            "chunk_size": chunk_size,
+            "data_type": "float32",
+            "n_channels": shape[1],
+            "raw_data_offset": 0,
+            "next_segment_offset": len(payload),
+            "file_size": len(payload),
+        }
+        start, stop = bounds
+        with path.open("rb") as resource:
+            actual = tdms_utils._read_sample_range(resource, fileinfo, start, stop)
+        np.testing.assert_array_equal(actual, expected[start:stop])
+        assert actual.dtype == expected.dtype
+
+
 class TestMultiSegment:
     """A TDMS file can hold several segments, each a stretch of time."""
 


### PR DESCRIPTION
## Description

TDMS segments containing multiple complete chunks interleaved samples from different chunks during decoding: `[1, 2, 3, 4, 5, 6]` became `[1, 3, 5, 2, 4, 6]`. Preserve chunk order when flattening the sample axis so full reads and `read_array` return chronological data.

Regression tests use independent expected values for one and two channels, complete chunks, a partial tail, and windows crossing chunk boundaries. All six non-interleaved cases fail on the original decoder; six interleaved cases protect the existing behavior.

The corrected decoder also matches npTDMS 1.10.0 on four generated TDMS files and both existing vendor fixtures (`iDAS005_tdms_example.626.tdms` and `sample_tdms_file_v4713.tdms`). The layout follows [NI's TDMS format specification](https://www.ni.com/en/support/documentation/supplemental/07/tdms-file-format-internal-structure.html). The existing vendor fixtures agree before the fix as well; the generated cases exercise the ordering defect. This does not add a dependency on npTDMS.

Validation: both full-repository pre-commit passes succeeded; 33 TDMS tests passed; the full suite and coverage run each passed 11,260 tests (148 skipped, 2 xfailed); 224 doctests and 112 script/filter tests passed.

## Changelog

- fixed: TDMS reads preserve chronological sample order across complete chunks within a segment.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected TDMS sample ordering so data is returned in chronological order across chunks.
  * Preserved channel identities for both decimated and non-decimated layouts.
  * Ensured full reads and bounded window reads handle complete chunks and partial tails correctly.

* **Tests**
  * Added coverage for sample ordering across storage layouts, chunk boundaries, and read ranges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->