### PR TITLE
Preserve exact coordinate values and descending order

### DIFF
--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -2760,11 +2760,10 @@ class CoordSegmented(BaseCoord):
         if len(values) < 3:
             out = get_coord(data=values, units=units)
         else:
-            diffs = np.diff(values)
-            zero = diffs[0] - diffs[0]
-            if not (np.all(diffs > zero) or np.all(diffs < zero)):
+            if not is_strictly_monotonic(values):
                 msg = "from_array requires strictly monotonic values."
                 raise CoordError(msg)
+            diffs = np.diff(values)
             # A diff belongs to a uniform run when it matches a neighboring
             # diff; isolated diffs are seams (gaps or sampling changes).
             eq_next = diffs[:-1] == diffs[1:]

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -2771,10 +2771,15 @@ class CoordSegmented(BaseCoord):
             in_run = np.zeros(len(diffs), dtype=bool)
             in_run[1:] |= eq_next
             in_run[:-1] |= eq_next
-            splits = np.flatnonzero(~in_run) + 1
-            blocks = np.split(values, splits)
-            segments = [CoordMonotonicArray(values=x, units=units) for x in blocks]
-            out = concat_coords(*segments)
+            if not np.any(in_run):
+                # Singleton segments carry no direction and would be sorted
+                # ascending by concat_coords. Keep the recorded order.
+                out = CoordMonotonicArray(values=values, units=units)
+            else:
+                splits = np.flatnonzero(~in_run) + 1
+                blocks = np.split(values, splits)
+                segments = [CoordMonotonicArray(values=x, units=units) for x in blocks]
+                out = concat_coords(*segments)
         if tolerance is not None:
             out = out.simplify(tolerance)
         return out

--- a/dascore/io/utils.py
+++ b/dascore/io/utils.py
@@ -27,7 +27,12 @@ from dascore.exceptions import (
 )
 from dascore.models import ArrayLike
 from dascore.units import convert_units, get_quantity_str
-from dascore.utils.misc import _to_slice, _validate_sample_values, unbyte
+from dascore.utils.misc import (
+    _to_slice,
+    _validate_sample_values,
+    is_strictly_monotonic,
+    unbyte,
+)
 
 # Stored coordinate arrays often carry sub-step jitter (e.g. GPS-stamped DAS
 # time). ``CoordSegmented.from_array`` treats every isolated sampling change as
@@ -325,10 +330,9 @@ def _is_over_segmented(values) -> bool:
     """
     if values.ndim != 1 or len(values) < _MIN_SEGMENT_GUARD_SIZE:
         return False
-    diffs = np.diff(values)
-    zero = diffs[0] - diffs[0]
-    if not (np.all(diffs > zero) or np.all(diffs < zero)):
+    if not is_strictly_monotonic(values):
         return False  # non-monotonic; from_array handles its own fallback
+    diffs = np.diff(values)
     # A diff belongs to a run when it matches a neighbor; isolated diffs seam.
     eq_next = diffs[:-1] == diffs[1:]
     in_run = np.zeros(len(diffs), dtype=bool)

--- a/dascore/io/utils.py
+++ b/dascore/io/utils.py
@@ -11,7 +11,12 @@ import numpy as np
 import dascore as dc
 from dascore.constants import INVENTORY_ATTRS
 from dascore.core.coordmanager import CoordManager
-from dascore.core.coords import BaseCoord, CoordSegmented, get_coord
+from dascore.core.coords import (
+    BaseCoord,
+    CoordMonotonicArray,
+    CoordSegmented,
+    get_coord,
+)
 from dascore.core.summary import normalize_source_patch_key
 from dascore.exceptions import (
     CoordError,
@@ -302,7 +307,9 @@ def get_exact_coord(values, units=None) -> BaseCoord:
     # array (0-d) becomes a length-1 coordinate rather than a scalar.
     values = np.atleast_1d(np.asarray(values))
     if _is_over_segmented(values):
-        return get_coord(data=values, units=units)
+        # The guard has established strict monotonicity. Keep the stored
+        # values: get_coord could approximate their jitter with a range.
+        return CoordMonotonicArray(values=values, units=units)
     try:
         return CoordSegmented.from_array(values, tolerance=0, units=units)
     except CoordError:

--- a/tests/test_core/test_coord_segmented.py
+++ b/tests/test_core/test_coord_segmented.py
@@ -1061,9 +1061,11 @@ class TestFromArray:
         coord = CoordSegmented.from_array(np.arange(10.0))
         assert isinstance(coord, CoordRange)
 
-    def test_irregular_returns_monotonic(self):
-        """Arrays with no uniform runs come back as one monotonic coord."""
+    @pytest.mark.parametrize("reverse", [False, True])
+    def test_irregular_returns_monotonic(self, reverse):
+        """Arrays with no uniform runs retain their values and direction."""
         values = np.array([0.0, 1.0, 2.1, 3.3, 4.0])
+        values = values[::-1] if reverse else values
         coord = CoordSegmented.from_array(values)
         assert isinstance(coord, CoordMonotonicArray)
         assert np.array_equal(coord.values, values)

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -358,6 +358,18 @@ class TestGetExactCoord:
         assert coord.units == dc.get_quantity("m")
         assert coord.reverse_sorted == reverse
 
+    @pytest.mark.parametrize("repeats", [2, 250])
+    def test_unsigned_unsorted_selection(self, repeats):
+        """Unsigned difference wraparound must not select a monotonic search path."""
+        values = np.tile(np.array([0, 2, 1, 3], dtype=np.uint16), repeats)
+        coord = get_exact_coord(values)
+
+        np.testing.assert_array_equal(coord.values, values)
+        selected, indexer = coord.select((1, 1))
+        expected = np.ones(repeats, dtype=values.dtype)
+        np.testing.assert_array_equal(selected.values, expected)
+        np.testing.assert_array_equal(values[indexer], expected)
+
     def test_large_non_monotonic_array_preserved(self):
         """A large non-monotonic array skips the segment guard and stays exact."""
         rng = np.random.default_rng(1)

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -343,6 +343,21 @@ class TestGetExactCoord:
         np.testing.assert_array_equal(coord.values, values)
         assert not isinstance(coord, CoordSegmented)
 
+    @pytest.mark.parametrize("length", [999, 1000, 2000])
+    @pytest.mark.parametrize("reverse", [False, True])
+    def test_float_jitter_preserved(self, length, reverse):
+        """Avoiding excessive segments must not approximate floating-point values."""
+        values = np.arange(length, dtype=float)
+        values += np.random.default_rng(4).uniform(-1e-5, 1e-5, length)
+        values = values[::-1] if reverse else values
+
+        coord = get_exact_coord(values, units="m")
+
+        np.testing.assert_array_equal(coord.values, values)
+        assert not isinstance(coord, CoordSegmented)
+        assert coord.units == dc.get_quantity("m")
+        assert coord.reverse_sorted == reverse
+
     def test_large_non_monotonic_array_preserved(self):
         """A large non-monotonic array skips the segment guard and stays exact."""
         rng = np.random.default_rng(1)


### PR DESCRIPTION
## Description

Exact IO coordinates could lose recorded floating-point jitter at the 1,000-sample segmentation threshold because the fallback used a constructor that inferred an approximate uniform range. Return an array-backed monotonic coordinate when the segmentation guard fires, preserving the values already loaded by the caller.

The boundary tests also exposed descending arrays with no uniform runs being reordered by singleton-segment concatenation. Construct those directly as monotonic arrays to retain their original sample order. Uniform ranges and genuinely piecewise-uniform coordinates retain their existing compact representations.

Tests compare values exactly for ascending and descending jittered arrays at 999, 1,000, and 2,000 samples, and cover descending arrays directly in the segmented constructor. Five new IO cases and the descending constructor case fail on the original implementation. Additional unsigned-coordinate selection tests protect both construction paths against subtraction wraparound by using the existing overflow-safe monotonicity check.

Validation: both full-repository pre-commit passes succeeded; 367 affected tests passed; the full suite and coverage run each passed 11,257 tests (148 skipped, 2 xfailed); 224 doctests and 112 script/filter tests passed.

## Changelog

- fixed: Exact coordinate construction preserves floating-point jitter when avoiding excessive segmentation and retains descending sample order for arrays without uniform runs.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
