### PR TITLE
Fix integration dtype promotion and uneven-axis weighting

### DIFF
--- a/dascore/transform/integrate.py
+++ b/dascore/transform/integrate.py
@@ -30,7 +30,7 @@ def _quasi_mean(array):
     return np.asarray([out], dtype=array.dtype)
 
 
-def _get_definite_integral(patch, dxs_or_vals, dims, axes):
+def _get_definite_integral(patch, array, dxs_or_vals, dims, axes):
     """Get a definite integral along axes."""
 
     def _get_new_coords_and_array(patch, array, dims):
@@ -44,7 +44,6 @@ def _get_definite_integral(patch, dxs_or_vals, dims, axes):
         cm = patch.coords.update(**new_coords)
         return array, cm
 
-    array = patch.data
     ndims = len(patch.shape)
     for dxs_or_val, ax in zip(dxs_or_vals, axes):
         # Numpy 2/3 compat code
@@ -57,24 +56,24 @@ def _get_definite_integral(patch, dxs_or_vals, dims, axes):
     return array, coords
 
 
-def _get_indefinite_integral(patch, dxs_or_vals, axes):
+def _get_indefinite_integral(patch, array, dxs_or_vals, axes):
     """
     Get indefinite integral along dimensions.
 
     We need to calculate the distance weighted average for the areas between
     samples for the integration dimension.
     """
-    array = patch.data
     for dx_or_val, ax in zip(dxs_or_vals, axes):
         out = np.zeros_like(array)
         # if coordinate values are provided need to get diffs.
         if is_array(dx_or_val):
-            dx_or_val = dx_or_val[1:] - dx_or_val[:-1]
+            intervals = dx_or_val[1:] - dx_or_val[:-1]
+            indexer = broadcast_for_index(array.ndim, ax, slice(None), fill=None)
+            dx_or_val = intervals[indexer]
         ndim = len(out.shape)
         # get diffs along dimension
         stop_indexer = broadcast_for_index(ndim, ax, slice(1, None), fill=slice(None))
         start_indexer = broadcast_for_index(ndim, ax, slice(None, -1), fill=slice(None))
-        # first_indexer = broadcast_for_index(ndim, ax, slice(0, 1), fill=slice(None))
         # get average values of trapezoid between points
         avs = (array[stop_indexer] + array[start_indexer]) * (dx_or_val / 2)
         out[stop_indexer] = np.cumsum(avs, axis=ax)
@@ -111,6 +110,9 @@ def integrate(
     value. To remove dimensions with length 1, use
     [`Patch.squeeze`](`dascore.Patch.squeeze`).
 
+    Integer and boolean data are converted to float64 before integration.
+    Floating-point and complex data are used without an explicit dtype cast.
+
     The output `data_type` is mapped through the pairs an integral is
     known to relate, which are those of
     [differentiate](`dascore.Patch.differentiate`) read backwards: along
@@ -132,10 +134,13 @@ def integrate(
     """
     dims = iterate(dim if dim is not None else patch.dims)
     dxs_or_vals, axes = _get_dx_or_spacing_and_axes(patch, dims)
+    array = patch.data
+    if array.dtype.kind in "biu":
+        array = array.astype(np.float64)
     if definite:
-        array, coords = _get_definite_integral(patch, dxs_or_vals, dims, axes)
+        array, coords = _get_definite_integral(patch, array, dxs_or_vals, dims, axes)
     else:
-        array, coords = _get_indefinite_integral(patch, dxs_or_vals, axes)
+        array, coords = _get_indefinite_integral(patch, array, dxs_or_vals, axes)
     new_units = _get_data_units_from_dims(patch, dims, mul)
     data_type = _get_data_type_from_dims(patch, dims, differentiate=False)
     attrs = patch.attrs.update(data_units=new_units, data_type=data_type)

--- a/dascore/transform/integrate.py
+++ b/dascore/transform/integrate.py
@@ -81,7 +81,7 @@ def _get_indefinite_integral(patch, array, dxs_or_vals, axes):
     return array, patch.coords  # coords shouldn't change
 
 
-@patch_function(version="1.1")
+@patch_function(version="1.2")
 def integrate(
     patch: PatchType,
     dim: Sequence[str] | str | None,

--- a/dascore/transform/integrate.py
+++ b/dascore/transform/integrate.py
@@ -135,7 +135,7 @@ def integrate(
     dims = iterate(dim if dim is not None else patch.dims)
     dxs_or_vals, axes = _get_dx_or_spacing_and_axes(patch, dims)
     array = patch.data
-    if array.dtype.kind in "biu":
+    if axes and array.dtype.kind in "biu":
         array = array.astype(np.float64)
     if definite:
         array, coords = _get_definite_integral(patch, array, dxs_or_vals, dims, axes)

--- a/tests/test_transform/test_integrate.py
+++ b/tests/test_transform/test_integrate.py
@@ -183,6 +183,19 @@ class TestNumericalIntegrals:
     """Analytic expectations for dtype and axis handling."""
 
     @pytest.mark.parametrize("definite", [False, True])
+    @pytest.mark.parametrize("dtype", [np.int64, np.bool_])
+    def test_no_dimensions(self, definite, dtype):
+        """An empty dimension selection preserves the original data exactly."""
+        data = np.array([2**53 + 1, 1 - 2**53], dtype=dtype)
+        patch = dc.Patch(
+            data=data, coords={"distance": np.arange(2)}, dims=("distance",)
+        )
+        out = patch.integrate((), definite=definite)
+        np.testing.assert_array_equal(out.data, data)
+        assert out.data.dtype == dtype
+        assert out.coords == patch.coords
+
+    @pytest.mark.parametrize("definite", [False, True])
     @pytest.mark.parametrize("dtype", [np.int8, np.uint8, np.int64, np.bool_])
     def test_integer_data(self, definite, dtype):
         """Promote before adding samples, preserving fractional areas."""

--- a/tests/test_transform/test_integrate.py
+++ b/tests/test_transform/test_integrate.py
@@ -177,3 +177,75 @@ class TestDataType:
         patch = random_patch.update_attrs(data_type="strain")
         out = patch.differentiate("time").integrate("time")
         assert out.attrs.data_type == "strain"
+
+
+class TestNumericalIntegrals:
+    """Analytic expectations for dtype and axis handling."""
+
+    @pytest.mark.parametrize("definite", [False, True])
+    @pytest.mark.parametrize("dtype", [np.int8, np.uint8, np.int64, np.bool_])
+    def test_integer_data(self, definite, dtype):
+        """Promote before adding samples, preserving fractional areas."""
+        data = np.array([0, 1, 1, 0], dtype=dtype)
+        patch = dc.Patch(
+            data=data, coords={"distance": np.arange(4)}, dims=("distance",)
+        )
+        out = patch.integrate("distance", definite=definite)
+        expected = np.array([0, 0.5, 1.5, 2])
+        np.testing.assert_array_equal(out.data, expected[-1:] if definite else expected)
+        assert out.data.dtype == np.float64
+        np.testing.assert_array_equal(patch.data, data)
+
+    @pytest.mark.parametrize("definite", [False, True])
+    @pytest.mark.parametrize("dtype", [np.int8, np.uint8])
+    def test_integer_overflow(self, definite, dtype):
+        """Narrow integer sample sums must not overflow before promotion."""
+        data = np.full(4, 100 if dtype == np.int8 else 200, dtype=dtype)
+        patch = dc.Patch(
+            data=data, coords={"distance": np.arange(4)}, dims=("distance",)
+        )
+        expected = np.arange(4, dtype=float) * float(data[0])
+        out = patch.integrate("distance", definite=definite)
+        np.testing.assert_array_equal(out.data, expected[-1:] if definite else expected)
+
+    @pytest.mark.parametrize("definite", [False, True])
+    @pytest.mark.parametrize(
+        "dtype", [np.float32, np.float64, np.complex64, np.complex128]
+    )
+    def test_inexact_data(self, definite, dtype):
+        """Floating precision and imaginary components survive integration."""
+        value = 1 + 2j if np.issubdtype(dtype, np.complexfloating) else 1
+        patch = dc.Patch(
+            data=np.full(4, value, dtype=dtype),
+            coords={"distance": np.arange(4)},
+            dims=("distance",),
+        )
+        expected = np.arange(4) * value
+        out = patch.integrate("distance", definite=definite)
+        np.testing.assert_array_equal(out.data, expected[-1:] if definite else expected)
+        if not definite:
+            assert out.data.dtype == dtype
+
+    @pytest.mark.parametrize("width", [2, 3])
+    @pytest.mark.parametrize("axis", [0, 1, 2])
+    def test_uneven_axis(self, width, axis):
+        """Uneven intervals weight the named axis in any array position."""
+        distance = np.array([0, 1, 3, 6])
+        patch = dc.Patch(
+            data=np.ones((4, 2, width)),
+            coords={"distance": distance, "x": np.arange(2), "y": np.arange(width)},
+            dims=("distance", "x", "y"),
+        )
+        dims = ["x", "y"]
+        dims.insert(axis, "distance")
+        out = patch.transpose(*dims).integrate("distance").transpose(*patch.dims)
+        expected = np.broadcast_to(distance[:, None, None], patch.shape)
+        np.testing.assert_array_equal(out.data, expected)
+        np.testing.assert_array_equal(out.data, patch.integrate("distance").data)
+
+    def test_multiple_uneven_axes(self):
+        """Integrating a constant over two uneven axes gives their product."""
+        x, y = np.array([0, 1, 3, 6]), np.array([0, 2, 5])
+        patch = dc.Patch(data=np.ones((4, 3)), coords={"x": x, "y": y}, dims=("x", "y"))
+        out = patch.integrate(None)
+        np.testing.assert_array_equal(out.data, x[:, None] * y[None, :])


### PR DESCRIPTION
## Description

Uneven cumulative integration applied interval weights along the final array axis rather than the requested dimension. An array of ones integrated along distances `[0, 1, 3, 6]` could either raise a broadcasting error or silently produce different values across channels. Shape the interval vector along the integration axis with the existing broadcasting helper.

Integer cumulative output also truncated fractional areas, and adjacent narrow-integer samples could overflow before assignment in either integration mode. Convert integer and boolean data to float64 before arithmetic for both cumulative and definite integration. Existing floating-point and complex inputs are not explicitly cast. Keep the current trapezoidal implementation and metadata behavior. Empty dimension selections preserve the original data and dtype. As with float64 conversion generally, integers outside its exact range can lose precision, including cancellation between large values. Advance the integration operation version so corrected results have distinct processing fingerprints.

Independent analytic regressions cover fractional areas, signed/unsigned overflow, bool inputs, float/complex values, uneven intervals in each of three axis positions, transpose invariance, and integration across two uneven dimensions. Sixteen new cases fail on the original code; eleven protect existing behavior.

Validation: 49 affected tests passed. The full suite and coverage run each passed 11,300 tests (148 skipped, 2 xfailed). Both clean pre-commit passes, 224 doctests, and 112 script/filter tests passed.

## Changelog

- fixed: Integration aligns uneven intervals with the requested axis and promotes integer and boolean data before arithmetic to avoid truncation and overflow.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved numerical integration for integer, unsigned integer, and boolean data by safely converting values to floating-point precision.
  * Corrected indefinite integration across uneven coordinate axes.
  * Ensured integration handles multiple uneven axes consistently.
  * Preserved existing floating-point and complex-number precision behavior.
  * Confirmed source data remains unchanged during integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->