### PR TITLE
Preserve fractional strided derivatives for integer data

### DIFF
--- a/dascore/transform/differentiate.py
+++ b/dascore/transform/differentiate.py
@@ -74,7 +74,7 @@ def _strided_diff(order, patch, axes, dx_or_spacing, step):
     return new_data
 
 
-@patch_function(version="1.1")
+@patch_function(version="1.2")
 def differentiate(
     patch: PatchType,
     dim: str | Sequence[str] | None,

--- a/dascore/transform/differentiate.py
+++ b/dascore/transform/differentiate.py
@@ -55,7 +55,7 @@ def _strided_diff(order, patch, axes, dx_or_spacing, step):
     if len(axes) > 1:
         msg = "Step in patch.differentiate can only be used along one axis."
         raise ParameterError(msg)
-    new_data = np.empty_like(patch.data)
+    new_data = None
     dx_or_space = dx_or_spacing[0]
     for step_ in range(step):
         current_slice = slice(step_, None, step)
@@ -67,7 +67,10 @@ def _strided_diff(order, patch, axes, dx_or_spacing, step):
         else:
             _dx_or_space = dx_or_space * step
         sub = _get_diff(order, patch.data[slicer], axes, [_dx_or_space])
+        if new_data is None:
+            new_data = np.empty_like(patch.data, dtype=sub.dtype)
         new_data[slicer] = sub
+    assert new_data is not None
     return new_data
 
 
@@ -107,6 +110,9 @@ def differentiate(
     order != 2, the optional package findiff must be installed in which case
     order is interpreted as accuracy ("order" means order of differentiation
     in that package).
+
+    Strided output uses the derivative backend's result dtype, including
+    floating-point results for integer input and complex-valued derivatives.
 
     The second order first derivative, for an evenly spaced coordinate,
     is defined as:

--- a/dascore/transform/strain.py
+++ b/dascore/transform/strain.py
@@ -17,6 +17,7 @@ from dascore.utils.patch import patch_function
 
 
 @patch_function(
+    version="1.1",
     required_dims=("distance",),
     required_attrs={"data_type": "velocity"},
 )

--- a/tests/test_transform/test_differentiate.py
+++ b/tests/test_transform/test_differentiate.py
@@ -107,6 +107,40 @@ class TestDifferentiateOrder2:
 class TestStep:
     """Tests for step != 1."""
 
+    @pytest.mark.parametrize(
+        "dtype",
+        [
+            np.int8,
+            np.uint8,
+            np.int64,
+            np.float32,
+            np.float64,
+            np.complex64,
+            np.complex128,
+        ],
+    )
+    @pytest.mark.parametrize("step", [2, 3])
+    @pytest.mark.parametrize("order", [2, 4])
+    def test_linear_dtype(self, dtype, step, order):
+        """Strided linear derivatives retain fractions and backend precision."""
+        if order != 2:
+            pytest.importorskip("findiff")
+        samples = np.arange(30, dtype=dtype)
+        slope = 0.5
+        if np.issubdtype(dtype, np.complexfloating):
+            samples = samples * (1 + 2j)
+            slope = 0.5 + 1j
+        patch = dc.Patch(
+            data=samples,
+            coords={"distance": np.arange(30) * 2},
+            dims=("distance",),
+        )
+        out = patch.differentiate("distance", step=step, order=order)
+        ordinary = patch.differentiate("distance", order=order)
+        np.testing.assert_allclose(out.data, slope, rtol=1e-5, atol=1e-6)
+        assert out.data.dtype == ordinary.data.dtype
+        assert out.coords == patch.coords
+
     def test_multi_dim_raises(self, random_patch):
         """Can only use step on a single dimension."""
         msg = "can only be used along one axis"

--- a/tests/test_transform/test_strain.py
+++ b/tests/test_transform/test_strain.py
@@ -73,6 +73,20 @@ class TestStrainRateConversion:
         out2 = terra15_das_patch.velocity_to_strain_rate(step_multiple=4)
         assert isinstance(out2, dc.Patch)
 
+    def test_integer_velocity(self):
+        """Strided strain conversion preserves fractional integer derivatives."""
+        patch = dc.Patch(
+            data=np.arange(12, dtype=np.int64),
+            coords={"distance": np.arange(12) * 2},
+            dims=("distance",),
+            attrs={"data_type": "velocity", "data_units": "m/s"},
+        ).set_units(distance="m")
+        out = patch.velocity_to_strain_rate(step_multiple=4)
+        np.testing.assert_allclose(out.data, 0.5)
+        assert out.data.dtype == np.float64
+        assert out.attrs.data_type == "strain_rate"
+        assert out.attrs.gauge_length == 8
+
     def test_gauge_multiple_removed(self, terra15_das_patch):
         """Ensure the removed parameter is rejected."""
         with pytest.raises(TypeError, match="gauge_multiple"):


### PR DESCRIPTION
## Description

Strided differentiation allocated output with the input dtype, so integer samples describing a linear function with slope `0.5` produced zeros for `step > 1`. Allocate the output using the first derivative result's dtype, following the selected backend's precision policy and preserving complex values. Advance the operation versions for differentiation and its `velocity_to_strain_rate` caller so corrected results receive distinct processing fingerprints.

Analytic linear-function tests cover signed/unsigned integer, float32/float64, and complex64/complex128 inputs, steps 2 and 3, and both NumPy and optional findiff backends. They check the known slope and the ordinary derivative's output dtype. All twelve integer cases fail on the original code; sixteen float/complex cases protect existing behavior.

Validation: 101 affected differentiation/strain tests passed, including findiff cases. The full suite and coverage run each passed 11,298 tests (148 skipped, 2 xfailed). Both clean pre-commit passes, 224 doctests, and 112 script/filter tests passed.

## Changelog

- fixed: Strided differentiation retains the backend result dtype, preserving fractional derivatives for integer input.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed strided differentiation for integer input so results retain the appropriate floating-point precision.
  * Improved handling of complex-valued data during differentiation.
  * Corrected strain-rate conversion for integer velocity data, preserving fractional derivative values.
* **Tests**
  * Added coverage for integer, floating-point, and complex differentiation, including multiple steps and derivative orders.
  * Added validation for integer velocity conversion and resulting strain-rate values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->