### PR TITLE
Use stored time envelopes for absolute spool queries

### DIFF
--- a/dascore/io/index/backend.py
+++ b/dascore/io/index/backend.py
@@ -29,6 +29,7 @@ from dascore.exceptions import (
 )
 from dascore.io.index.ingest import (
     SourceRecord,
+    _envelope,
     assemble_source_records,
     attr_column_name,
     dump_path_attrs,
@@ -586,6 +587,11 @@ class SQLiteIndexBackend:
                     )
                 )
                 for patch in record.patches:
+                    # Plans and rebuilt records can carry incomplete or non-time
+                    # hot bounds. Coordinate records are the authority at ingest.
+                    time_min, time_max, time_step = _envelope(
+                        patch.coords, "time", "time"
+                    )
                     patch_rows.append(
                         (
                             patch_id,
@@ -594,9 +600,9 @@ class SQLiteIndexBackend:
                             patch.dims,
                             patch.dtype,
                             patch.data_size,
-                            patch.time_min,
-                            patch.time_max,
-                            patch.time_step,
+                            time_min,
+                            time_max,
+                            time_step,
                             patch.distance_min,
                             patch.distance_max,
                             patch.distance_step,

--- a/dascore/io/index/query.py
+++ b/dascore/io/index/query.py
@@ -527,6 +527,13 @@ def build_coord_clause(
         raise InvalidSpoolQueryError(msg)
 
     compatible_units = _compatible_coord_units(rows, typed_values, name)
+    if name == "time" and kind == "time" and compatible_units is None:
+        # These columns copy the absolute coordinate's exact ns envelope.
+        # Relative, numeric, and absent time coords leave them NULL.
+        for bound, column, op in ((lo, "time_max", ">="), (hi, "time_min", "<=")):
+            if bound is not None:
+                where.add(f"p.{column} {op} ?", bound)
+        return
 
     min_col, max_col = {
         "time": ("min_ns", "max_ns"),
@@ -633,8 +640,24 @@ def _order_clause(
     kind, name, ascending = order_by
     direction = "ASC" if ascending else "DESC"
     params: list = []
+    missing_time = ""
     if kind == "coord" and name in _HOT_COORDS:
         column = f"p.{quote(f'{name}_min')}"
+        rows = coord_meta[coord_meta["coord_name"] == name]
+        if name == "time" and (
+            rows["value_kind"].ne("time").any() or rows["is_relative"].any()
+        ):
+            # Only absolute times populate the hot column. Other time
+            # coordinate kinds sort by their own minimum after absolute times.
+            column = (
+                f"COALESCE({column}, (SELECT "
+                "COALESCE(cd.min_ns, cd.min_num, cd.min_str) "
+                "FROM patch_coords pc JOIN coord_defs cd "
+                "ON cd.coord_def_id = pc.coord_def_id "
+                "WHERE pc.patch_id = p.patch_id AND pc.coord_name = ?))"
+            )
+            params.append(name)
+            missing_time = "p.time_min IS NULL, "
     elif kind == "coord":
         rows = coord_meta[coord_meta["coord_name"] == name]
         # a coord observed under several kinds orders by its first kind
@@ -655,7 +678,10 @@ def _order_clause(
     # the ordinal renumberer's missing-time-last rule); the null key
     # repeats the column expression, so its parameters repeat too
     params = [*params, *params]
-    sql = f"ORDER BY {column} IS NULL, {column} {direction}, s.ordinal, p.patch_id"
+    sql = (
+        f"ORDER BY {missing_time}{column} IS NULL, "
+        f"{column} {direction}, s.ordinal, p.patch_id"
+    )
     return sql, params
 
 

--- a/docs/notes/spool_index.qmd
+++ b/docs/notes/spool_index.qmd
@@ -22,6 +22,12 @@ The last two tables are deliberately separate. Many patches can share a distance
 
 `attrs` and `attr_meta` are also complementary. Attribute names are open-ended, so the index cannot define every typed column in advance. `attr_meta` records the stable mapping and units needed to interpret the columns added to `attrs` as data is ingested.
 
+## Time queries
+
+Absolute-time range queries use the nanosecond `time_min` and `time_max` envelopes already stored on `patches`. Database writes derive these cached time bounds from the coordinate records, including auxiliary time coordinates in planned outputs; duration and numeric time coordinates leave the absolute-time bounds empty. These bounds select candidate patches; exact coordinate trimming still happens when a patch loads. Duration, numeric, string, and other coordinate queries retain the general coordinate-table path. Coordinate types and units remain in their existing tables.
+
+The direct predicates work with existing catalogs. No schema change, additional metadata table, or index rebuild is required.
+
 ## Lifecycle and validation
 
 The index is an incrementally updated cache. A directory update scans new or changed sources, transactionally replaces their patch rows, and removes rows for deleted sources. Foreign keys cascade source deletion through patches, attributes, and patch-coordinate links. Unreferenced coordinate definitions may remain available for reuse.

--- a/tests/test_io/test_index/test_time_query.py
+++ b/tests/test_io/test_index/test_time_query.py
@@ -1,0 +1,240 @@
+"""Time envelope queries agree with the general coordinate query engine."""
+
+from __future__ import annotations
+
+import pickle
+from dataclasses import replace
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import dascore as dc
+from dascore.io.index.backend import get_backend
+from dascore.io.index.catalog import PatchCatalog
+from dascore.io.index.query import Query, build_sql
+
+
+@pytest.fixture()
+def time_backend(tmp_path):
+    """Identical time/reference coordinates across heterogeneous patch types."""
+    start = np.datetime64("2024-01-01", "ns")
+    offsets = np.arange(4) * np.timedelta64(1, "s")
+    coordinates = [
+        start + offsets,
+        start + np.timedelta64(10, "s") + offsets,
+        offsets,
+        np.arange(4.0),
+        np.array(["a", "b", "c", "d"]),
+    ]
+    patches = [
+        dc.Patch(
+            data=np.arange(4),
+            coords={"time": values, "reference_time": ("time", values)},
+            dims=("time",),
+            attrs={"tag": f"patch-{index}"},
+        )
+        for index, values in enumerate(coordinates)
+    ]
+    patches.append(
+        dc.Patch(
+            data=np.arange(4), coords={"distance": np.arange(4)}, dims=("distance",)
+        )
+    )
+    catalog = PatchCatalog.from_patches(patches)
+    path = tmp_path / "index.sqlite3"
+    backend = get_backend(path)
+    backend.write_sources(catalog.backend.export_records())
+    catalog.close()
+    yield backend
+    backend.close()
+
+
+class TestTimeQuery:
+    """Only eligible absolute-time bounds use the existing hot columns."""
+
+    @pytest.mark.parametrize(
+        "bounds",
+        [
+            (np.datetime64("2024-01-01"), np.datetime64("2024-01-01")),
+            (
+                np.datetime64("2024-01-01T00:00:02"),
+                np.datetime64("2024-01-01T00:00:12"),
+            ),
+            (None, np.datetime64("2024-01-01T00:00:12")),
+            (np.datetime64("2024-01-01T00:00:12"), None),
+            (Ellipsis, np.datetime64("2023-01-01")),
+            (np.datetime64("2025-01-01"), Ellipsis),
+            (np.timedelta64(1, "s"), np.timedelta64(2, "s")),
+            (1, 2),
+            ("b", "c"),
+        ],
+    )
+    def test_matches_general_query(self, time_backend, bounds):
+        """Projection, membership, and counts agree for all coordinate kinds."""
+        direct = Query(coords={"time": bounds})
+        general = Query(coords={"reference_time": bounds})
+        pd.testing.assert_frame_equal(
+            time_backend.query(direct), time_backend.query(general)
+        )
+        assert time_backend.query_ids(direct) == time_backend.query_ids(general)
+        assert time_backend.count(direct) == time_backend.count(general)
+
+    def test_sorted_membership(self, time_backend):
+        """Fast time predicates compose with attribute filters and fixed membership."""
+        bounds = (np.datetime64("2024-01-01"), None)
+        direct = [Query(coords={"time": bounds}), Query(attrs={"tag": "patch-*"})]
+        general = [
+            Query(coords={"reference_time": bounds}),
+            Query(attrs={"tag": "patch-*"}),
+        ]
+        options = {"order_by": ("coord", "time", False), "patch_ids": (1, 2, 3)}
+        assert time_backend.query_ids(direct, **options) == time_backend.query_ids(
+            general, **options
+        )
+
+    def test_uses_stored_time_bounds(self, time_backend):
+        """An absolute-time count avoids visiting coordinate attachment tables."""
+        query = Query(coords={"time": (np.datetime64("2024-01-01T00:00:10"), None)})
+        queries, attrs, coords = time_backend._query_context(query)
+        sql, params, residuals = build_sql(queries, attrs, coords, count=True)
+        assert not residuals
+        assert "patch_coords" not in sql
+        plan = time_backend._con.execute("EXPLAIN QUERY PLAN " + sql, params).fetchall()
+        assert not any(
+            "patch_coords" in row[-1] or "coord_defs" in row[-1] for row in plan
+        )
+        assert time_backend.count(query) == 1
+
+    def test_existing_catalog(self, time_backend):
+        """Old catalogs remain valid without rebuilding sources or adding schema."""
+        query = Query(coords={"time": (np.datetime64("2024-01-01"), None)})
+        expected = time_backend.query_ids(query)
+        reopened = get_backend(time_backend._path)
+        try:
+            assert reopened.query_ids(query) == expected
+        finally:
+            reopened.close()
+
+    def test_mixed_time_sort(self):
+        """Relative times retain their position after absolute-time patches."""
+        origin = np.datetime64("2024-01-01", "ns")
+        offsets = np.arange(4) * np.timedelta64(1, "s")
+        coordinates = [
+            offsets,
+            origin + offsets + np.timedelta64(10, "s"),
+            origin + offsets,
+        ]
+        patches = [
+            dc.Patch(
+                data=np.arange(4),
+                coords={"time": values},
+                dims=("time",),
+                attrs={"tag": tag},
+            )
+            for values, tag in zip(coordinates, ["relative", "later", "earlier"])
+        ]
+        spool = dc.spool(patches)
+        assert list(spool.sort("time").get_contents()["tag"]) == [
+            "earlier",
+            "later",
+            "relative",
+        ]
+        spool._catalog.close()
+
+    def test_date_strings(self):
+        """Date strings on ordinary datetime catalogs retain coercion and trimming."""
+        start = np.datetime64("2024-01-01", "ns")
+        patch = dc.Patch(
+            data=np.arange(4),
+            coords={"time": start + np.arange(4) * np.timedelta64(1, "s")},
+            dims=("time",),
+        )
+        spool = dc.spool([patch])
+        selected = spool.select(time=("2024-01-01T00:00:01", "2024-01-01T00:00:02"))
+        assert len(selected) == 1
+        assert np.array_equal(selected[0].data, [1, 2])
+        spool._catalog.close()
+
+
+class TestPlannedTimeQueries:
+    """Planned and rebuilt records keep the same absolute-time cache contract."""
+
+    @pytest.mark.parametrize("operation", ["chunk", "concatenate"])
+    @pytest.mark.parametrize("serialized", [False, True])
+    def test_auxiliary_time(self, operation, serialized):
+        """An auxiliary time envelope survives planning on its distance dimension."""
+        start = np.datetime64("2024-01-01", "ns")
+        patches = [
+            dc.Patch(
+                data=np.arange(offset, offset + 4),
+                coords={
+                    "distance": np.arange(offset, offset + 4),
+                    "time": (
+                        "distance",
+                        start + np.arange(offset, offset + 4) * np.timedelta64(1, "s"),
+                    ),
+                },
+                dims=("distance",),
+            )
+            for offset in (0, 4)
+        ]
+        spool = getattr(dc.spool(patches), operation)(distance=None, conflict="drop")
+        if serialized:
+            spool = pickle.loads(pickle.dumps(spool))
+        selected = spool.select(time=(start + np.timedelta64(6, "s"), None))
+        assert len(selected) == 1
+        assert np.array_equal(selected[0].data, [6, 7])
+
+    @pytest.mark.parametrize("duration", [False, True])
+    @pytest.mark.parametrize("serialized", [False, True])
+    def test_non_absolute_plan(self, duration, serialized):
+        """Numeric and duration plans never become absolute-time candidates."""
+        values = np.arange(4)
+        if duration:
+            values = values * np.timedelta64(1, "s")
+        patch = dc.Patch(data=np.arange(4), coords={"time": values}, dims=("time",))
+        spool = dc.spool([patch]).chunk(time=None)
+        if serialized:
+            spool = pickle.loads(pickle.dumps(spool))
+        assert len(spool.select(time=(None, np.datetime64("2024-01-01")))) == 0
+
+    @pytest.mark.parametrize("duration", [False, True])
+    @pytest.mark.parametrize("serialized", [False, True])
+    def test_non_absolute_sort(self, duration, serialized):
+        """Clearing absolute-time caches preserves numeric and duration ordering."""
+        patches = []
+        for offset in (10, 0):
+            values = np.arange(offset, offset + 4)
+            if duration:
+                values = values * np.timedelta64(1, "s")
+            patches.append(
+                dc.Patch(data=np.arange(4), coords={"time": values}, dims=("time",))
+            )
+        spool = dc.spool(patches).concatenate(time=1)
+        if serialized:
+            spool = pickle.loads(pickle.dumps(spool))
+        ordered = spool.sort("time")
+        expected = [patch.coords.get_coord("time").min() for patch in patches]
+        assert list(ordered.get_contents()["time_min"]) == sorted(expected)
+
+    def test_rebuilt_record_bounds(self, time_backend):
+        """Re-ingesting legacy records derives cached bounds from their coordinates."""
+        records = time_backend.export_records()
+        records = [
+            replace(
+                record,
+                patches=tuple(
+                    replace(patch, time_min=0, time_max=3, time_step=1)
+                    for patch in record.patches
+                ),
+            )
+            for record in records
+        ]
+        time_backend.write_sources(records)
+        bounds = (None, np.datetime64("2025-01-01"))
+        assert (
+            time_backend.count(Query(coords={"time": bounds}))
+            == time_backend.count(Query(coords={"reference_time": bounds}))
+            == 2
+        )


### PR DESCRIPTION
## Description

Absolute-time selections currently find overlapping patches through the general coordinate tables, although each patch already stores the same nanosecond time bounds. This change uses those bounds directly for eligible queries. Database writes derive the cached bounds from coordinate records, so auxiliary coordinates in planned outputs are included and duration/numeric coordinates cannot become absolute-time candidates. Nonabsolute time coordinates still sort by their coordinate minima after absolute times. Other coordinate kinds keep their existing query path, and loaded patches still receive exact trimming. It requires no schema changes, new indexes, duplicated metadata, or additional caches.

On 50,000 synthetic patch records without an additional index, median backend count time changed from roughly 29 milliseconds to 18–21 milliseconds across early, middle, and late time windows. These measurements include query setup and exclude waveform reads. Tests compare projection, membership, and counts against the general coordinate path across absolute, relative, numeric, string, and missing coordinates.

Validation: full suite and coverage run each passed with 11,445 tests passed, 149 skipped, and 2 expected failures; all 224 doctests passed. Full-repository pre-commit passed twice. API documentation generation and the full Quarto site build passed. Regression coverage includes auxiliary coordinates, planned outputs, numeric/duration ordering, and pickle round trips.

## Changelog

- changed: Absolute-time spool selections use the existing patch time bounds to reduce metadata query work.
- fixed: Planned spool time bounds consistently describe absolute-time coordinates, including auxiliary time coordinates.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved absolute-time range queries for faster and more consistent patch matching.
  - Enhanced time-based sorting across datasets containing absolute, relative, or numeric time coordinates.
  - Preserved time-query behavior for planned outputs, rebuilt records, chunked data, concatenated data, and serialized catalogs.

- **Documentation**
  - Added guidance explaining time-range query behavior, precision, and compatibility with other coordinate query types.

- **Tests**
  - Expanded coverage for time queries, filtering, sorting, date inputs, and catalog compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->