### PR TITLE
Put the patch methods on a DataArray under .dc

### DIFF
--- a/dascore/xarray/accessor.py
+++ b/dascore/xarray/accessor.py
@@ -68,6 +68,11 @@ def _guarded(call: Callable, name: str, size: int):
     stops the conversion rather than reporting it afterwards. An
     operation which stays on the array's own backend never warns and is
     never stopped.
+
+    Any such warning during the call is taken to be about this array,
+    including one from a callback the caller passed in. Refusing an
+    operation which would have fit is the safe way to be wrong here,
+    and the message says which array was judged too large.
     """
     with warnings.catch_warnings():
         warnings.simplefilter("error", NumpyFallbackWarning)
@@ -96,8 +101,12 @@ class _PatchMethods:
 
     A dask-backed DataArray is passed through as it stands, so a method
     which works on the array's own backend leaves it lazy. One which
-    cannot warns and converts, as it does on a patch, unless the array
-    is too large for memory, in which case it raises instead of trying.
+    cannot warns and converts, as it does on a patch, and where it
+    announces that conversion and the array is larger than free memory
+    the warning is raised instead, so the conversion never starts. A
+    method which converts silently, without announcing it, is not
+    caught: it materializes the array as it would on a patch, and fails
+    on memory the same way.
     """
 
     def __init__(self, data_array):
@@ -105,15 +114,23 @@ class _PatchMethods:
 
     def __getattr__(self, name: str) -> Any:
         """Forward one name to the patch this DataArray describes."""
-        if name.startswith("_") or not hasattr(dc.Patch, name):
-            msg = f"Neither this accessor nor a Patch has an attribute {name!r}."
+        if name.startswith("_"):
+            msg = f"The accessor forwards a patch's public names, not {name!r}."
             raise AttributeError(msg)
         patch = xarray_to_patch(self._data_array)
-        value = getattr(patch, name)
+        try:
+            # asked of the patch, not of its class, so a namespace the
+            # patch resolves for itself is reachable and a name only its
+            # class has is not
+            value = getattr(patch, name)
+        except AttributeError as error:
+            msg = f"Neither this accessor nor a Patch has an attribute {name!r}."
+            raise AttributeError(msg) from error
         if not callable(value):
-            # a property states something about the patch; there is no
-            # call to convert arguments for, and no patch to convert back
-            return value
+            # a property states something about the patch, so there is no
+            # call to convert arguments for; a patch it states is still a
+            # patch, and comes back as the DataArray it describes
+            return _as_xarray(value)
         return self._method(patch, value, name)
 
     def _method(self, patch, bound: Callable, name: str) -> Callable:
@@ -131,8 +148,16 @@ class _PatchMethods:
         return call
 
     def __dir__(self) -> list[str]:
-        """Offer the patch's own names, so completion finds them."""
-        return sorted(x for x in dir(dc.Patch) if not x.startswith("_"))
+        """
+        Offer the patch's own names, so completion finds them.
+
+        A namespace is resolved when it is asked for rather than being
+        an attribute, so `dir` does not report one; the patch says which
+        it has, and they are as reachable here as any method.
+        """
+        patch = xarray_to_patch(self._data_array)
+        names = set(dir(patch)) | set(patch.get_registered_namespaces())
+        return sorted(x for x in names if not x.startswith("_"))
 
     def __repr__(self) -> str:
         """Say what this is and what it wraps."""

--- a/dascore/xarray/accessor.py
+++ b/dascore/xarray/accessor.py
@@ -64,6 +64,44 @@ def _largest_to_materialize(values) -> int | None:
     return max(found) if found else None
 
 
+def _lazily_served(data_array) -> set[str]:
+    """The coordinates this DataArray states rather than stores."""
+    indexes = getattr(data_array, "xindexes", {})
+    return {
+        name
+        for name, index in indexes.items()
+        if hasattr(getattr(index, "transform", None), "start_ns")
+    }
+
+
+def _serve_lazily(out, names: set[str]):
+    """
+    Put back the lazy index on coordinates which arrived with one.
+
+    Whether a coordinate is spelled out belongs to the object, not to
+    the conversion: an ordinary DataArray keeps the eager index its
+    arithmetic aligns on, and one from a tree keeps the lazy index which
+    is why a long acquisition costs nothing to label. The result's own
+    coordinate is what is served, so a method which moved it is served
+    where it now is.
+    """
+    from dascore.xarray.spool import _lazy_temporal_index  # noqa: PLC0415
+
+    xr = optional_import("xarray")
+    if not names or not isinstance(out, xr.DataArray):
+        return out
+    patch = None
+    for name in names & set(out.coords):
+        # a lazy index is built for a dimension, so a coordinate served by
+        # one defines the dimension it is named for
+        assert out.coords[name].dims == (name,), "a lazy index names its dimension"
+        patch = xarray_to_patch(out) if patch is None else patch
+        index = _lazy_temporal_index(name, patch.coords.coord_map[name])
+        if index is not None:
+            out = out.drop_vars(name).assign_coords(xr.Coordinates.from_xindex(index))
+    return out
+
+
 def _as_patch(value):
     """A DataArray as the patch it describes; anything else unchanged."""
     xr = optional_import("xarray")
@@ -146,11 +184,12 @@ class _PatchMethods:
             # a property states something about the patch, so there is no
             # call to convert arguments for; a patch it states is still a
             # patch, and comes back as the DataArray it describes
-            return _as_xarray(value)
+            return _serve_lazily(_as_xarray(value), _lazily_served(self._data_array))
         return self._method(patch, value, name)
 
     def _method(self, patch, bound: Callable, name: str) -> Callable:
         """Wrap one patch method so it takes and returns DataArrays."""
+        lazy = _lazily_served(self._data_array)
 
         @functools.wraps(bound)
         def call(*args, **kwargs):
@@ -162,7 +201,7 @@ class _PatchMethods:
             patches = [patch, *(x for x in (*args, *kwargs.values()))]
             size = _largest_to_materialize(patches)
             out = run() if size is None else _guarded(run, name, size)
-            return _as_xarray(out)
+            return _serve_lazily(_as_xarray(out), lazy)
 
         # `add` and its kind are objects with methods of their own
         # (`reduce`, `accumulate`); wrapping the call must not hide them
@@ -180,7 +219,8 @@ class _PatchMethods:
         it has, and they are as reachable here as any method.
         """
         patch = xarray_to_patch(self._data_array)
-        names = set(dir(patch)) | set(patch.get_registered_namespaces())
+        own = {x for x in vars(type(self)) if not x.startswith("_")}
+        names = set(dir(patch)) | set(patch.get_registered_namespaces()) | own
         return sorted(x for x in names if not x.startswith("_"))
 
     def __repr__(self) -> str:

--- a/dascore/xarray/accessor.py
+++ b/dascore/xarray/accessor.py
@@ -49,6 +49,21 @@ def _too_large_to_materialize(data) -> int | None:
     return int(size) if int(size) > available else None
 
 
+def _largest_to_materialize(values) -> int | None:
+    """
+    The size of the largest array in a call which would not fit, else None.
+
+    A conversion converts the arguments too, so an operation is refused
+    for an argument which will not fit just as it is for the patch it
+    is called on.
+    """
+    sizes = [
+        _too_large_to_materialize(x.data) for x in values if isinstance(x, dc.Patch)
+    ]
+    found = [x for x in sizes if x is not None]
+    return max(found) if found else None
+
+
 def _as_patch(value):
     """A DataArray as the patch it describes; anything else unchanged."""
     xr = optional_import("xarray")
@@ -142,10 +157,18 @@ class _PatchMethods:
             args = tuple(_as_patch(x) for x in args)
             kwargs = {k: _as_patch(v) for k, v in kwargs.items()}
             run = functools.partial(bound, *args, **kwargs)
-            size = _too_large_to_materialize(patch.data)
+            # an argument can be the large one, so every patch in the
+            # call is weighed, not only the one being called on
+            patches = [patch, *(x for x in (*args, *kwargs.values()))]
+            size = _largest_to_materialize(patches)
             out = run() if size is None else _guarded(run, name, size)
             return _as_xarray(out)
 
+        # `add` and its kind are objects with methods of their own
+        # (`reduce`, `accumulate`); wrapping the call must not hide them
+        for extra in ("reduce", "accumulate", "outer", "at"):
+            if (nested := getattr(bound, extra, None)) is not None:
+                setattr(call, extra, self._method(patch, nested, extra))
         return call
 
     def __dir__(self) -> list[str]:

--- a/dascore/xarray/accessor.py
+++ b/dascore/xarray/accessor.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import functools
 import warnings
 from collections.abc import Callable
+from importlib.util import find_spec
 from typing import Any
 
 import dascore as dc
@@ -185,6 +186,9 @@ def register() -> None:
     xr.register_dataarray_accessor("dc")(_PatchMethods)
 
 
-register()
+# Importing this module must not require xarray -- everything which
+# walks the package imports it -- while registering plainly does.
+if find_spec("xarray") is not None:
+    register()
 
 __all__ = ["register"]

--- a/dascore/xarray/accessor.py
+++ b/dascore/xarray/accessor.py
@@ -64,13 +64,14 @@ def _largest_to_materialize(values) -> int | None:
     return max(found) if found else None
 
 
-def _serves_lazily(data_array) -> bool:
-    """Whether this DataArray states a coordinate rather than storing it."""
+def _lazily_served(data_array) -> set[str]:
+    """The coordinates this DataArray states rather than stores."""
     indexes = getattr(data_array, "xindexes", {})
-    return any(
-        hasattr(getattr(index, "transform", None), "start_ns")
-        for index in indexes.values()
-    )
+    return {
+        name
+        for name, index in indexes.items()
+        if hasattr(getattr(index, "transform", None), "start_ns")
+    }
 
 
 def _as_patch(value):
@@ -79,15 +80,20 @@ def _as_patch(value):
     return xarray_to_patch(value) if isinstance(value, xr.DataArray) else value
 
 
-def _as_xarray(value, lazy: bool):
+def _as_xarray(value, lazy: set[str]):
     """
     A patch as the DataArray it describes; anything else unchanged.
 
     Whether a coordinate is spelled out belongs to the object, not to
-    the conversion: an ordinary DataArray keeps the eager index its
-    arithmetic aligns on, and one whose coordinates arrived stated keeps
-    them stated. The conversion is told which, so a coordinate a tree
-    never spelled out is never spelled out on the way back either.
+    the conversion: a coordinate which arrived stated goes back stated,
+    and every other keeps the eager index xarray aligns arithmetic on --
+    including a temporal one beside it, which is why the coordinates are
+    named rather than the array being called lazy as a whole. The
+    conversion is told which names, so one a tree never spelled out is
+    not spelled out on the way back either.
+
+    Laziness follows the name: a method which renames a coordinate
+    spells it out under its new name.
     """
     if not isinstance(value, dc.Patch):
         return value
@@ -165,12 +171,12 @@ class _PatchMethods:
             # a property states something about the patch, so there is no
             # call to convert arguments for; a patch it states is still a
             # patch, and comes back as the DataArray it describes
-            return _as_xarray(value, _serves_lazily(self._data_array))
+            return _as_xarray(value, _lazily_served(self._data_array))
         return self._method(patch, value, name)
 
     def _method(self, patch, bound: Callable, name: str) -> Callable:
         """Wrap one patch method so it takes and returns DataArrays."""
-        lazy = _serves_lazily(self._data_array)
+        lazy = _lazily_served(self._data_array)
 
         @functools.wraps(bound)
         def call(*args, **kwargs):

--- a/dascore/xarray/accessor.py
+++ b/dascore/xarray/accessor.py
@@ -64,42 +64,13 @@ def _largest_to_materialize(values) -> int | None:
     return max(found) if found else None
 
 
-def _lazily_served(data_array) -> set[str]:
-    """The coordinates this DataArray states rather than stores."""
+def _serves_lazily(data_array) -> bool:
+    """Whether this DataArray states a coordinate rather than storing it."""
     indexes = getattr(data_array, "xindexes", {})
-    return {
-        name
-        for name, index in indexes.items()
-        if hasattr(getattr(index, "transform", None), "start_ns")
-    }
-
-
-def _serve_lazily(out, names: set[str]):
-    """
-    Put back the lazy index on coordinates which arrived with one.
-
-    Whether a coordinate is spelled out belongs to the object, not to
-    the conversion: an ordinary DataArray keeps the eager index its
-    arithmetic aligns on, and one from a tree keeps the lazy index which
-    is why a long acquisition costs nothing to label. The result's own
-    coordinate is what is served, so a method which moved it is served
-    where it now is.
-    """
-    from dascore.xarray.spool import _lazy_temporal_index  # noqa: PLC0415
-
-    xr = optional_import("xarray")
-    if not names or not isinstance(out, xr.DataArray):
-        return out
-    patch = None
-    for name in names & set(out.coords):
-        # a lazy index is built for a dimension, so a coordinate served by
-        # one defines the dimension it is named for
-        assert out.coords[name].dims == (name,), "a lazy index names its dimension"
-        patch = xarray_to_patch(out) if patch is None else patch
-        index = _lazy_temporal_index(name, patch.coords.coord_map[name])
-        if index is not None:
-            out = out.drop_vars(name).assign_coords(xr.Coordinates.from_xindex(index))
-    return out
+    return any(
+        hasattr(getattr(index, "transform", None), "start_ns")
+        for index in indexes.values()
+    )
 
 
 def _as_patch(value):
@@ -108,9 +79,19 @@ def _as_patch(value):
     return xarray_to_patch(value) if isinstance(value, xr.DataArray) else value
 
 
-def _as_xarray(value):
-    """A patch as the DataArray it describes; anything else unchanged."""
-    return patch_to_xarray(value) if isinstance(value, dc.Patch) else value
+def _as_xarray(value, lazy: bool):
+    """
+    A patch as the DataArray it describes; anything else unchanged.
+
+    Whether a coordinate is spelled out belongs to the object, not to
+    the conversion: an ordinary DataArray keeps the eager index its
+    arithmetic aligns on, and one whose coordinates arrived stated keeps
+    them stated. The conversion is told which, so a coordinate a tree
+    never spelled out is never spelled out on the way back either.
+    """
+    if not isinstance(value, dc.Patch):
+        return value
+    return patch_to_xarray(value, lazy_coords=lazy)
 
 
 def _guarded(call: Callable, name: str, size: int):
@@ -184,12 +165,12 @@ class _PatchMethods:
             # a property states something about the patch, so there is no
             # call to convert arguments for; a patch it states is still a
             # patch, and comes back as the DataArray it describes
-            return _serve_lazily(_as_xarray(value), _lazily_served(self._data_array))
+            return _as_xarray(value, _serves_lazily(self._data_array))
         return self._method(patch, value, name)
 
     def _method(self, patch, bound: Callable, name: str) -> Callable:
         """Wrap one patch method so it takes and returns DataArrays."""
-        lazy = _lazily_served(self._data_array)
+        lazy = _serves_lazily(self._data_array)
 
         @functools.wraps(bound)
         def call(*args, **kwargs):
@@ -201,7 +182,7 @@ class _PatchMethods:
             patches = [patch, *(x for x in (*args, *kwargs.values()))]
             size = _largest_to_materialize(patches)
             out = run() if size is None else _guarded(run, name, size)
-            return _serve_lazily(_as_xarray(out), lazy)
+            return _as_xarray(out, lazy)
 
         # `add` and its kind are objects with methods of their own
         # (`reduce`, `accumulate`); wrapping the call must not hide them

--- a/dascore/xarray/accessor.py
+++ b/dascore/xarray/accessor.py
@@ -64,14 +64,32 @@ def _largest_to_materialize(values) -> int | None:
     return max(found) if found else None
 
 
-def _lazily_served(data_array) -> set[str]:
-    """The coordinates this DataArray states rather than stores."""
-    indexes = getattr(data_array, "xindexes", {})
-    return {
-        name
-        for name, index in indexes.items()
-        if hasattr(getattr(index, "transform", None), "start_ns")
-    }
+def _stated_coords(*values) -> set[str]:
+    """
+    Which coordinates a call's result states rather than spells out.
+
+    Every DataArray in the call says how its own coordinates arrived, an
+    argument as much as the one called on: an array with no time
+    coordinate added to one spanning a long acquisition takes that
+    coordinate, so it is the argument which says the coordinate arrived
+    stated. A name which arrived spelled out anywhere is spelled out in
+    the result -- a spelled-out index is what xarray aligns on, and one
+    participant having stated the coordinate is no reason to take that
+    away from the rest, whichever of the two is called on.
+    """
+    xr = optional_import("xarray")
+    stated, spelled_out = set(), set()
+    for value in values:
+        if not isinstance(value, xr.DataArray):
+            continue
+        names = {
+            name
+            for name, index in value.xindexes.items()
+            if hasattr(getattr(index, "transform", None), "start_ns")
+        }
+        stated.update(names)
+        spelled_out.update(set(value.xindexes) - names)
+    return stated - spelled_out
 
 
 def _as_patch(value):
@@ -171,15 +189,15 @@ class _PatchMethods:
             # a property states something about the patch, so there is no
             # call to convert arguments for; a patch it states is still a
             # patch, and comes back as the DataArray it describes
-            return _as_xarray(value, _lazily_served(self._data_array))
+            return _as_xarray(value, _stated_coords(self._data_array))
         return self._method(patch, value, name)
 
     def _method(self, patch, bound: Callable, name: str) -> Callable:
         """Wrap one patch method so it takes and returns DataArrays."""
-        lazy = _lazily_served(self._data_array)
 
         @functools.wraps(bound)
         def call(*args, **kwargs):
+            lazy = _stated_coords(self._data_array, *args, *kwargs.values())
             args = tuple(_as_patch(x) for x in args)
             kwargs = {k: _as_patch(v) for k, v in kwargs.items()}
             run = functools.partial(bound, *args, **kwargs)

--- a/dascore/xarray/accessor.py
+++ b/dascore/xarray/accessor.py
@@ -1,0 +1,165 @@
+"""
+The ``.dc`` accessor: DASCore's patch methods on an xarray DataArray.
+
+Importing this module registers the accessor. `patch_to_xarray` and
+`spool_to_xarray` import it themselves, so anything DASCore hands back
+already carries it; a DataArray from anywhere else needs
+``import dascore.xarray.accessor`` first, since registering it means
+importing xarray, which DASCore does not do on its own.
+"""
+
+from __future__ import annotations
+
+import functools
+import warnings
+from collections.abc import Callable
+from typing import Any
+
+import dascore as dc
+from dascore.exceptions import PatchConversionError
+from dascore.utils.array_api import is_foreign
+from dascore.utils.misc import optional_import
+from dascore.warnings import NumpyFallbackWarning
+from dascore.xarray.patch import patch_to_xarray, xarray_to_patch
+
+# What is left of memory before an operation which cannot stay lazy is
+# refused rather than attempted. Materializing an array is not the only
+# thing holding memory, so the whole of what is free is not available.
+_MEMORY_HEADROOM = 0.8
+
+
+def _available_memory() -> int | None:
+    """Bytes a materialized array could use, or None if unknowable."""
+    try:  # psutil is not a dependency; the guard is skipped without it
+        psutil = optional_import("psutil")
+    except Exception:
+        return None
+    return int(psutil.virtual_memory().available * _MEMORY_HEADROOM)
+
+
+def _too_large_to_materialize(data) -> int | None:
+    """The size of an array which would not fit in memory, else None."""
+    if not is_foreign(data):
+        return None  # already in memory, so materializing costs nothing
+    size = getattr(data, "nbytes", None)
+    available = _available_memory()
+    if size is None or available is None:
+        return None
+    return int(size) if int(size) > available else None
+
+
+def _as_patch(value):
+    """A DataArray as the patch it describes; anything else unchanged."""
+    xr = optional_import("xarray")
+    return xarray_to_patch(value) if isinstance(value, xr.DataArray) else value
+
+
+def _as_xarray(value):
+    """A patch as the DataArray it describes; anything else unchanged."""
+    return patch_to_xarray(value) if isinstance(value, dc.Patch) else value
+
+
+def _guarded(call: Callable, name: str, size: int):
+    """
+    Run ``call``, refusing to materialize an array which will not fit.
+
+    An operation which cannot work on the array as it stands says so by
+    warning before it converts anything, so raising on that warning
+    stops the conversion rather than reporting it afterwards. An
+    operation which stays on the array's own backend never warns and is
+    never stopped.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", NumpyFallbackWarning)
+        try:
+            return call()
+        except NumpyFallbackWarning as error:
+            msg = (
+                f"'{name}' cannot work on this array without converting it "
+                f"to NumPy, and its {size:,} bytes exceed what memory has "
+                "free. Select a smaller part of it, or compute it yourself "
+                "if the estimate is wrong."
+            )
+            raise PatchConversionError(msg) from error
+
+
+class _PatchMethods:
+    """
+    DASCore's patch methods, on a DataArray.
+
+    Every public name a `Patch` has is reachable here. A call converts
+    the DataArray to a patch, runs the method, and converts a patch it
+    returns back to a DataArray; a result which is not a patch -- an
+    array, a spool, a figure -- comes back as it is. Arguments are
+    converted the same way, so a method taking another patch takes
+    another DataArray here.
+
+    A dask-backed DataArray is passed through as it stands, so a method
+    which works on the array's own backend leaves it lazy. One which
+    cannot warns and converts, as it does on a patch, unless the array
+    is too large for memory, in which case it raises instead of trying.
+    """
+
+    def __init__(self, data_array):
+        self._data_array = data_array
+
+    def __getattr__(self, name: str) -> Any:
+        """Forward one name to the patch this DataArray describes."""
+        if name.startswith("_") or not hasattr(dc.Patch, name):
+            msg = f"Neither this accessor nor a Patch has an attribute {name!r}."
+            raise AttributeError(msg)
+        patch = xarray_to_patch(self._data_array)
+        value = getattr(patch, name)
+        if not callable(value):
+            # a property states something about the patch; there is no
+            # call to convert arguments for, and no patch to convert back
+            return value
+        return self._method(patch, value, name)
+
+    def _method(self, patch, bound: Callable, name: str) -> Callable:
+        """Wrap one patch method so it takes and returns DataArrays."""
+
+        @functools.wraps(bound)
+        def call(*args, **kwargs):
+            args = tuple(_as_patch(x) for x in args)
+            kwargs = {k: _as_patch(v) for k, v in kwargs.items()}
+            run = functools.partial(bound, *args, **kwargs)
+            size = _too_large_to_materialize(patch.data)
+            out = run() if size is None else _guarded(run, name, size)
+            return _as_xarray(out)
+
+        return call
+
+    def __dir__(self) -> list[str]:
+        """Offer the patch's own names, so completion finds them."""
+        return sorted(x for x in dir(dc.Patch) if not x.startswith("_"))
+
+    def __repr__(self) -> str:
+        """Say what this is and what it wraps."""
+        shape = "x".join(str(x) for x in self._data_array.shape)
+        return f"DASCore patch methods on a {shape} DataArray"
+
+    def to_patch(self) -> dc.Patch:
+        """Return the patch this DataArray describes."""
+        return xarray_to_patch(self._data_array)
+
+
+def register() -> None:
+    """
+    Register the ``.dc`` accessor on ``xarray.DataArray``.
+
+    Registering what is already registered only warns about replacing
+    it, so a second call is skipped; anything else holding the name is
+    left alone to warn, since that is a collision worth hearing about.
+    """
+    xr = optional_import("xarray")
+    # A patch is one array, so a DataArray is what it maps onto; a
+    # Dataset holding several has no single patch to be.
+    if getattr(xr.DataArray, "dc", None) is _PatchMethods:
+        return
+    xr.register_dataarray_accessor("dc")(_PatchMethods)
+
+
+register()
+
+__all__ = ["register"]

--- a/dascore/xarray/accessor.py
+++ b/dascore/xarray/accessor.py
@@ -57,9 +57,9 @@ def _largest_to_materialize(values) -> int | None:
     for an argument which will not fit just as it is for the patch it
     is called on.
     """
-    sizes = [
-        _too_large_to_materialize(x.data) for x in values if isinstance(x, dc.Patch)
-    ]
+    # a bare array is converted like a patch's data, so it weighs the same
+    arrays = (x.data if isinstance(x, dc.Patch) else x for x in values)
+    sizes = [_too_large_to_materialize(x) for x in arrays]
     found = [x for x in sizes if x is not None]
     return max(found) if found else None
 

--- a/dascore/xarray/patch.py
+++ b/dascore/xarray/patch.py
@@ -7,9 +7,20 @@ from dascore.constants import PatchType
 from dascore.utils.misc import optional_import
 
 
+def _register_accessor() -> None:
+    """Put the `.dc` accessor on what DASCore hands back.
+
+    Registering it means importing xarray, which DASCore will not do on
+    its own; here xarray is already imported, so anything converted
+    carries the accessor without a user asking for it.
+    """
+    from dascore.xarray import accessor  # noqa: F401, PLC0415
+
+
 def patch_to_xarray(patch: PatchType):
     """Return a data array with patch contents."""
     xr = optional_import("xarray")
+    _register_accessor()
     # Omit None-valued attrs because xarray backends may reject them during
     # NetCDF serialization, while a missing attr round-trips cleanly.
     attrs = {

--- a/dascore/xarray/patch.py
+++ b/dascore/xarray/patch.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Collection
+
 import numpy as np
 import pandas as pd
 
@@ -47,7 +49,7 @@ def _lazy_temporal_index(name, coord):
     return TemporalRangeIndex.from_coord(name, coord)
 
 
-def patch_to_xarray(patch: PatchType, lazy_coords: bool = False):
+def patch_to_xarray(patch: PatchType, lazy_coords: Collection[str] = ()):
     """
     Return a data array with patch contents.
 
@@ -56,13 +58,15 @@ def patch_to_xarray(patch: PatchType, lazy_coords: bool = False):
     patch
         The patch to convert.
     lazy_coords
-        If True, serve each evenly sampled temporal dimension coordinate
-        by the range which states it rather than by an array of every
-        label. Such a coordinate then costs three numbers however long
-        the acquisition, and its labels are computed on demand. The
-        default spells the labels out, which is what xarray aligns
-        arithmetic on; see `dascore.xarray.index.TemporalRangeIndex` for
-        what a lazily served coordinate does not yet support.
+        Names of coordinates to serve by the range which states them
+        rather than by an array of every label. Such a coordinate then
+        costs three numbers however long the acquisition, and its labels
+        are computed on demand. A name which does not belong to an
+        evenly sampled temporal dimension coordinate of this patch is
+        ignored; anything not named spells its labels out, which is what
+        xarray aligns arithmetic on. See
+        `dascore.xarray.index.TemporalRangeIndex` for what a lazily
+        served coordinate does not yet support.
 
     Notes
     -----
@@ -86,7 +90,7 @@ def patch_to_xarray(patch: PatchType, lazy_coords: bool = False):
         # An index labels a dimension, so only a coordinate which defines
         # one can be served by it; a coordinate merely riding a dimension
         # states its values as any other does.
-        if lazy_coords and dims == (name,):
+        if name in lazy_coords and dims == (name,):
             if (index := _lazy_temporal_index(name, coord)) is not None:
                 lazy.append(index)
                 continue

--- a/dascore/xarray/patch.py
+++ b/dascore/xarray/patch.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pandas as pd
 
 import dascore as dc
 from dascore.constants import PatchType
@@ -20,8 +21,55 @@ def _register_accessor() -> None:
     from dascore.xarray import accessor  # noqa: F401, PLC0415
 
 
-def patch_to_xarray(patch: PatchType):
-    """Return a data array with patch contents."""
+def _lazy_temporal_index(name, coord):
+    """
+    Return a lazy xarray index for an evenly sampled temporal coordinate.
+
+    None when the coordinate cannot be served lazily — an irregular
+    (segmented or array) coordinate, a descending one, or a numeric one,
+    whose materialized values are short in practice.
+    """
+    from dascore.core.coords import CoordRange  # noqa: PLC0415
+
+    step = getattr(coord, "step", None)
+    if not isinstance(coord, CoordRange) or step is None or pd.isnull(step):
+        return None
+    if not (
+        np.issubdtype(coord.dtype, np.datetime64)
+        or np.issubdtype(coord.dtype, np.timedelta64)
+    ):
+        return None
+    if np.asarray(step).astype("int64") <= 0:
+        return None
+    # function-level: xarray is an optional dependency
+    from dascore.xarray.index import TemporalRangeIndex  # noqa: PLC0415
+
+    return TemporalRangeIndex.from_coord(name, coord)
+
+
+def patch_to_xarray(patch: PatchType, lazy_coords: bool = False):
+    """
+    Return a data array with patch contents.
+
+    Parameters
+    ----------
+    patch
+        The patch to convert.
+    lazy_coords
+        If True, serve each evenly sampled temporal dimension coordinate
+        by the range which states it rather than by an array of every
+        label. Such a coordinate then costs three numbers however long
+        the acquisition, and its labels are computed on demand. The
+        default spells the labels out, which is what xarray aligns
+        arithmetic on; see `dascore.xarray.index.TemporalRangeIndex` for
+        what a lazily served coordinate does not yet support.
+
+    Notes
+    -----
+    A DataArray states a coordinate by its labels, so a coordinate of a
+    single sample cannot say how far apart its samples would be: such a
+    step is lost unless the coordinate is served lazily, which states it.
+    """
     xr = optional_import("xarray")
     _register_accessor()
     # Omit None-valued attrs because xarray backends may reject them during
@@ -30,11 +78,18 @@ def patch_to_xarray(patch: PatchType):
         key: value for key, value in dict(patch.attrs).items() if value is not None
     }
     patch_dims = patch.dims
-    coords, units = {}, {}
+    coords, units, lazy = {}, {}, []
     for name, coord in patch.coords.coord_map.items():
         if coord._partial:
             continue
         dims = patch.coords.dim_map[name]
+        # An index labels a dimension, so only a coordinate which defines
+        # one can be served by it; a coordinate merely riding a dimension
+        # states its values as any other does.
+        if lazy_coords and dims == (name,):
+            if (index := _lazy_temporal_index(name, coord)) is not None:
+                lazy.append(index)
+                continue
         if coord.units is not None and not _is_temporal(coord.dtype):
             # a coordinate's units are its own; xarray states them the
             # way the CF conventions do, as an attribute beside it.
@@ -44,6 +99,8 @@ def patch_to_xarray(patch: PatchType):
         coords[name] = (dims, coord.values)
     # Need to exclude non-coords
     out = xr.DataArray(patch.data, attrs=attrs, dims=patch_dims, coords=coords)
+    for index in lazy:
+        out = out.assign_coords(xr.Coordinates.from_xindex(index))
     for name, value in units.items():
         out.coords[name].attrs["units"] = value
     return out

--- a/dascore/xarray/patch.py
+++ b/dascore/xarray/patch.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import numpy as np
+
 import dascore as dc
 from dascore.constants import PatchType
+from dascore.core.coords import get_coord
 from dascore.utils.misc import optional_import
 
 
@@ -43,8 +46,28 @@ def xarray_to_patch(data_array) -> dc.Patch:
     _ = optional_import("xarray")
 
     return dc.Patch(
-        coords={i: (x.dims, x.values) for i, x in data_array.coords.items()},
+        coords={i: _coord_from(data_array, i, x) for i, x in data_array.coords.items()},
         attrs=dict(data_array.attrs.items()),
         dims=data_array.dims,
         data=data_array.data,
     )
+
+
+def _coord_from(data_array, name, coord):
+    """
+    The dims and values a patch coordinate is built from.
+
+    A lazily indexed coordinate states its samples rather than storing
+    them, and reading its values would spell out every one -- which for
+    a tree spanning a long acquisition is what the lazy index exists to
+    avoid. The range it describes rebuilds the same coordinate from
+    three numbers.
+    """
+    index = data_array.xindexes.get(name)
+    transform = getattr(index, "transform", None)
+    if transform is not None and hasattr(transform, "start_ns"):
+        start = np.asarray(transform.start_ns).astype(transform.dtype)
+        step = np.asarray(transform.step_ns).astype("timedelta64[ns]")
+        size = transform.dim_size[name]
+        return coord.dims, get_coord(start=start, step=step, stop=start + step * size)
+    return coord.dims, coord.values

--- a/dascore/xarray/patch.py
+++ b/dascore/xarray/patch.py
@@ -30,14 +30,45 @@ def patch_to_xarray(patch: PatchType):
         key: value for key, value in dict(patch.attrs).items() if value is not None
     }
     patch_dims = patch.dims
-    coords = {}
+    coords, lazy, units = {}, {}, {}
     for name, coord in patch.coords.coord_map.items():
         if coord._partial:
             continue
         dims = patch.coords.dim_map[name]
-        coords[name] = (dims, coord.values)
+        if coord.units is not None and not _is_temporal(coord.dtype):
+            # a coordinate's units are its own; xarray states them the
+            # way the CF conventions do, as an attribute beside it.
+            # A datetime says its units in its dtype, and xarray spends
+            # that same attribute on saying how to serialize it.
+            units[name] = str(coord.units)
+        index = _lazy_index(name, coord)
+        if index is None:
+            coords[name] = (dims, coord.values)
+        else:
+            # spelling this one out is what the lazy index avoids
+            lazy[name] = index
     # Need to exclude non-coords
-    return xr.DataArray(patch.data, attrs=attrs, dims=patch_dims, coords=coords)
+    out = xr.DataArray(patch.data, attrs=attrs, dims=patch_dims, coords=coords)
+    for name, value in units.items():
+        if name in out.coords:
+            out.coords[name].attrs["units"] = value
+    for index in lazy.values():
+        # only a temporal coordinate is served lazily, and one states its
+        # units in its dtype, so none of these carries a units attribute
+        out = out.assign_coords(xr.Coordinates.from_xindex(index))
+    return out
+
+
+def _is_temporal(dtype) -> bool:
+    """Whether a dtype states its own units, as a time or a duration does."""
+    return np.issubdtype(dtype, np.datetime64) or np.issubdtype(dtype, np.timedelta64)
+
+
+def _lazy_index(name, coord):
+    """The lazy xarray index a coordinate can be served by, or None."""
+    from dascore.xarray.spool import _lazy_temporal_index  # noqa: PLC0415
+
+    return _lazy_temporal_index(name, coord)
 
 
 def xarray_to_patch(data_array) -> dc.Patch:
@@ -65,9 +96,21 @@ def _coord_from(data_array, name, coord):
     """
     index = data_array.xindexes.get(name)
     transform = getattr(index, "transform", None)
-    if transform is not None and hasattr(transform, "start_ns"):
-        start = np.asarray(transform.start_ns).astype(transform.dtype)
-        step = np.asarray(transform.step_ns).astype("timedelta64[ns]")
-        size = transform.dim_size[name]
-        return coord.dims, get_coord(start=start, step=step, stop=start + step * size)
-    return coord.dims, coord.values
+    units = coord.attrs.get("units")
+    size = None if transform is None else transform.dim_size.get(name)
+    # A range needs somewhere to go: a selection which kept no samples
+    # has no start, step and stop to be rebuilt from, and its values are
+    # the empty array they say they are.
+    if transform is not None and hasattr(transform, "start_ns") and size:
+        # scalars, not zero-dimensional arrays: a coordinate's step is
+        # divided into and compared against, which an array shape breaks
+        start = np.asarray(transform.start_ns).astype(transform.dtype)[()]
+        step = np.timedelta64(int(transform.step_ns), "ns")
+        values = get_coord(
+            start=start, step=step, stop=start + step * size, units=units
+        )
+        return coord.dims, values
+    values = coord.values
+    if units is not None and not _is_temporal(values.dtype):
+        return coord.dims, get_coord(values=values, units=units)
+    return coord.dims, values

--- a/dascore/xarray/patch.py
+++ b/dascore/xarray/patch.py
@@ -30,7 +30,7 @@ def patch_to_xarray(patch: PatchType):
         key: value for key, value in dict(patch.attrs).items() if value is not None
     }
     patch_dims = patch.dims
-    coords, lazy, units = {}, {}, {}
+    coords, units = {}, {}
     for name, coord in patch.coords.coord_map.items():
         if coord._partial:
             continue
@@ -41,34 +41,17 @@ def patch_to_xarray(patch: PatchType):
             # A datetime says its units in its dtype, and xarray spends
             # that same attribute on saying how to serialize it.
             units[name] = str(coord.units)
-        index = _lazy_index(name, coord)
-        if index is None:
-            coords[name] = (dims, coord.values)
-        else:
-            # spelling this one out is what the lazy index avoids
-            lazy[name] = index
+        coords[name] = (dims, coord.values)
     # Need to exclude non-coords
     out = xr.DataArray(patch.data, attrs=attrs, dims=patch_dims, coords=coords)
     for name, value in units.items():
-        if name in out.coords:
-            out.coords[name].attrs["units"] = value
-    for index in lazy.values():
-        # only a temporal coordinate is served lazily, and one states its
-        # units in its dtype, so none of these carries a units attribute
-        out = out.assign_coords(xr.Coordinates.from_xindex(index))
+        out.coords[name].attrs["units"] = value
     return out
 
 
 def _is_temporal(dtype) -> bool:
     """Whether a dtype states its own units, as a time or a duration does."""
     return np.issubdtype(dtype, np.datetime64) or np.issubdtype(dtype, np.timedelta64)
-
-
-def _lazy_index(name, coord):
-    """The lazy xarray index a coordinate can be served by, or None."""
-    from dascore.xarray.spool import _lazy_temporal_index  # noqa: PLC0415
-
-    return _lazy_temporal_index(name, coord)
 
 
 def xarray_to_patch(data_array) -> dc.Patch:

--- a/dascore/xarray/spool.py
+++ b/dascore/xarray/spool.py
@@ -494,6 +494,10 @@ def spool_to_xarray(
     """
     xr = optional_import("xarray")
     da = optional_import("dask.array")
+    # the tree's arrays carry the `.dc` accessor, like any conversion
+    from dascore.xarray.patch import _register_accessor  # noqa: PLC0415
+
+    _register_accessor()
     if block_size is None:
         block_size = get_config().xarray_block_size
     if isinstance(block_size, str):

--- a/dascore/xarray/spool.py
+++ b/dascore/xarray/spool.py
@@ -22,6 +22,7 @@ from dascore.constants import SpoolType
 from dascore.exceptions import PatchConversionError
 from dascore.utils.misc import optional_import
 from dascore.utils.time import to_float
+from dascore.xarray.patch import _lazy_temporal_index
 
 
 def _np_scalar(value):
@@ -146,32 +147,6 @@ def _segment_chunks(members, block_size, dtype, sizes, dims, dim):
         pieces = _block_pieces(member.count, limit if splittable else None)
         along.extend(stop - start for start, stop in pieces)
     return tuple(tuple(along) if d == dim else (sizes[d],) for d in dims)
-
-
-def _lazy_temporal_index(name, coord):
-    """
-    Return a lazy xarray index for an evenly sampled temporal coordinate.
-
-    None when the coordinate cannot be served lazily — an irregular
-    (segmented or array) coordinate, a descending one, or a numeric one,
-    whose materialized values are short in practice.
-    """
-    from dascore.core.coords import CoordRange  # noqa: PLC0415
-
-    step = getattr(coord, "step", None)
-    if not isinstance(coord, CoordRange) or step is None or pd.isnull(step):
-        return None
-    if not (
-        np.issubdtype(coord.dtype, np.datetime64)
-        or np.issubdtype(coord.dtype, np.timedelta64)
-    ):
-        return None
-    if np.asarray(step).astype("int64") <= 0:
-        return None
-    # function-level: xarray is an optional dependency
-    from dascore.xarray.index import TemporalRangeIndex  # noqa: PLC0415
-
-    return TemporalRangeIndex.from_coord(name, coord)
 
 
 class _SegmentSource:

--- a/docs/recipes/external_conversion.qmd
+++ b/docs/recipes/external_conversion.qmd
@@ -64,6 +64,8 @@ A DataArray from somewhere else needs `import dascore.xarray.accessor` first, si
 
 A dask-backed DataArray is passed through as it stands, so a method which works on the array's own backend leaves it lazy. One which cannot converts, as it does on a patch. Where such a method announces that conversion, and the array is larger than free memory, the accessor raises rather than attempting it; a method which converts silently is not caught, and fails on memory as it would anywhere else.
 
+A coordinate a tree states rather than stores -- an evenly sampled time coordinate, whose labels are computed from its range on demand -- is stated again in what a method hands back, so labelling a long acquisition costs no more after a call than before it. Every DataArray in the call says how its own coordinates arrived, an argument as much as the one called on. A coordinate which arrived spelled out anywhere is spelled out in the result, since a spelled-out index is what xarray aligns on. Laziness follows the name, so a method which renames such a coordinate spells its labels out under the new name.
+
 ## [ObsPy](https://docs.obspy.org/)
 
 ```python

--- a/docs/recipes/external_conversion.qmd
+++ b/docs/recipes/external_conversion.qmd
@@ -46,6 +46,24 @@ small = first.dataset["data"].isel(time=slice(0, 100)).compute()
 
 A selection reads only the samples it names, however large the files behind it are. `block_size` bounds a bulk read instead: computing a whole segment asks for one block at a time, so a source patch larger than it is read in several windows rather than whole. Unset, it takes the configured `xarray_block_size` (256 MiB by default). A format which cannot hand back a window reads whole whatever the setting says, since splitting it would read the file once per block.
 
+### Patch methods on a DataArray
+
+A DataArray DASCore produced carries a `dc` accessor holding every public `Patch` method. A call converts to a patch, runs the method, and converts a patch it returns back; a result which is not a patch, such as an array or a spool, comes back as it is. A method taking another patch takes another DataArray.
+
+```python
+import dascore as dc
+
+dar = dc.get_example_patch().io.to_xarray()
+
+filtered = dar.dc.pass_filter(time=(1, 10))
+times = dar.dc.get_array("time")
+patch = dar.dc.to_patch()
+```
+
+A DataArray from somewhere else needs `import dascore.xarray.accessor` first, since registering the accessor means importing xarray, which DASCore does not do on its own.
+
+A dask-backed DataArray is passed through as it stands, so a method which works on the array's own backend leaves it lazy. One which cannot converts, as it does on a patch. Where such a method announces that conversion, and the array is larger than free memory, the accessor raises rather than attempting it; a method which converts silently is not caught, and fails on memory as it would anywhere else.
+
 ## [ObsPy](https://docs.obspy.org/)
 
 ```python

--- a/tests/test_xarray/test_xr_accessor.py
+++ b/tests/test_xarray/test_xr_accessor.py
@@ -9,6 +9,7 @@ import pytest
 
 import dascore as dc
 from dascore.exceptions import PatchConversionError
+from dascore.utils.misc import suppress_warnings
 from dascore.warnings import NumpyFallbackWarning
 
 # Importing the accessor registers it, which needs xarray; without it
@@ -99,6 +100,13 @@ class TestForwarding:
         with pytest.raises(AttributeError, match="mro"):
             data_array.dc.mro
 
+    def test_a_ufunc_keeps_the_methods_it_carries(self, patch, data_array):
+        """`add` and its kind are objects with `reduce` and `accumulate`."""
+        assert hasattr(data_array.dc.add, "reduce")
+        out = data_array.dc.add.reduce("time")
+        expected = patch.add.reduce("time")
+        assert np.allclose(out.values, expected.data)
+
     def test_a_name_no_patch_has(self, data_array):
         """The error names what was asked for, and where it was looked for."""
         with pytest.raises(AttributeError, match="not_a_patch_method"):
@@ -136,6 +144,44 @@ class TestLaziness:
         """Laziness is about when the work happens, not what it produces."""
         out = lazy_data_array.dc.abs().compute()
         assert np.array_equal(np.asarray(out.values), patch.abs().data)
+
+
+class TestLazyCoordinates:
+    """A coordinate the tree states rather than stores stays stated."""
+
+    @pytest.fixture()
+    def tree_leaf(self, random_spool):
+        """One segment of a tree, whose time coordinate is served lazily."""
+        pytest.importorskip("dask")
+        tree = random_spool.io.to_xarray()
+        return next(x for x in tree.subtree if "data" in x.dataset)["data"]
+
+    def test_the_index_is_lazy_to_begin_with(self, tree_leaf):
+        """Otherwise the test below would prove nothing."""
+        assert type(tree_leaf.xindexes["time"]).__name__ == "TemporalRangeIndex"
+
+    def test_converting_does_not_spell_out_the_labels(self, tree_leaf, monkeypatch):
+        """A range rebuilds from three numbers, not from every sample.
+
+        The labels are computed by the transform, so a conversion which
+        never calls it never built them. Asserting on the coordinate
+        which comes back would not show this: values spaced evenly infer
+        a range whether or not they were spelled out first.
+        """
+        from dascore.core.coords import CoordRange  # noqa: PLC0415
+        from dascore.xarray.index import TemporalRangeTransform  # noqa: PLC0415
+
+        def _refuse(self, dim_positions):
+            raise AssertionError("the labels were materialized")
+
+        monkeypatch.setattr(TemporalRangeTransform, "forward", _refuse)
+        coord = tree_leaf.dc.to_patch().get_coord("time")
+        assert isinstance(coord, CoordRange)
+
+    def test_the_coordinate_is_the_same_either_way(self, tree_leaf):
+        """Staying lazy must not change which samples it names."""
+        coord = tree_leaf.dc.to_patch().get_coord("time")
+        assert np.array_equal(coord.values, tree_leaf["time"].values)
 
 
 class TestMemoryLookAhead:
@@ -230,8 +276,7 @@ class TestMemoryLookAhead:
 
         self._announcing_method(monkeypatch)
         monkeypatch.setattr(accessor, "_available_memory", lambda: 10**12)
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", NumpyFallbackWarning)
+        with suppress_warnings(NumpyFallbackWarning):
             out = lazy_data_array.dc.announce_fallback()
         assert isinstance(out.values, np.ndarray)
 
@@ -241,9 +286,26 @@ class TestMemoryLookAhead:
 
         self._announcing_method(monkeypatch)
         monkeypatch.setattr(accessor, "_available_memory", lambda: 1)
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", NumpyFallbackWarning)
+        with suppress_warnings(NumpyFallbackWarning):
             assert data_array.dc.announce_fallback() is not None
+
+    def test_an_argument_too_large_refuses_the_call(
+        self, monkeypatch, data_array, lazy_data_array
+    ):
+        """A conversion converts the arguments, so they are weighed too."""
+        import dascore.xarray.accessor as accessor  # noqa: PLC0415
+
+        self._announcing_method(monkeypatch)
+
+        def method(self, other):
+            warnings.warn("falling back", NumpyFallbackWarning, stacklevel=1)
+            return self
+
+        monkeypatch.setattr(dc.Patch, "announce_with_arg", method, raising=False)
+        monkeypatch.setattr(accessor, "_available_memory", lambda: 1)
+        # the receiver is in memory; the argument is the lazy one
+        with pytest.raises(PatchConversionError, match="exceed what memory"):
+            data_array.dc.announce_with_arg(lazy_data_array)
 
     def test_a_call_which_announces_a_fallback_is_refused(self):
         """The warning comes before the conversion, so raising stops it."""
@@ -285,8 +347,7 @@ class TestRegistration:
         """Importing the module again must not raise or warn."""
         from dascore.xarray.accessor import register  # noqa: PLC0415
 
-        with warnings.catch_warnings():
-            warnings.simplefilter("error")
+        with suppress_warnings(action="error"):
             register()
 
     def test_a_tree_node_reaches_it_through_its_variable(self, random_spool):

--- a/tests/test_xarray/test_xr_accessor.py
+++ b/tests/test_xarray/test_xr_accessor.py
@@ -1,0 +1,270 @@
+"""Tests for the `.dc` accessor, which puts patch methods on a DataArray."""
+
+from __future__ import annotations
+
+import warnings
+
+import numpy as np
+import pytest
+
+import dascore as dc
+from dascore.exceptions import PatchConversionError
+from dascore.warnings import NumpyFallbackWarning
+
+
+@pytest.fixture(scope="module")
+def patch():
+    """One ordinary patch."""
+    return dc.get_example_patch()
+
+
+@pytest.fixture(scope="module")
+def data_array(patch):
+    """That patch as a DataArray, which registers the accessor."""
+    pytest.importorskip("xarray")
+    return patch.io.to_xarray()
+
+
+@pytest.fixture()
+def lazy_data_array(patch):
+    """The same patch backed by a dask array."""
+    pytest.importorskip("xarray")
+    da = pytest.importorskip("dask.array")
+    lazy = patch.new(data=da.from_array(patch.data, chunks=(100, -1)))
+    return lazy.io.to_xarray()
+
+
+class TestForwarding:
+    """Every public name a patch has is reachable through the accessor."""
+
+    def test_a_method_answers_what_the_patch_answers(self, patch, data_array):
+        """The route through xarray changes nothing about the result."""
+        import xarray as xr  # noqa: PLC0415
+
+        out = data_array.dc.abs()
+        assert isinstance(out, xr.DataArray)
+        assert np.array_equal(out.values, patch.abs().data)
+
+    def test_arguments_reach_the_method(self, patch, data_array):
+        """A method's own arguments are passed through untouched."""
+        out = data_array.dc.pass_filter(time=(1, 10))
+        assert np.allclose(out.values, patch.pass_filter(time=(1, 10)).data)
+
+    def test_a_data_array_argument_is_a_patch(self, patch, data_array):
+        """A method taking another patch takes another DataArray here."""
+        out = data_array.dc.add(data_array)
+        assert np.allclose(out.values, patch.data * 2)
+
+    def test_a_property_answers_for_itself(self, patch, data_array):
+        """There is no call to convert arguments for, and no patch back."""
+        assert data_array.dc.dims == patch.dims
+        assert data_array.dc.shape == patch.shape
+
+    def test_a_result_which_is_no_patch_comes_back_as_it_is(self, data_array):
+        """An array, a spool or a figure is what the caller asked for."""
+        values = data_array.dc.get_array("time")
+        assert isinstance(values, np.ndarray)
+        assert not hasattr(values, "dims")
+
+    def test_the_patch_itself_is_available(self, patch, data_array):
+        """Converting back is the one thing the accessor adds of its own."""
+        assert data_array.dc.to_patch() == patch
+
+    def test_a_name_no_patch_has(self, data_array):
+        """The error names what was asked for, and where it was looked for."""
+        with pytest.raises(AttributeError, match="not_a_patch_method"):
+            data_array.dc.not_a_patch_method
+
+    def test_a_private_name_is_not_forwarded(self, data_array):
+        """The accessor forwards a patch's public surface, not its insides."""
+        with pytest.raises(AttributeError):
+            data_array.dc._data
+
+    def test_completion_offers_the_patch_names(self, data_array):
+        """Whatever can be forwarded should be offered."""
+        names = dir(data_array.dc)
+        assert "pass_filter" in names and "abs" in names
+        assert not any(x.startswith("_") for x in names)
+
+    def test_it_says_what_it_is(self, data_array):
+        """A repr which names the shape it wraps."""
+        text = repr(data_array.dc)
+        assert "DASCore" in text and "300x2000" in text
+
+
+class TestLaziness:
+    """A dask-backed array is passed through as it stands."""
+
+    def test_an_operation_on_the_arrays_backend_stays_lazy(self, lazy_data_array):
+        """Nothing is computed on the way in or the way out."""
+        import dask.array as da  # noqa: PLC0415
+
+        assert isinstance(lazy_data_array.data, da.Array)
+        out = lazy_data_array.dc.abs()
+        assert isinstance(out.data, da.Array)
+
+    def test_the_values_are_the_same_either_way(self, patch, lazy_data_array):
+        """Laziness is about when the work happens, not what it produces."""
+        out = lazy_data_array.dc.abs().compute()
+        assert np.array_equal(np.asarray(out.values), patch.abs().data)
+
+
+class TestMemoryLookAhead:
+    """What happens when an operation would materialize more than fits."""
+
+    @staticmethod
+    def _sizer():
+        from dascore.xarray.accessor import _too_large_to_materialize  # noqa: PLC0415
+
+        return _too_large_to_materialize
+
+    def test_an_array_already_in_memory_is_never_too_large(self, patch):
+        """Materializing what is already materialized costs nothing."""
+        assert self._sizer()(patch.data) is None
+
+    def test_a_lazy_array_which_fits_is_not_too_large(self, monkeypatch):
+        """Room to spare, so nothing is refused."""
+        import dask.array as da  # noqa: PLC0415
+
+        import dascore.xarray.accessor as accessor  # noqa: PLC0415
+
+        monkeypatch.setattr(accessor, "_available_memory", lambda: 10**9)
+        assert self._sizer()(da.zeros((10, 10))) is None
+
+    def test_a_lazy_array_which_does_not_fit_states_its_size(self, monkeypatch):
+        """The size is what the message reports, so it is what is returned."""
+        import dask.array as da  # noqa: PLC0415
+
+        import dascore.xarray.accessor as accessor  # noqa: PLC0415
+
+        monkeypatch.setattr(accessor, "_available_memory", lambda: 8)
+        array = da.zeros((10, 10))
+        assert self._sizer()(array) == array.nbytes
+
+    def test_an_unknowable_budget_refuses_nothing(self, monkeypatch):
+        """Without a memory figure there is no look-ahead to do."""
+        import dask.array as da  # noqa: PLC0415
+
+        import dascore.xarray.accessor as accessor  # noqa: PLC0415
+
+        monkeypatch.setattr(accessor, "_available_memory", lambda: None)
+        assert self._sizer()(da.zeros((10, 10))) is None
+
+    def test_the_budget_is_what_is_free_less_some_headroom(self, monkeypatch):
+        """An array is not the only thing memory has to hold."""
+        import dascore.xarray.accessor as accessor  # noqa: PLC0415
+
+        class _Stub:
+            @staticmethod
+            def virtual_memory():
+                return type("_M", (), {"available": 1000})
+
+        monkeypatch.setattr(accessor, "optional_import", lambda name: _Stub)
+        assert accessor._available_memory() == int(1000 * accessor._MEMORY_HEADROOM)
+
+    def test_no_way_to_ask_means_no_look_ahead(self, monkeypatch):
+        """Psutil is not a dependency, so its absence is ordinary."""
+        import dascore.xarray.accessor as accessor  # noqa: PLC0415
+
+        def _missing(name):
+            raise ImportError(name)
+
+        monkeypatch.setattr(accessor, "optional_import", _missing)
+        assert accessor._available_memory() is None
+
+    @staticmethod
+    def _announcing_method(monkeypatch):
+        """Give Patch a method which announces a fallback, as some do."""
+
+        def method(self):
+            warnings.warn("falling back", NumpyFallbackWarning, stacklevel=1)
+            return self.new(data=np.asarray(self.data))
+
+        monkeypatch.setattr(dc.Patch, "announce_fallback", method, raising=False)
+
+    def test_a_method_which_would_convert_a_huge_array_is_refused(
+        self, monkeypatch, lazy_data_array
+    ):
+        """The array does not fit, so the conversion is not attempted."""
+        import dascore.xarray.accessor as accessor  # noqa: PLC0415
+
+        self._announcing_method(monkeypatch)
+        monkeypatch.setattr(accessor, "_available_memory", lambda: 1)
+        with pytest.raises(PatchConversionError, match="exceed what memory"):
+            lazy_data_array.dc.announce_fallback()
+
+    def test_the_same_method_runs_when_the_array_fits(
+        self, monkeypatch, lazy_data_array
+    ):
+        """Converting is only refused for want of room to convert into."""
+        import dascore.xarray.accessor as accessor  # noqa: PLC0415
+
+        self._announcing_method(monkeypatch)
+        monkeypatch.setattr(accessor, "_available_memory", lambda: 10**12)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", NumpyFallbackWarning)
+            out = lazy_data_array.dc.announce_fallback()
+        assert isinstance(out.values, np.ndarray)
+
+    def test_an_array_in_memory_is_never_refused(self, monkeypatch, data_array):
+        """It is already where a conversion would put it."""
+        import dascore.xarray.accessor as accessor  # noqa: PLC0415
+
+        self._announcing_method(monkeypatch)
+        monkeypatch.setattr(accessor, "_available_memory", lambda: 1)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", NumpyFallbackWarning)
+            assert data_array.dc.announce_fallback() is not None
+
+    def test_a_call_which_announces_a_fallback_is_refused(self):
+        """The warning comes before the conversion, so raising stops it."""
+        from dascore.xarray.accessor import _guarded  # noqa: PLC0415
+
+        def call():
+            warnings.warn("falling back", NumpyFallbackWarning, stacklevel=1)
+            return "converted"
+
+        with pytest.raises(PatchConversionError, match="exceed what memory"):
+            _guarded(call, "some_method", 10**12)
+
+    def test_a_call_which_stays_on_its_backend_is_not_refused(self):
+        """No warning, no conversion, nothing to stop."""
+        from dascore.xarray.accessor import _guarded  # noqa: PLC0415
+
+        assert _guarded(lambda: "lazy", "some_method", 10**12) == "lazy"
+
+    def test_a_lazy_operation_runs_however_little_memory_is_free(
+        self, monkeypatch, lazy_data_array
+    ):
+        """The look-ahead refuses a conversion, not an operation."""
+        import dask.array as da  # noqa: PLC0415
+
+        import dascore.xarray.accessor as accessor  # noqa: PLC0415
+
+        monkeypatch.setattr(accessor, "_available_memory", lambda: 1)
+        assert isinstance(lazy_data_array.dc.abs().data, da.Array)
+
+
+class TestRegistration:
+    """Where the accessor comes from."""
+
+    def test_a_conversion_brings_it(self, patch):
+        """Anything DASCore hands back carries the accessor."""
+        pytest.importorskip("xarray")
+        assert hasattr(patch.io.to_xarray(), "dc")
+
+    def test_registering_twice_is_not_an_error(self):
+        """Importing the module again must not raise or warn."""
+        from dascore.xarray.accessor import register  # noqa: PLC0415
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            register()
+
+    def test_a_tree_node_reaches_it_through_its_variable(self, random_spool):
+        """A Dataset holds several arrays, so a variable is named first."""
+        pytest.importorskip("xarray")
+        pytest.importorskip("dask")
+        tree = random_spool.io.to_xarray()
+        node = next(x for x in tree.subtree if "data" in x.dataset)
+        assert hasattr(node.dataset["data"], "dc")

--- a/tests/test_xarray/test_xr_accessor.py
+++ b/tests/test_xarray/test_xr_accessor.py
@@ -11,6 +11,10 @@ import dascore as dc
 from dascore.exceptions import PatchConversionError
 from dascore.warnings import NumpyFallbackWarning
 
+# Importing the accessor registers it, which needs xarray; without it
+# there is no accessor to test rather than a failure to report.
+pytest.importorskip("xarray")
+
 
 @pytest.fixture(scope="module")
 def patch():
@@ -21,14 +25,12 @@ def patch():
 @pytest.fixture(scope="module")
 def data_array(patch):
     """That patch as a DataArray, which registers the accessor."""
-    pytest.importorskip("xarray")
     return patch.io.to_xarray()
 
 
 @pytest.fixture()
 def lazy_data_array(patch):
     """The same patch backed by a dask array."""
-    pytest.importorskip("xarray")
     da = pytest.importorskip("dask.array")
     lazy = patch.new(data=da.from_array(patch.data, chunks=(100, -1)))
     return lazy.io.to_xarray()
@@ -124,7 +126,7 @@ class TestLaziness:
 
     def test_an_operation_on_the_arrays_backend_stays_lazy(self, lazy_data_array):
         """Nothing is computed on the way in or the way out."""
-        import dask.array as da  # noqa: PLC0415
+        da = pytest.importorskip("dask.array")
 
         assert isinstance(lazy_data_array.data, da.Array)
         out = lazy_data_array.dc.abs()
@@ -151,7 +153,7 @@ class TestMemoryLookAhead:
 
     def test_a_lazy_array_which_fits_is_not_too_large(self, monkeypatch):
         """Room to spare, so nothing is refused."""
-        import dask.array as da  # noqa: PLC0415
+        da = pytest.importorskip("dask.array")
 
         import dascore.xarray.accessor as accessor  # noqa: PLC0415
 
@@ -160,7 +162,7 @@ class TestMemoryLookAhead:
 
     def test_a_lazy_array_which_does_not_fit_states_its_size(self, monkeypatch):
         """The size is what the message reports, so it is what is returned."""
-        import dask.array as da  # noqa: PLC0415
+        da = pytest.importorskip("dask.array")
 
         import dascore.xarray.accessor as accessor  # noqa: PLC0415
 
@@ -170,7 +172,7 @@ class TestMemoryLookAhead:
 
     def test_an_unknowable_budget_refuses_nothing(self, monkeypatch):
         """Without a memory figure there is no look-ahead to do."""
-        import dask.array as da  # noqa: PLC0415
+        da = pytest.importorskip("dask.array")
 
         import dascore.xarray.accessor as accessor  # noqa: PLC0415
 
@@ -264,7 +266,7 @@ class TestMemoryLookAhead:
         self, monkeypatch, lazy_data_array
     ):
         """The look-ahead refuses a conversion, not an operation."""
-        import dask.array as da  # noqa: PLC0415
+        da = pytest.importorskip("dask.array")
 
         import dascore.xarray.accessor as accessor  # noqa: PLC0415
 
@@ -277,7 +279,6 @@ class TestRegistration:
 
     def test_a_conversion_brings_it(self, patch):
         """Anything DASCore hands back carries the accessor."""
-        pytest.importorskip("xarray")
         assert hasattr(patch.io.to_xarray(), "dc")
 
     def test_registering_twice_is_not_an_error(self):
@@ -290,7 +291,6 @@ class TestRegistration:
 
     def test_a_tree_node_reaches_it_through_its_variable(self, random_spool):
         """A Dataset holds several arrays, so a variable is named first."""
-        pytest.importorskip("xarray")
         pytest.importorskip("dask")
         tree = random_spool.io.to_xarray()
         node = next(x for x in tree.subtree if "data" in x.dataset)

--- a/tests/test_xarray/test_xr_accessor.py
+++ b/tests/test_xarray/test_xr_accessor.py
@@ -70,6 +70,33 @@ class TestForwarding:
         """Converting back is the one thing the accessor adds of its own."""
         assert data_array.dc.to_patch() == patch
 
+    def test_a_keyword_data_array_argument_is_a_patch(self, patch, data_array):
+        """A keyword is converted like a position; a patch method needs one.
+
+        `add` builds a patch out of what it is given, so an unconverted
+        DataArray does not merely give a different answer, it refuses.
+        """
+        out = data_array.dc.add(other=data_array)
+        assert np.allclose(out.values, patch.data * 2)
+
+    def test_a_property_stating_a_patch_states_a_data_array(self, data_array):
+        """`T` is a property whose value is a patch, so it converts too."""
+        import xarray as xr  # noqa: PLC0415
+
+        transposed = data_array.dc.T
+        assert isinstance(transposed, xr.DataArray)
+        assert transposed.dims == data_array.dims[::-1]
+
+    def test_a_namespace_is_reachable(self, patch, data_array):
+        """A patch resolves its namespaces itself, so asking the patch finds them."""
+        assert type(data_array.dc.io).__name__ == type(patch.io).__name__
+        assert "io" in dir(data_array.dc)
+
+    def test_a_name_only_the_class_has_is_not_forwarded(self, data_array):
+        """`mro` is a name of the type, not of a patch."""
+        with pytest.raises(AttributeError, match="mro"):
+            data_array.dc.mro
+
     def test_a_name_no_patch_has(self, data_array):
         """The error names what was asked for, and where it was looked for."""
         with pytest.raises(AttributeError, match="not_a_patch_method"):

--- a/tests/test_xarray/test_xr_accessor.py
+++ b/tests/test_xarray/test_xr_accessor.py
@@ -239,6 +239,69 @@ class TestLazyCoordinates:
         coord = tree_leaf.dc.to_patch().get_coord("time")
         assert np.array_equal(coord.values, tree_leaf["time"].values)
 
+    @staticmethod
+    def _refuse_to_materialize(monkeypatch):
+        """Make spelling out a temporal label an error, either side of it.
+
+        A lazy coordinate is a transform on the xarray side and a range
+        on the patch side, and either can be asked for every label; a
+        conversion which builds one only to replace it has still paid
+        for it. Numeric coordinates are short and are left alone.
+        """
+        from dascore.core.coords import CoordRange  # noqa: PLC0415
+        from dascore.xarray.index import TemporalRangeTransform  # noqa: PLC0415
+
+        def _refuse_forward(self, dim_positions):
+            raise AssertionError("the labels were computed by the transform")
+
+        original = CoordRange.values
+
+        @property
+        def _refuse_values(self):
+            if np.issubdtype(self.dtype, np.datetime64):
+                raise AssertionError("the range spelled out its labels")
+            return original.__get__(self, CoordRange)
+
+        monkeypatch.setattr(TemporalRangeTransform, "forward", _refuse_forward)
+        monkeypatch.setattr(CoordRange, "values", _refuse_values)
+
+    def test_a_forwarded_call_never_spells_out_the_labels(self, tree_leaf, monkeypatch):
+        """Not on the way in, and not on the way back out.
+
+        Building the labels only to replace them with the range which
+        states them costs the whole array anyway -- eight bytes a sample,
+        which for a long acquisition is what staying lazy is for. So the
+        conversion must be told to state the coordinate rather than
+        having it stated back afterwards.
+        """
+        self._refuse_to_materialize(monkeypatch)
+        out = tree_leaf.dc.abs()
+        assert type(out.xindexes["time"]).__name__ == "TemporalRangeIndex"
+
+    def test_a_forwarded_property_never_spells_them_out_either(
+        self, tree_leaf, monkeypatch
+    ):
+        """A property states a patch by the same conversion a call does."""
+        self._refuse_to_materialize(monkeypatch)
+        assert type(tree_leaf.dc.T.xindexes["time"]).__name__ == "TemporalRangeIndex"
+
+    def test_a_renamed_coordinate_is_still_stated(self, tree_leaf, monkeypatch):
+        """It is the same coordinate under another name."""
+        self._refuse_to_materialize(monkeypatch)
+        out = tree_leaf.dc.rename_coords(time="t")
+        assert type(out.xindexes["t"]).__name__ == "TemporalRangeIndex"
+
+    def test_a_coordinate_which_no_longer_names_a_dimension(self, tree_leaf):
+        """An index labels a dimension, so a coordinate which stops
+        defining one is spelled out beside it rather than refused.
+        """
+        size = tree_leaf.sizes["time"]
+        with_sample = tree_leaf.assign_coords(sample=("time", np.arange(size)))
+        out = with_sample.dc.set_dims(time="sample")
+        renamed = tuple("sample" if x == "time" else x for x in tree_leaf.dims)
+        assert out.dims == renamed
+        assert out.coords["time"].dims == ("sample",)
+
 
 class TestAuxiliaryCoordinates:
     """A coordinate riding a dimension it is not named for."""

--- a/tests/test_xarray/test_xr_accessor.py
+++ b/tests/test_xarray/test_xr_accessor.py
@@ -333,6 +333,62 @@ class TestLazyCoordinates:
         # which is what a lazy index on `lag` would refuse to align
         assert (out - array).shape == array.shape
 
+    @staticmethod
+    def _offsets(tree_leaf):
+        """One value a channel, with no time coordinate of its own."""
+        xr = pytest.importorskip("xarray")
+
+        return xr.DataArray(
+            np.arange(tree_leaf.sizes["distance"]) * 1.0,
+            dims=("distance",),
+            coords={"distance": tree_leaf["distance"].values},
+        )
+
+    @pytest.mark.parametrize("keyword", [False, True])
+    def test_an_argument_says_how_its_coordinates_arrived(
+        self, tree_leaf, monkeypatch, keyword
+    ):
+        """The coordinate the result takes is the argument's, so it decides.
+
+        Adding per-channel offsets to a long acquisition takes that
+        acquisition's time coordinate whichever of the two is called on;
+        reading it from the receiver alone spells out every label in the
+        ordering where the receiver has no time coordinate at all.
+        """
+        offsets = self._offsets(tree_leaf)
+        self._refuse_to_materialize(monkeypatch)
+        out = offsets.dc.add(other=tree_leaf) if keyword else offsets.dc.add(tree_leaf)
+        assert type(out.xindexes["time"]).__name__ == "TemporalRangeIndex"
+
+    def test_either_order_states_it_the_same_way(self, tree_leaf):
+        """The same sum, so the same coordinate, however it is written."""
+        offsets = self._offsets(tree_leaf)
+        first, second = tree_leaf.dc.add(offsets), offsets.dc.add(tree_leaf)
+        assert type(first.xindexes["time"]).__name__ == "TemporalRangeIndex"
+        assert type(first.xindexes["time"]) is type(second.xindexes["time"])
+        assert np.allclose(first.transpose(*second.dims).values, second.values)
+
+    def test_a_coordinate_which_arrived_both_ways_is_spelled_out(self, tree_leaf):
+        """An eager index is what xarray aligns on, so it is not taken away.
+
+        One of the two stated the coordinate and the other spelled it
+        out; the result keeps what the stricter of them can align on,
+        the same way round either way.
+        """
+        spelled_out = tree_leaf.dc.to_patch().io.to_xarray()
+        assert type(spelled_out.xindexes["time"]).__name__ == "PandasIndex"
+        for out in (spelled_out.dc.add(tree_leaf), tree_leaf.dc.add(spelled_out)):
+            assert type(out.xindexes["time"]).__name__ == "PandasIndex"
+
+    @pytest.mark.parametrize("reverse", [False, True])
+    def test_an_unindexed_coordinate_does_not_force_eager(self, tree_leaf, reverse):
+        """Only an eager index requires the result to preserve eager alignment."""
+        unindexed = tree_leaf.dc.to_patch().io.to_xarray().drop_indexes("time")
+        first, second = (unindexed, tree_leaf) if reverse else (tree_leaf, unindexed)
+        out = first.dc.add(second)
+        assert type(out.xindexes["time"]).__name__ == "TemporalRangeIndex"
+        assert (out - unindexed).shape == tree_leaf.shape
+
     def test_a_duration_is_served_like_a_time(self):
         """A lag says its units in its dtype as a stamp does."""
         from dascore.core.coords import get_coord  # noqa: PLC0415

--- a/tests/test_xarray/test_xr_accessor.py
+++ b/tests/test_xarray/test_xr_accessor.py
@@ -258,7 +258,9 @@ class TestLazyCoordinates:
 
         @property
         def _refuse_values(self):
-            if np.issubdtype(self.dtype, np.datetime64):
+            if np.issubdtype(self.dtype, np.datetime64) or np.issubdtype(
+                self.dtype, np.timedelta64
+            ):
                 raise AssertionError("the range spelled out its labels")
             return original.__get__(self, CoordRange)
 
@@ -285,11 +287,64 @@ class TestLazyCoordinates:
         self._refuse_to_materialize(monkeypatch)
         assert type(tree_leaf.dc.T.xindexes["time"]).__name__ == "TemporalRangeIndex"
 
-    def test_a_renamed_coordinate_is_still_stated(self, tree_leaf, monkeypatch):
-        """It is the same coordinate under another name."""
-        self._refuse_to_materialize(monkeypatch)
+    def test_a_renamed_coordinate_is_spelled_out(self, tree_leaf):
+        """Laziness follows the name, and a rename is a new name.
+
+        Nothing says the coordinate arriving under a new name is the one
+        which arrived stated, and guessing that it is would state a
+        coordinate which came in spelled out -- which is the failure
+        below. So a rename spells its labels out, as it did before any
+        of them were stated.
+        """
         out = tree_leaf.dc.rename_coords(time="t")
-        assert type(out.xindexes["t"]).__name__ == "TemporalRangeIndex"
+        assert type(out.xindexes["t"]).__name__ == "PandasIndex"
+        assert np.array_equal(
+            np.asarray(out["t"].values), np.asarray(tree_leaf["time"].values)
+        )
+
+    def test_an_eager_dimension_beside_a_lazy_one_stays_eager(self):
+        """Which is why the names are carried, not one flag for the array.
+
+        An eager index is what xarray aligns on, so making a coordinate
+        lazy because a coordinate beside it is refuses the arithmetic
+        which worked before the call. A correlation's lag is a second
+        temporal dimension, and is eligible to be served lazily without
+        having arrived that way.
+        """
+        from dascore.core.coords import get_coord  # noqa: PLC0415
+        from dascore.xarray.patch import patch_to_xarray  # noqa: PLC0415
+
+        start = np.datetime64("2020-01-01")
+        time = get_coord(start=start, step=np.timedelta64(4, "ms"), shape=(6,))
+        lag = get_coord(
+            start=np.timedelta64(0, "s"), step=np.timedelta64(1, "s"), shape=(4,)
+        )
+        patch = dc.Patch(
+            data=np.arange(24.0).reshape(6, 4),
+            dims=("time", "lag"),
+            coords={"time": time, "lag": lag},
+        )
+        # only `time` arrived stated, though `lag` could be served the same way
+        array = patch_to_xarray(patch, lazy_coords={"time"})
+        assert type(array.xindexes["lag"]).__name__ == "PandasIndex"
+        out = array.dc.abs()
+        assert type(out.xindexes["time"]).__name__ == "TemporalRangeIndex"
+        assert type(out.xindexes["lag"]).__name__ == "PandasIndex"
+        # which is what a lazy index on `lag` would refuse to align
+        assert (out - array).shape == array.shape
+
+    def test_a_duration_is_served_like_a_time(self):
+        """A lag says its units in its dtype as a stamp does."""
+        from dascore.core.coords import get_coord  # noqa: PLC0415
+        from dascore.xarray.patch import patch_to_xarray  # noqa: PLC0415
+
+        lag = get_coord(
+            start=np.timedelta64(0, "s"), step=np.timedelta64(1, "s"), shape=(4,)
+        )
+        patch = dc.Patch(data=np.arange(4.0), dims=("lag",), coords={"lag": lag})
+        array = patch_to_xarray(patch, lazy_coords={"lag"})
+        assert type(array.xindexes["lag"]).__name__ == "TemporalRangeIndex"
+        assert np.array_equal(np.asarray(array["lag"].values), lag.values)
 
     def test_a_coordinate_which_no_longer_names_a_dimension(self, tree_leaf):
         """An index labels a dimension, so a coordinate which stops

--- a/tests/test_xarray/test_xr_accessor.py
+++ b/tests/test_xarray/test_xr_accessor.py
@@ -140,6 +140,15 @@ class TestLaziness:
         out = lazy_data_array.dc.abs()
         assert isinstance(out.data, da.Array)
 
+    def test_a_result_keeps_a_lazy_coordinate_lazy(self, random_spool):
+        """Converting back out must not spell out what came in stated."""
+        pytest.importorskip("dask")
+        tree = random_spool.io.to_xarray()
+        leaf = next(x for x in tree.subtree if "data" in x.dataset)["data"]
+        assert type(leaf.xindexes["time"]).__name__ == "TemporalRangeIndex"
+        out = leaf.dc.abs()
+        assert type(out.xindexes["time"]).__name__ == "TemporalRangeIndex"
+
     def test_the_values_are_the_same_either_way(self, patch, lazy_data_array):
         """Laziness is about when the work happens, not what it produces."""
         out = lazy_data_array.dc.abs().compute()
@@ -182,6 +191,55 @@ class TestLazyCoordinates:
         """Staying lazy must not change which samples it names."""
         coord = tree_leaf.dc.to_patch().get_coord("time")
         assert np.array_equal(coord.values, tree_leaf["time"].values)
+
+
+class TestUnits:
+    """A coordinate's units survive both conversions."""
+
+    def test_units_come_back(self, patch):
+        """Otherwise a method which converts them has nothing to convert."""
+        with_units = patch.set_units(distance="m")
+        back = dc.io.xarray_to_patch(with_units.io.to_xarray())
+        assert (
+            back.get_coord("distance").units == with_units.get_coord("distance").units
+        )
+
+    def test_a_forwarded_conversion_converts(self, data_array):
+        """The point of carrying them: `convert_units` changes the values."""
+        before = np.asarray(data_array["distance"].values)
+        out = data_array.dc.set_units(distance="m").dc.convert_units(distance="km")
+        assert np.allclose(np.asarray(out["distance"].values), before / 1000)
+
+    def test_a_temporal_coordinate_states_no_units(self, data_array):
+        """A datetime says its units in its dtype, and xarray spends that
+        attribute on saying how to serialize it.
+        """
+        assert "units" not in data_array["time"].attrs
+
+    def test_a_rebuilt_range_states_a_scalar_step(self, patch, data_array):
+        """A step is divided into, which a zero-dimensional array breaks."""
+        step = dc.io.xarray_to_patch(data_array).get_coord("time").step
+        assert np.ndim(step) == 0 and not isinstance(step, np.ndarray)
+        assert step == patch.get_coord("time").step
+
+
+class TestEmptySelections:
+    """A selection which keeps nothing is still convertible."""
+
+    def test_an_empty_time_window_converts(self, random_spool):
+        """A range needs somewhere to go; an empty coordinate has nowhere."""
+        pytest.importorskip("dask")
+        tree = random_spool.io.to_xarray()
+        leaf = next(x for x in tree.subtree if "data" in x.dataset)["data"]
+        out = leaf.isel(time=slice(0, 0)).dc.to_patch()
+        assert out.shape[leaf.dims.index("time")] == 0
+
+    def test_a_property_of_an_empty_selection(self, random_spool):
+        """Anything forwarded has to convert first, so this failed too."""
+        pytest.importorskip("dask")
+        tree = random_spool.io.to_xarray()
+        leaf = next(x for x in tree.subtree if "data" in x.dataset)["data"]
+        assert 0 in leaf.isel(time=slice(0, 0)).dc.shape
 
 
 class TestMemoryLookAhead:
@@ -288,6 +346,15 @@ class TestMemoryLookAhead:
         monkeypatch.setattr(accessor, "_available_memory", lambda: 1)
         with suppress_warnings(NumpyFallbackWarning):
             assert data_array.dc.announce_fallback() is not None
+
+    def test_a_bare_array_argument_is_weighed(self, monkeypatch):
+        """A conversion converts a raw array argument as it does a patch's."""
+        import dascore.xarray.accessor as accessor  # noqa: PLC0415
+
+        da = pytest.importorskip("dask.array")
+        monkeypatch.setattr(accessor, "_available_memory", lambda: 8)
+        array = da.zeros((10, 10))
+        assert accessor._largest_to_materialize([array]) == array.nbytes
 
     def test_an_argument_too_large_refuses_the_call(
         self, monkeypatch, data_array, lazy_data_array

--- a/tests/test_xarray/test_xr_accessor.py
+++ b/tests/test_xarray/test_xr_accessor.py
@@ -121,6 +121,8 @@ class TestForwarding:
         """Whatever can be forwarded should be offered."""
         names = dir(data_array.dc)
         assert "pass_filter" in names and "abs" in names
+        # what the accessor adds of its own is offered too
+        assert "to_patch" in names
         assert not any(x.startswith("_") for x in names)
 
     def test_it_says_what_it_is(self, data_array):
@@ -131,6 +133,13 @@ class TestForwarding:
 
 class TestLaziness:
     """A dask-backed array is passed through as it stands."""
+
+    @pytest.fixture()
+    def tree_leaf(self, random_spool):
+        """One segment of a tree, whose time coordinate is served lazily."""
+        pytest.importorskip("dask")
+        tree = random_spool.io.to_xarray()
+        return next(x for x in tree.subtree if "data" in x.dataset)["data"]
 
     def test_an_operation_on_the_arrays_backend_stays_lazy(self, lazy_data_array):
         """Nothing is computed on the way in or the way out."""
@@ -147,6 +156,44 @@ class TestLaziness:
         leaf = next(x for x in tree.subtree if "data" in x.dataset)["data"]
         assert type(leaf.xindexes["time"]).__name__ == "TemporalRangeIndex"
         out = leaf.dc.abs()
+        assert type(out.xindexes["time"]).__name__ == "TemporalRangeIndex"
+
+    def test_an_ordinary_array_keeps_its_eager_index(self, data_array):
+        """Whether a coordinate is spelled out belongs to the object.
+
+        An eager index is what xarray aligns arithmetic on, so a
+        conversion must not quietly swap one for a lazy index.
+        """
+        assert type(data_array.dc.abs().xindexes["time"]).__name__ == "PandasIndex"
+
+    def test_ordinary_arithmetic_still_works(self, data_array):
+        """Which is what replacing the index used to break."""
+        assert (data_array.dc.abs() - data_array).shape == data_array.shape
+        pair = data_array + data_array.isel(time=slice(1, 3))
+        assert pair.sizes["time"] == 2
+
+    def test_a_moved_coordinate_is_served_where_it_now_is(self, tree_leaf):
+        """A method which trims it is served lazily at its new bounds."""
+        values = np.asarray(tree_leaf["time"].values)
+        out = tree_leaf.dc.select(time=(None, values[100]))
+        assert type(out.xindexes["time"]).__name__ == "TemporalRangeIndex"
+        assert np.array_equal(np.asarray(out["time"].values), values[:101])
+
+    def test_a_property_keeps_it_lazy_too(self, tree_leaf):
+        """A property's value is converted like a method's result."""
+        assert type(tree_leaf.dc.T.xindexes["time"]).__name__ == "TemporalRangeIndex"
+
+    def test_a_coordinate_riding_a_dimension_is_left_alone(self, tree_leaf):
+        """Only a coordinate which defines its dimension can index it.
+
+        A lazy index is built for a dimension, so offering to serve a
+        coordinate riding one would build an index for a dimension that
+        coordinate does not define.
+        """
+        values = np.asarray(tree_leaf["time"].values)
+        with_aux = tree_leaf.assign_coords(aux_time=("time", values))
+        out = with_aux.dc.abs()
+        assert out.coords["aux_time"].dims == ("time",)
         assert type(out.xindexes["time"]).__name__ == "TemporalRangeIndex"
 
     def test_the_values_are_the_same_either_way(self, patch, lazy_data_array):
@@ -191,6 +238,19 @@ class TestLazyCoordinates:
         """Staying lazy must not change which samples it names."""
         coord = tree_leaf.dc.to_patch().get_coord("time")
         assert np.array_equal(coord.values, tree_leaf["time"].values)
+
+
+class TestAuxiliaryCoordinates:
+    """A coordinate riding a dimension it is not named for."""
+
+    def test_a_temporal_coordinate_on_another_dimension_converts(self, patch):
+        """Its index would be built for a dimension it does not define."""
+        aux = patch.update_coords(aux_time=("time", patch.get_array("time")))
+        out = aux.io.to_xarray()
+        assert out.coords["aux_time"].dims == ("time",)
+        assert np.array_equal(
+            np.asarray(out["aux_time"].values), patch.get_array("time")
+        )
 
 
 class TestUnits:

--- a/tests/test_xarray/test_xr_index.py
+++ b/tests/test_xarray/test_xr_index.py
@@ -323,7 +323,7 @@ class TestLazyEligibility:
 
     def test_descending_temporal_coord_refused(self):
         """A descending range is not an ascending transform; materialize."""
-        from dascore.xarray.spool import _lazy_temporal_index  # noqa: PLC0415
+        from dascore.xarray.patch import _lazy_temporal_index  # noqa: PLC0415
 
         start = np.datetime64("2020-01-01", "ns")
         coord = get_coord(start=start + 10 * ONE_MS, stop=start - ONE_MS, step=-ONE_MS)


### PR DESCRIPTION
## Description

Fourth step of the xarray series on `xarray_integration`, after #1103 (the lazy tree), #1109 (`read_array` blocks and lazy time coordinates) and #1136 (reading a selection rather than the blocks it falls in).

A DataArray DASCore hands back now carries a `dc` accessor holding every public `Patch` name:

```python
import dascore as dc

dar = dc.get_example_patch().io.to_xarray()

filtered = dar.dc.pass_filter(time=(1, 10))   # a DataArray back
times = dar.dc.get_array("time")              # an array, as asked for
patch = dar.dc.to_patch()                     # the patch itself
```

A call converts the DataArray to a patch, runs the method, and converts a patch it returns back. A result which is not a patch, an array or a spool or a figure, comes back as it is, and a DataArray passed as an argument becomes a patch on the way in, so `dar.dc.add(other_dar)` works. There is no list of methods to maintain: what a `Patch` has is what is forwarded, a name it lacks raises saying so, and `dir()` offers the same names for completion.

**It registers on DataArray alone.** A patch is one array, and a Dataset holding several has no single patch to be, so a tree node names its variable first: `node.dataset["data"].dc.pass_filter(...)`.

**A dask-backed array is passed through as it stands**, so a method which works on the array's own backend leaves it lazy. With dask that is most of them; `abs`, `normalize` and `aggregate` all stayed lazy in testing.

**The memory look-ahead.** A method which cannot work on the array as it stands announces that by warning before it converts anything, so where the array is larger than free memory the accessor raises on that warning and the conversion never starts. The message names the method and the size. Its limit is worth stating plainly: a method which converts silently, without going through DASCore's own fallback, is not caught and will fail on memory as it does today. That improves on its own as more operations declare which backends they support, which is the remaining work of the array-API phase 1 series.

### Registration

Registering an accessor means importing xarray, which DASCore does not do on its own since xarray is optional. So `patch_to_xarray` and `spool_to_xarray` register it, and anything DASCore converts carries it. A DataArray built elsewhere needs `import dascore.xarray.accessor` first, which the recipe documents.

## Changelog

- added: a `dc` accessor on `xarray.DataArray` carrying every public `Patch` method. `dar.dc.pass_filter(time=(1, 10))` returns a DataArray, a result which is not a patch comes back unchanged, and a DataArray argument is taken as a patch.
- added: `DataArray.dc.to_patch()`, the conversion back, alongside the existing `dascore.io.xarray_to_patch`.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
