### PR TITLE
Add exact integer grids for time and integer range coordinates

### DIFF
--- a/dascore/core/coordmanager.py
+++ b/dascore/core/coordmanager.py
@@ -830,7 +830,7 @@ class CoordManager(RichRepr, DascoreBaseModel):
                 Row(
                     name=stated,
                     kind=Text(
-                        coord._repr_name or type(coord).__name__,
+                        type(coord).__name__,
                         style=coord._rich_style,
                     ),
                     fields=coord._repr_fields(),

--- a/dascore/core/coordmanager.py
+++ b/dascore/core/coordmanager.py
@@ -829,7 +829,10 @@ class CoordManager(RichRepr, DascoreBaseModel):
             rows.append(
                 Row(
                     name=stated,
-                    kind=Text(type(coord).__name__, style=coord._rich_style),
+                    kind=Text(
+                        coord._repr_name or type(coord).__name__,
+                        style=coord._rich_style,
+                    ),
                     fields=coord._repr_fields(),
                 )
             )

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -65,6 +65,7 @@ from dascore.utils.docs import compose_docstring, get_docstring
 from dascore.utils.misc import (
     _get_nullish,
     _maybe_array_to_slice,
+    _maybe_unpack,
     _to_slice,
     _validate_sample_values,
     all_close,
@@ -244,7 +245,7 @@ class CoordSummary(DascoreBaseModel):
     dims: tuple[str, ...] = ()
     len: int | None = None
     fingerprint: str | None = None
-    # The exact grid of a CoordRangeInt, in ticks; None for other coords.
+    # The exact grid of a CoordRange, in ticks; None for other coords.
     step_numerator: int | None = None
     step_denominator: int | None = None
     origin_offset: int | None = None
@@ -309,7 +310,7 @@ class CoordSummary(DascoreBaseModel):
             if self.len is None:
                 msg = "An exact grid summary needs its length to rebuild a coord."
                 raise CoordError(msg)
-            return CoordRangeInt(
+            return CoordRange(
                 start=self.min if num >= 0 else self.max,
                 shape=(self.len,),
                 step_numerator=num,
@@ -322,7 +323,7 @@ class CoordSummary(DascoreBaseModel):
             start, stop = self.max, self.min + step
         else:
             start, stop = self.min, self.max + step
-        return _build_range(start=start, stop=stop, step=step, units=self.units)
+        return CoordRange(start=start, stop=stop, step=step, units=self.units)
 
 
 @cache
@@ -406,9 +407,6 @@ class BaseCoord(RichRepr, DascoreBaseModel, abc.ABC):
             """The coordinate's values."""
 
     _rich_style = dascore_styles["default_coord"]
-    # The name a repr states; a subclass which is an implementation detail
-    # of another coordinate kind states that kind's name.
-    _repr_name: str | None = None
     _evenly_sampled = False
     _sorted = False
     _reverse_sorted = False
@@ -693,7 +691,7 @@ class BaseCoord(RichRepr, DascoreBaseModel, abc.ABC):
     def __rich__(self):
         key_style = dascore_styles["keys"]
         base = Text("")
-        base += Text(self._repr_name or self.__class__.__name__, style=self._rich_style)
+        base += Text(self.__class__.__name__, style=self._rich_style)
         base += Text("(")
         for label, value, labelled in self._repr_fields():
             base += Text(f" {label}: ", key_style) if labelled else Text(" ")
@@ -822,13 +820,11 @@ class BaseCoord(RichRepr, DascoreBaseModel, abc.ABC):
         units; a float step has no exact form and gives None.
         """
         step = self.step
-        if step is None or _is_null_scalar(step):
+        if _is_null(step):
             return None
         if is_timedelta64(step):
-            return Fraction(int(to_int(step)), 10**9)
-        if _is_int_scalar(step):
-            return Fraction(int(step))
-        return None
+            return Fraction(int(to_int(step)), _NS_PER_S)
+        return Fraction(int(step)) if _is_int(step) else None
 
     @property
     def evenly_sampled(self) -> bool:
@@ -1567,18 +1563,309 @@ class CoordPartial(BaseCoord):
         )
 
 
+_EXACT_GRID_FIELDS = ("step_numerator", "step_denominator", "origin_offset")
+# Nanoseconds per second: the tick of every exact time grid.
+_NS_PER_S = 10**9
+
+
+def _fraction_step(step) -> Fraction | None:
+    """A step given as a Fraction or (numerator, denominator) tuple, else None."""
+    if isinstance(step, tuple):
+        return Fraction(*step)
+    return step if isinstance(step, Fraction) else None
+
+
+def _is_null(value) -> bool:
+    """Return True for None or a null scalar (NaN, NaT)."""
+    if value is None:
+        return True
+    if _fraction_step(value) is not None:
+        return False
+    return bool(pd.isnull(_maybe_unpack(value)))
+
+
+def _is_int(value) -> bool:
+    """Return True for a python or numpy integer (not a bool)."""
+    value = _maybe_unpack(value)
+    return isinstance(value, int | np.integer) and not isinstance(
+        value, bool | np.bool_
+    )
+
+
+def _to_tick(value) -> int:
+    """Return a time value as nanoseconds, or an integer value as itself."""
+    value = _maybe_unpack(value)
+    if is_datetime64(value) or is_timedelta64(value):
+        return int(to_int(value))
+    if isinstance(value, float | np.floating):
+        if not float(value).is_integer():
+            msg = f"An integer coordinate cannot hold the non-integer value {value}."
+            raise CoordError(msg)
+        return int(value)
+    try:
+        return int(value)
+    except (TypeError, ValueError) as e:
+        msg = f"{value!r} is not an integer or time value."
+        raise CoordError(msg) from e
+
+
+def _exact_dtype(start, stop, step, shape) -> np.dtype | None:
+    """
+    The dtype of the exact grid these inputs describe, or None for a float range.
+
+    Nanosecond time and integers have a tick (a nanosecond, or one); a
+    fraction step is only meaningful on such a grid. Coarser time units,
+    floats, and integer spans that do not divide by their count keep the
+    float representation, as they always have.
+    """
+    anchor = stop if _is_null(start) else start
+    fraction = _fraction_step(step)
+    ends = [np.asarray(x).dtype for x in (start, stop) if not _is_null(x)]
+    if is_datetime64(anchor) or is_timedelta64(anchor):
+        if fraction is not None:
+            return np.dtype(f"{ends[0].kind}8[ns]")
+        parts = (
+            ends if _is_null(step) else [*ends, np.asarray(_maybe_unpack(step)).dtype]
+        )
+        try:
+            dtype = np.result_type(*parts)
+        except TypeError:  # not all time-like: the float validator says so
+            return None
+        return dtype if dtype.kind in "mM" and dtype.str.endswith("[ns]") else None
+    if not (_is_int(anchor) and (_is_null(stop) or _is_int(stop))):
+        if fraction is not None:
+            msg = (
+                "A fraction step requires a datetime64, timedelta64, or integer "
+                f"coordinate, not {np.asarray(anchor).dtype}."
+            )
+            raise CoordError(msg)
+        return None
+    if _is_null(step):
+        # Without a step the spacing comes from the span and count, and an
+        # uneven division makes floats, as it always has.
+        length = next(iter(iterate(shape))) if shape is not None else 0
+        if len(ends) == 2 and length and (_to_tick(stop) - _to_tick(start)) % length:
+            return None
+        step = 1
+    if fraction is None and not _is_int(step):
+        return None
+    tick = round(fraction) if fraction is not None else _maybe_unpack(step)
+    return np.asarray(_maybe_unpack(anchor) + tick).dtype
+
+
+def _grid_fields(start_tick: int, num: int, den: int, offset: int, count: int, dtype):
+    """
+    The stored fields of an exact grid, normalized and checked.
+
+    The grid is reduced by the common divisor of all three terms, never of
+    the step alone: from (num 3, den 2, offset 1) the stride-two grid (6, 2,
+    1) must stay as it is, since (3, 1, 0) keeps the labels but moves the
+    origin by half a tick. The labels must fit the dtype: a grid that would
+    wrap an int8 or overflow int64 arithmetic is refused.
+    """
+    g = math.gcd(num, den, offset)
+    num, den, offset = num // g, den // g, offset // g
+    dtype = np.dtype(dtype)
+    info = np.iinfo(np.int64 if dtype.kind in "mM" else cast("Any", dtype))
+    stop_tick = start_tick + (offset + count * num) // den
+    low, high = min(start_tick, stop_tick), max(start_tick, stop_tick)
+    if abs(count * num) + den >= 2**63 or low < info.min or high > info.max:
+        msg = (
+            f"A grid of {count} samples with step {num}/{den} ticks from "
+            f"{start_tick} exceeds the {dtype} range."
+        )
+        raise CoordError(msg)
+    ticks = np.asarray([start_tick, stop_tick], dtype=np.int64).astype(dtype)
+    step_tick = round(Fraction(num, den))
+    step = np.timedelta64(step_tick, "ns") if dtype.kind in "mM" else step_tick
+    return dict(
+        start=ticks[0][()],
+        stop=ticks[1][()],
+        step=step,
+        shape=(count,),
+        dtype=dtype,
+        step_numerator=num,
+        step_denominator=den,
+        origin_offset=offset,
+    )
+
+
+def _exact_fields(values, dtype: np.dtype) -> dict:
+    """Resolve the exact grid a validator input describes."""
+    start, stop, step = (
+        None if _is_null(v := values.get(x)) else _maybe_unpack(v)
+        for x in ("start", "stop", "step")
+    )
+    shape = values.get("shape")
+    time_like = dtype.kind in "mM"
+    start_tick = None if start is None else _to_tick(start)
+    stop_tick = None if stop is None else _to_tick(stop)
+    count = None
+    if shape is not None:
+        shape = tuple(iterate(shape))
+        if len(shape) != 1:
+            msg = "Coord range only works for 1D coords."
+            raise CoordError(msg)
+        count = int(shape[0])
+        if count < 1:
+            msg = "A range coordinate needs at least one sample."
+            raise CoordError(msg)
+    # The grid: a fraction step wins, then explicit grid fields, then a
+    # scalar step, then the span divided by the count.
+    offset = int(values.get("origin_offset") or 0)
+    if (frac := _fraction_step(step)) is not None:
+        if time_like:
+            frac = frac * _NS_PER_S
+        num, den = frac.numerator, frac.denominator
+    elif values.get("step_numerator") is not None:
+        num = int(values["step_numerator"])
+        den = int(values.get("step_denominator") or 1)
+    elif step is not None:
+        num, den, offset = _to_tick(step), 1, 0
+    else:
+        if start_tick is None or stop_tick is None or count is None:
+            msg = (
+                "Three of ('start', 'stop', 'step', 'shape') are required "
+                f"to create CoordRange. You passed {values}"
+            )
+            raise CoordError(msg)
+        frac = Fraction(stop_tick - start_tick, count)
+        num, den, offset = frac.numerator, frac.denominator, 0
+    if den < 1:
+        msg = "step_denominator must be positive."
+        raise CoordError(msg)
+    if 0 < abs(num) < den:
+        msg = "A step smaller than one tick would repeat labels."
+        raise CoordError(msg)
+    if not 0 <= offset < den:
+        msg = f"origin_offset must satisfy 0 <= offset < {den}, got {offset}."
+        raise CoordError(msg)
+    if count is None:
+        if start_tick is None or stop_tick is None:
+            msg = "start, stop, and step, or a shape, are needed."
+            raise CoordError(msg)
+        if num == 0 or start_tick == stop_tick:
+            count = 1
+        else:
+            span = stop_tick - start_tick
+            if (span > 0) != (num > 0):
+                msg = "Sign of step must match sign of stop - start"
+                raise CoordError(msg)
+            # Rounded to a tenth of a sample as a float, as the float range
+            # always has, so a stop a hair past a sample does not add one.
+            ratio = float(Fraction(span * den - offset, num))
+            count = max(1, math.ceil(round(ratio, 1)))
+    if start_tick is None:
+        assert stop_tick is not None, "start or stop is present"
+        # The ideal origin is count steps before stop; start is its floor.
+        start_tick, offset = divmod(stop_tick * den - count * num, den)
+    return _grid_fields(start_tick, num, den, offset, count, dtype)
+
+
+def _float_fields(values) -> dict:
+    """Resolve a float (or coarse-time) range from a validator input."""
+
+    def _round_ratio(numerator, denominator, digits):
+        """Round numerator/denominator, cheaply for scalars."""
+        # Inputs are always scalar-like (multi-element arrays are rejected
+        # by the pd.isnull check above) and rounding python floats is
+        # ~10x faster than numpy scalars, hence the float conversion.
+        ratio = _maybe_unpack(numerator / denominator)
+        return round(float(ratio), digits)
+
+    req_values = ("start", "stop", "step", "shape")
+    _attrs = [values.get(x, None) for x in req_values]
+    valid_count = sum(not pd.isnull(x) for x in _attrs)
+    if valid_count < 3:
+        msg = (
+            f"Three of {req_values} are required to create CoordRange. "
+            f"You passed {values}"
+        )
+        raise CoordError(msg)
+    # Now get start, stop, step from length, if provided.
+    start, stop, step, shape = _attrs
+    if not pd.isnull(shape):
+        shape = tuple(iterate(shape))
+        if len(shape) != 1:
+            msg = "Coord range only works for 1D coords."
+            raise CoordError(msg)
+        length = shape[0]
+        if pd.isnull(start):
+            start = stop - step * length
+        if pd.isnull(stop):
+            stop = start + step * length
+        if pd.isnull(step):
+            step = (stop - start) / length
+            # handle conversion to integer if other values are ints.
+            if isinstance(start, int) and isinstance(stop, int):
+                step = int(step) if np.isclose(np.round(step), step) else step
+
+    zero = _TD64_ZERO if is_timedelta64(step) else 0
+    if step != zero:
+        span = _round_ratio(stop - start, step, 1)
+        int_val = int(_maybe_unpack(np.ceil(span)))
+        stop = start + step * int_val
+    start_equal_stop = _maybe_unpack(start == stop)
+    length = 1 if start_equal_stop else int(_round_ratio(stop - start, step, 0))
+    # step should have the same sign as stop-start, see #321.
+    # Compare signs via direct comparisons (rather than np.sign) since
+    # np.sign(datetime64) returns a datetime64 which includes precision,
+    # so even if the sign is the same, differing precision fails; direct
+    # comparisons are also much cheaper than to_float conversions.
+    diff = stop - start
+    try:
+        same_sign = ((step > zero) == (diff > zero)) & ((step < zero) == (diff < zero))
+    except TypeError:  # mixed types (e.g. datetime.timedelta vs int zero)
+        same_sign = np.sign(to_float(step)) == np.sign(to_float(diff))
+    if not same_sign:
+        msg = "Sign of step must match sign of stop - start"
+        raise CoordError(msg)
+    # Note: dtype was a property before but it messed up model
+    # serialization.
+    return dict(
+        start=start,
+        stop=stop,
+        step=step,
+        shape=(length,),
+        dtype=np.asarray(start + step).dtype,
+        step_numerator=None,
+        step_denominator=None,
+        origin_offset=None,
+    )
+
+
 class CoordRange(BaseCoord):
     """
-    A coordinate represent a range of evenly sampled data.
+    A coordinate representing a range of evenly sampled data.
+
+    Nanosecond time and integer ranges hold their sampling exactly: labels
+    are integer ticks (nanoseconds, or the integers themselves), the ideal
+    grid has a spacing of ``step_numerator / step_denominator`` ticks and an
+    origin ``origin_offset / step_denominator`` ticks after ``start``, and
+    each label is the floor of its ideal position. A slice, stride, or
+    reversal therefore reproduces the labels of the original exactly, and a
+    1024 Hz grid never drifts the way a step rounded to 976562 ns would.
+    ``step`` reports the nearest whole-tick spacing; ``step_exact`` the
+    fraction, in seconds for time.
+
+    Float ranges, and time ranges in units other than nanoseconds, keep a
+    scalar step and evaluate their labels by linear spacing; their grid
+    fields are None.
 
     Parameters
     ----------
     start
         The starting value
     stop
-        The ending value
+        The ending value, exclusive.
     step
-        The step between start and stop.
+        The step between start and stop; for exact grids also a `Fraction`
+        or a ``(numerator, denominator)`` tuple in coordinate units.
+    shape
+        The sample count.
+    step_numerator, step_denominator, origin_offset
+        The exact grid in ticks, normally supplied only when rebuilding a
+        dumped coordinate.
 
     Notes
     -----
@@ -1588,8 +1875,91 @@ class CoordRange(BaseCoord):
     start: Any = None
     stop: Any = None
     step: Any = None
+    step_numerator: int | None = None
+    step_denominator: int | None = None
+    origin_offset: int | None = None
     _evenly_sampled = True
     _rich_style = dascore_styles["coord_range"]
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_start_stop_step_len(cls, values):
+        """Coerce the needed values from the inputs."""
+        get = values.get
+        dtype = _exact_dtype(get("start"), get("stop"), get("step"), get("shape"))
+        fields = (
+            _float_fields(values) if dtype is None else _exact_fields(values, dtype)
+        )
+        values.update(fields)
+        return values
+
+    # --- the two primitives every range operation is built from
+
+    @property
+    def _exact(self) -> bool:
+        """Whether the labels come from an integer grid."""
+        return self.step_numerator is not None
+
+    @property
+    def _grid_terms(self) -> tuple[int, int, int]:
+        """The numerator, denominator, and origin offset of an exact grid."""
+        assert self._exact, "only an exact grid has terms"
+        terms = (self.step_numerator, self.step_denominator, self.origin_offset)
+        return cast("tuple[int, int, int]", terms)
+
+    @property
+    @cached_method
+    def _start_tick(self) -> int:
+        return _to_tick(self.start)
+
+    @property
+    def _ideal_origin(self) -> Fraction:
+        """The ideal origin of an exact grid, in ticks."""
+        _, den, offset = self._grid_terms
+        return Fraction(self._start_tick * den + offset, den)
+
+    def _labels(self, indices) -> np.ndarray:
+        """The labels at these (non-negative, possibly out of range) indices."""
+        indices = np.asarray(indices)
+        if self._exact:
+            indices = indices.astype(np.int64)
+            num, den, offset = self._grid_terms
+            if den == 1:
+                ticks = self._start_tick + indices * num
+            else:
+                ticks = self._start_tick + (offset + indices * num) // den
+            return np.asarray(ticks).astype(self.dtype)
+        if len(self) == 1 or dtype_time_like(self.dtype):
+            return np.asarray(self.start + indices * self.step, dtype=self.dtype)
+        # Match linspace's inferred floating dtype, rounding, and exact endpoint.
+        stop = self.stop - self.step
+        dtype = np.result_type(self.start, stop, 0.0)
+        delta = np.subtract(stop, self.start, dtype=dtype)
+        step = delta / (len(self) - 1)
+        values = indices.astype(dtype)
+        if step == 0:
+            values = (values / (len(self) - 1)) * delta
+        else:
+            values = values * step
+        values = values + self.start
+        values = np.where(indices == len(self) - 1, stop, values)
+        return values.astype(self.dtype)
+
+    def _sliced(self, first: int, stride: int, count: int) -> Self:
+        """The coordinate of the samples first, first + stride, ... (count)."""
+        if self._exact:
+            num, den, offset = self._grid_terms
+            q, offset = divmod(offset + first * num, den)
+            return self._grid(self._start_tick + q, stride * num, den, offset, count)
+        return self._new_grid(self.start + first * self.step, self.step * stride, count)
+
+    def _grid(self, start_tick: int, num: int, den: int, offset: int, count: int):
+        """Construct an exact grid without re-validation."""
+        return self.model_construct(
+            _fields_set=set(self.model_fields_set) | set(_EXACT_GRID_FIELDS),
+            units=self.units,
+            **_grid_fields(start_tick, num, den, offset, count, self.dtype),
+        )
 
     def _new_grid(self, start, step, length: int) -> Self:
         """
@@ -1606,6 +1976,8 @@ class CoordRange(BaseCoord):
         CoordRange and length is computed from indices; anything taking user
         input must go through the validating constructor.
         """
+        if self._exact:
+            return self._grid(_to_tick(start), _to_tick(step), 1, 0, length)
         units = self.units
         # Mirror check_time_units, which forces time-like coords to seconds.
         # Note it tests `start` for truthiness, so a coord starting at exactly
@@ -1624,93 +1996,126 @@ class CoordRange(BaseCoord):
             stop=start + step * length,
         )
 
-    @model_validator(mode="before")
-    @classmethod
-    def validate_start_stop_step_len(cls, values):
-        """Coerce the needed values from the inputs."""
+    # --- identity and display
 
-        def _maybe_unbox_scalar(value):
-            """Extract scalar from a 1-element array-like value."""
-            if isinstance(value, np.ndarray) and value.ndim > 0 and value.size == 1:
-                return value.reshape(-1)[0]
-            return value
-
-        req_values = ("start", "stop", "step", "shape")
-        _attrs = [values.get(x, None) for x in req_values]
-        valid_count = sum(not pd.isnull(x) for x in _attrs)
-        if valid_count < 3:
-            msg = (
-                f"Three of {req_values} are required to create CoordRange. "
-                f"You passed {values}"
-            )
-            raise CoordError(msg)
-        # Now get start, stop, step from length, if provided.
-        start, stop, step, shape = _attrs
-        if not pd.isnull(shape):
-            shape = tuple(iterate(shape))
-            if len(shape) != 1:
-                msg = "Coord range only works for 1D coords."
-                raise CoordError(msg)
-            length = shape[0]
-            if pd.isnull(start):
-                start = stop - step * length
-            if pd.isnull(stop):
-                stop = start + step * length
-            if pd.isnull(step):
-                step = (stop - start) / length
-                # handle conversion to integer if other values are ints.
-                if isinstance(start, int) and isinstance(stop, int):
-                    step = int(step) if np.isclose(np.round(step), step) else step
-
-        def _round_ratio(numerator, denominator, digits):
-            """Round numerator/denominator, cheaply for scalars."""
-            # Inputs are always scalar-like (multi-element arrays are rejected
-            # by the pd.isnull check above) and rounding python floats is
-            # ~10x faster than numpy scalars, hence the float conversion.
-            ratio = _maybe_unbox_scalar(numerator / denominator)
-            return round(float(ratio), digits)
-
-        zero = _TD64_ZERO if is_timedelta64(step) else 0
-        if step != zero:
-            span = _round_ratio(stop - start, step, 1)
-            int_val = int(_maybe_unbox_scalar(np.ceil(span)))
-            stop = start + step * int_val
-        start_equal_stop = _maybe_unbox_scalar(start == stop)
-        length = 1 if start_equal_stop else int(_round_ratio(stop - start, step, 0))
-        shape = (length,)
-        values.update(dict(start=start, stop=stop, shape=shape, step=step))
-        # step should have the same sign as stop-start, see #321.
-        # Compare signs via direct comparisons (rather than np.sign) since
-        # np.sign(datetime64) returns a datetime64 which includes precision,
-        # so even if the sign is the same, differing precision fails; direct
-        # comparisons are also much cheaper than to_float conversions.
-        diff = stop - start
-        step_ = values["step"]
-        try:
-            same_sign = ((step_ > zero) == (diff > zero)) & (
-                (step_ < zero) == (diff < zero)
-            )
-        except TypeError:  # mixed types (e.g. datetime.timedelta vs int zero)
-            same_sign = np.sign(to_float(step_)) == np.sign(to_float(diff))
-        if not same_sign:
-            msg = "Sign of step must match sign of stop - start"
-            raise CoordError(msg)
-        # Note: dtype was a property before but it messed up model
-        # serialization.
-        values["dtype"] = np.asarray(start + step).dtype
-        return values
+    @property
+    def step_exact(self) -> Fraction | None:
+        """The exact spacing in coordinate units (seconds for time), or None."""
+        if not self._exact:
+            return super().step_exact
+        num, den, _ = self._grid_terms
+        frac = Fraction(num, den)
+        return frac / _NS_PER_S if dtype_time_like(self.dtype) else frac
 
     def _fingerprint_components(self) -> tuple[Any, ...]:
-        """Return the scalar payload needed to fingerprint range coords."""
-        return (
+        """The scalar payload of a range, plus the grid when it is not whole ticks."""
+        components = (
             self.shape,
             self._hash_scalar(self.start, "start"),
             self._hash_scalar(self.stop, "stop"),
             self._hash_scalar(self.step, "step"),
         )
+        if self._exact and self.step_denominator != 1:
+            return (*components, self._grid_terms)
+        return components
+
+    def _get_fingerprintable_coord(self) -> Self:
+        if self._exact and self.step_denominator != 1:
+            return self  # units cannot convert; see _convert_units
+        return super()._get_fingerprintable_coord()
+
+    def _repr_fields(self) -> tuple[tuple[str, Text, bool], ...]:
+        fields = super()._repr_fields()
+        if not self._exact or self.step_denominator == 1:
+            return fields
+        # The rounded step misstates a fractional grid (976562 ns is not
+        # 1024 Hz), so the step is said exactly.
+        exact = cast("Fraction", self.step_exact)
+        text = Text(f"{exact}")
+        if dtype_time_like(self.dtype):
+            rate = 1 / abs(exact)
+            rate_str = (
+                str(rate.numerator) if rate.denominator == 1 else f"{float(rate):g}"
+            )
+            text += Text(" s") + Text(f" ({rate_str} Hz)", dascore_styles["units"])
+        elif self.unit_str:
+            text += Text(f" {self.unit_str}", dascore_styles["units"])
+        return tuple(
+            ("step", text, True) if name == "step" else (name, value, labelled)
+            for name, value, labelled in fields
+        )
+
+    def to_summary(self, dims=()) -> CoordSummary:
+        """Get the summary info about the coord, exact grid included."""
+        summary = super().to_summary(dims=dims)
+        if not self._exact:
+            return summary
+        return summary.model_copy(
+            update={name: getattr(self, name) for name in _EXACT_GRID_FIELDS}
+        )
+
+    # --- evaluation
+
+    @property
+    @cached_method
+    def values(self) -> ArrayLike:
+        """Return the values of the coordinate as an array."""
+        if self._exact or len(self) == 1:
+            # Cached, so it must be read-only like the other branch.
+            return array(self._labels(np.arange(len(self))))
+        # note: linspace works better for floats that might have slightly
+        # uneven spacing. It ensures the length of the output array is robust
+        # to small deviations in spacing. However, this doesnt work for datetimes.
+        if is_datetime64(self.start) or is_timedelta64(self.start):
+            out = np.arange(self.start, self.stop, self.step)
+        else:
+            out = np.linspace(
+                self.start, self.stop - self.step, num=len(self), dtype=self.dtype
+            )
+        # again, due to round-off error the array can one element longer than
+        # anticipated. The slice here just ensures shape and len match.
+        return array(out[: len(self)])
+
+    def _get_index_values(self, indices):
+        """Evaluate only requested samples using the same grid as ``values``."""
+        indices = np.asarray(indices)
+        return self._labels(np.where(indices < 0, indices + len(self), indices))
+
+    @cached_method
+    def __len__(self):
+        return self.shape[0]
+
+    def _ends(self) -> tuple:
+        """The first and last labels, in coordinate order."""
+        if self._exact:
+            return tuple(self._labels([0, len(self) - 1]))
+        # like range, coord range is exclusive of final value.
+        return self.start, self.stop - self.step
+
+    def _min(self):
+        """Return min value."""
+        return np.min(self._ends())
+
+    def _max(self):
+        """Return max value in range."""
+        return np.max(self._ends())
+
+    @property
+    def sorted(self) -> bool:
+        """Returns true if sorted in ascending order."""
+        zero = _TD64_ZERO if is_timedelta64(self.step) else 0
+        return self.step >= zero
+
+    @property
+    def reverse_sorted(self) -> bool:
+        """Returns true if sorted in descending order."""
+        zero = _TD64_ZERO if is_timedelta64(self.step) else 0
+        return self.step < zero
+
+    # --- indexing and selection
 
     def __getitem__(self, item):
-        if isinstance(item, (int | np.integer)):
+        if isinstance(item, int | np.integer):
             if item >= len(self) or item < -len(self):
                 raise IndexError(f"{item} exceeds coord length of {self}")
             return self._get_index_values(item)[()]
@@ -1718,56 +2123,40 @@ class CoordRange(BaseCoord):
         if isinstance(item, slice):
             start = None if item.start is ... else item.start
             end = None if item.stop is ... else item.stop
-            item = slice(start, end, item.step)
             # A (possibly strided) slice of an evenly sampled range is still
             # evenly sampled, so preserve the step rather than collapsing to a
             # CoordMonotonicArray (which loses step for len==1). See #567.
-            indices = range(len(self))[item]
+            indices = range(len(self))[slice(start, end, item.step)]
             if len(indices):
-                new_step = self.step * indices.step
-                new_start = self.start + indices.start * self.step
-                return self._new_grid(new_start, new_step, len(indices))
+                return self._sliced(indices.start, indices.step, len(indices))
             return get_coord(data=np.empty(0, dtype=self.dtype), units=self.units)
-        out = self.values[item]
-        return get_coord(data=out, units=self.units)
+        return get_coord(data=self.values[item], units=self.units)
 
-    def _get_index_values(self, indices):
-        """Evaluate only requested samples using the same grid as ``values``."""
-        indices = np.asarray(indices)
-        indices = np.where(indices < 0, indices + len(self), indices)
-        if len(self) == 1 or dtype_time_like(self.dtype):
-            return np.asarray(self.start + indices * self.step, dtype=self.dtype)
-        # Match linspace's inferred floating dtype, rounding, and exact endpoint.
-        stop = self.stop - self.step
-        dtype = np.result_type(self.start, stop, 0.0)
-        delta = np.subtract(stop, self.start, dtype=dtype)
-        step = delta / (len(self) - 1)
-        values = indices.astype(dtype)
-        if step == 0:
-            values = (values / (len(self) - 1)) * delta
-        else:
-            values = values * step
-        values = values + self.start
-        values = np.where(indices == len(self) - 1, stop, values)
-        if np.issubdtype(self.dtype, np.integer):
-            values = np.floor(values)
-        return values.astype(self.dtype)
+    def index(self, indexer, axis: int | None = None) -> BaseCoord:
+        """Index the coordinate; a slice keeps the grid, as ``coord[slice]`` does."""
+        if isinstance(indexer, slice) and not axis:
+            return self[indexer]
+        return super().index(indexer, axis=axis)
 
-    @cached_method
-    def __len__(self):
-        return self.shape[0]
+    def coord_range(self, extend: bool = True):
+        """The span of the coordinate; extended, to its exclusive end."""
+        if not extend or not self._exact:
+            return super().coord_range(extend=extend)
+        first, last = self._labels([0, len(self)])
+        return np.abs(last - first)
 
-    def _convert_units(self, units) -> Self:
-        """Convert units, or set units if none exist."""
-        # cant convert time units
-        if dtype_time_like(self.dtype):
+    @compose_docstring(doc=get_docstring(BaseCoord.change_length))
+    def change_length(self, length: int) -> Self:
+        """
+        {doc}
+        """
+        # CoordRange is always 1D by construction; keep as an internal invariant.
+        assert self.ndim == 1, "Can only change length for 1D coords."
+        length = _validate_new_length(length)
+        if len(self) == length:
             return self
-        out = dict(units=units)
-        start = convert_units(self.start, to_units=units, from_units=self.units)
-        stop = convert_units(self.stop, to_units=units, from_units=self.units)
-        step = (stop - start) / len(self)
-        out["start"], out["stop"], out["step"] = start, stop, step
-        return self.__class__(**out)
+        # Only the sample count changes; start/step are already valid.
+        return self._sliced(0, 1, length)
 
     def select(
         self, args, relative=False, samples=False
@@ -1791,29 +2180,15 @@ class CoordRange(BaseCoord):
         data = slice(start, (stop + 1) if stop is not None else stop)
         if self._slice_degenerate(data):
             return self.empty(), slice(0, 0)
-        # The sample count is known exactly from the indices, so build the
-        # new grid directly rather than making the validator re-derive it.
-        first = 0 if start is None else start
-        last = (len(self) - 1) if stop is None else stop
-        new_start = self[start] if start is not None else self.start
-        new_coords = self._new_grid(new_start, self.step, last + 1 - first)
-        return new_coords, data
+        return self[data], data
 
     def sort(self, reverse=False) -> tuple[BaseCoord, slice | ArrayLike]:
         """Sort the contents of the coord. Return new coord and slice for sorting."""
-        #
         forward_forward = not reverse and self.sorted
         reverse_reverse = reverse and self.reverse_sorted
         if forward_forward or reverse_reverse:
             return self, slice(None)
-        new_step = -self.step
-        if reverse:  # reversing a forward sorted CoordRange
-            new_start = self.max()
-        else:  # order a reverse sorted one
-            new_start = self.min()
-        # reversing preserves the sample count.
-        out = self._new_grid(new_start, new_step, len(self))
-        return out, slice(None, None, -1)
+        return self[::-1], slice(None, None, -1)
 
     def _get_zero_step_index(self, value, forward):
         """
@@ -1828,10 +2203,86 @@ class CoordRange(BaseCoord):
             return 0 if value <= start else len(self)
         return 0 if value >= start else -1
 
+    def _index_of(self, tick: int, forward: bool) -> int:
+        """
+        The sample index a label tick of an exact grid maps to.
+
+        Forward: the first index whose label is at or past ``tick`` in the
+        coordinate's direction. Otherwise the last index whose label is at
+        or before it. Exact, since a label is the floor of its ideal
+        position and ``tick`` is an integer.
+        """
+        num, den, offset = self._grid_terms
+        rel = (tick - self._start_tick) * den - offset
+        if num > 0:
+            if forward:  # label >= tick  <=>  ideal >= tick
+                return -((-rel) // num)
+            # label <= tick  <=>  ideal < tick + 1
+            return -((-(rel + den)) // num) - 1
+        if forward:  # label <= tick  <=>  ideal < tick + 1
+            return (rel + den) // num + 1
+        # label >= tick  <=>  ideal >= tick
+        return rel // num
+
+    def _indices_of(self, ticks: np.ndarray, forward: bool) -> np.ndarray:
+        """``_index_of`` for an array of ticks."""
+        if self.step_denominator != 1:
+            return np.asarray(
+                [self._index_of(int(t), forward) for t in ticks], dtype=np.int64
+            )
+        num, _, _ = self._grid_terms
+        rel = ticks - self._start_tick
+        if num > 0:
+            if forward:
+                return -np.floor_divide(-rel, num)
+            return -np.floor_divide(-(rel + 1), num) - 1
+        if forward:
+            return np.floor_divide(rel + 1, num) + 1
+        return np.floor_divide(rel, num)
+
+    def _bound_ticks(self, values, forward: bool) -> np.ndarray:
+        """
+        The integer ticks an array of query bounds is equivalent to.
+
+        A bound between ticks asks for the labels past it, which are the
+        labels past the next tick in that direction.
+        """
+        values = np.atleast_1d(values)
+        if values.dtype.kind in "mM":  # already nanoseconds, the tick
+            return values.astype("int64")
+        if values.dtype.kind == "f":
+            values = (np.ceil if forward == self.sorted else np.floor)(values)
+        # A bound past the int64 range lies past the coordinate either way.
+        limits = np.iinfo(np.int64)
+        return np.clip(values, limits.min, limits.max).astype(np.int64)
+
     def _get_index(self, value, forward=True):
         """Get the index corresponding to a value."""
         if (value := self._get_compatible_value(value)) is None:
             return value
+        if isinstance(value, np.ndarray) and value.ndim == 0:
+            value = value[()]
+        if not self._exact:
+            return self._get_float_index(value, forward)
+        if self.step_numerator == 0:
+            return self._get_zero_step_index(value, forward)
+        if not isinstance(value, Sized):
+            if isinstance(value, float | np.floating) and not math.isfinite(value):
+                # A bound past one end of the coordinate; its sign says
+                # which, and the checks below open that side.
+                out = len(self) if (value > 0) == self.sorted else -1
+            else:
+                tick = int(self._bound_ticks(value, forward)[0])
+                out = self._index_of(tick, forward)
+            if forward and out < 0:
+                return None
+            if not forward and out >= len(self):
+                return None
+            return out
+        return self._indices_of(self._bound_ticks(value, forward), forward)
+
+    def _get_float_index(self, value, forward=True):
+        """Get the index corresponding to a value of a float range."""
         start, step = self.start, self.step
         if not isinstance(value, Sized):
             # Scalar fast path; avoids several small-array allocations.
@@ -1866,738 +2317,28 @@ class CoordRange(BaseCoord):
             if not forward and out >= len(self):
                 return None
             return out
-        # A 0d array is Sized but holds a single bound, so unbox it rather
-        # than let the array path cast its infinity to the smallest int64.
-        if getattr(value, "ndim", 1) == 0:
-            return self._get_index(value[()], forward=forward)
         array = np.atleast_1d(value)
         func = np.ceil if forward else np.floor
         # Due to float weirdness we need a little bit of a fudge factor here.
         fraction = func(np.round((array - start) / step, decimals=10))
         return fraction.astype(np.int64)
 
-    @compose_docstring(doc=get_docstring(BaseCoord.update_limits))
-    def update_limits(self, min=None, max=None, step=None, **kwargs) -> BaseCoord:
-        """{doc}."""
-        if all(x is not None for x in [min, max, step]):
-            msg = "At most two parameters can be specified in update_limits."
-            raise ValueError(msg)
-        # first case, we need to determine new dt.
-        if min is not None and max is not None:
-            new_step = (max - min) / len(self)
-            return get_coord(start=min, stop=max, step=new_step, units=self.units)
-        # For other combinations we just apply adjustments sequentially
-        # after ensuring that the types are compatible.
-        out = self
-        if step is not None:
-            step = get_compatible_values(step, type(self.step))
-            new_stop = out.start + step * len(out)
-            out = out.new(stop=new_stop, step=step)
-        if min is not None:
-            min = get_compatible_values(min, self.dtype)
-            diff = min - out.start
-            new_stop = out.stop + diff
-            out = out.new(start=min, stop=new_stop)
-        if max is not None:
-            max = get_compatible_values(max, self.dtype)
-            translation = (max + out.step) - out.stop
-            new_start = self.start + translation
-            # we add step so the new range is inclusive of stop.
-            out = out.new(start=new_start, stop=max + out.step)
-        return out.new(**kwargs)
-
-    @property
-    @cached_method
-    def values(self) -> ArrayLike:
-        """Return the values of the coordinate as an array."""
-        if len(self) == 1:
-            # Cached, so it must be read-only like the other branch.
-            return array(np.asarray([self.start]))
-        # note: linspace works better for floats that might have slightly
-        # uneven spacing. It ensures the length of the output array is robust
-        # to small deviations in spacing. However, this doesnt work for datetimes.
-        if is_datetime64(self.start) or is_timedelta64(self.start):
-            out = np.arange(self.start, self.stop, self.step)
-        else:
-            out = np.linspace(
-                self.start, self.stop - self.step, num=len(self), dtype=self.dtype
-            )
-        # again, due to round-off error the array can one element longer than
-        # anticipated. The slice here just ensures shape and len match.
-        return array(out[: len(self)])
-
-    def _min(self):
-        """Return min value."""
-        return np.min([self.start, self.stop - self.step])
-
-    def _max(self):
-        """Return max value in range."""
-        # like range, coord range is exclusive of final value.
-        # the min/max are needed for reverse sorted coord.
-        return np.max([self.stop - self.step, self.start])
-
-    @compose_docstring(doc=get_docstring(BaseCoord.change_length))
-    def change_length(self, length: int) -> Self:
-        """
-        {doc}
-        """
-        # CoordRange is always 1D by construction; keep as an internal invariant.
-        assert self.ndim == 1, "Can only change length for 1D coords."
-        length = _validate_new_length(length)
-        if len(self) == length:
-            return self
-        # Only the sample count changes; start/step are already valid.
-        return self._new_grid(self.start, self.step, length)
-
-    @property
-    def sorted(self) -> bool:
-        """Returns true if sorted in ascending order."""
-        zero = _TD64_ZERO if is_timedelta64(self.step) else 0
-        return self.step >= zero
-
-    @property
-    def reverse_sorted(self) -> bool:
-        """Returns true if sorted in ascending order."""
-        zero = _TD64_ZERO if is_timedelta64(self.step) else 0
-        return self.step < zero
-
-
-_EXACT_GRID_FIELDS = ("step_numerator", "step_denominator", "origin_offset")
-# Nanoseconds per second: the tick of every exact time grid.
-_NS_PER_S = 10**9
-
-
-def _unbox_scalar(value):
-    """Extract the scalar from a 0-d or 1-element array."""
-    if isinstance(value, np.ndarray) and value.size == 1:
-        return value.reshape(-1)[0]
-    return value
-
-
-def _is_int_scalar(value) -> bool:
-    """Return True for a python or numpy integer (not a bool)."""
-    value = _unbox_scalar(value)
-    return isinstance(value, int | np.integer) and not isinstance(
-        value, bool | np.bool_
-    )
-
-
-def _is_fraction_step(step) -> bool:
-    """Return True if step is a Fraction or a (numerator, denominator) tuple."""
-    return isinstance(step, Fraction | tuple)
-
-
-def _as_fraction(step) -> Fraction:
-    """A Fraction or (numerator, denominator) step as a Fraction."""
-    return Fraction(*step) if isinstance(step, tuple) else Fraction(step)
-
-
-def _is_null_scalar(value) -> bool:
-    """Return True for None or a null scalar (NaN, NaT); False for others."""
-    if value is None:
-        return True
-    if _is_fraction_step(value):
-        return False
-    return bool(pd.isnull(_unbox_scalar(value)))
-
-
-def _exact_time_dtype(start, stop, step) -> np.dtype | None:
-    """
-    The nanosecond dtype an exact time range holds, or None to stay legacy.
-
-    Ticks are nanoseconds, DASCore's time unit. A scalar step resolves as
-    `start + step` does, so only nanosecond inputs are exact; a fraction
-    step is stated in seconds and always resolves to nanoseconds.
-    """
-    ends = [np.asarray(x).dtype for x in (start, stop) if not _is_null_scalar(x)]
-    if _is_fraction_step(step):
-        return np.dtype(f"{ends[0].kind}8[ns]")
-    parts = ends if step is None else [*ends, np.asarray(_unbox_scalar(step)).dtype]
-    try:
-        dtype = np.result_type(*parts)
-    except TypeError:  # not all time-like: let the legacy validator say so
-        return None
-    return dtype if dtype.kind in "mM" and dtype.str.endswith("[ns]") else None
-
-
-def _to_tick(value) -> int:
-    """Return a time value as nanoseconds, or an integer value as itself."""
-    value = _unbox_scalar(value)
-    if is_datetime64(value) or is_timedelta64(value):
-        return int(to_int(value))
-    if isinstance(value, float | np.floating):
-        if not float(value).is_integer():
-            msg = f"An integer coordinate cannot hold the non-integer value {value}."
-            raise CoordError(msg)
-        return int(value)
-    try:
-        return int(value)
-    except (TypeError, ValueError) as e:
-        msg = f"{value!r} is not an integer or time value."
-        raise CoordError(msg) from e
-
-
-def _step_value(step_tick: int, dtype: np.dtype):
-    """A whole-tick step as a scalar of the coordinate's step type."""
-    if dtype.kind in "mM":
-        return np.timedelta64(step_tick, "ns")
-    return step_tick
-
-
-def _range_class(start, stop, step, shape) -> type[CoordRange]:
-    """
-    Pick the range class for these inputs.
-
-    Time and integer inputs get an exact integer grid (CoordRangeInt);
-    everything else stays a plain CoordRange. A fraction step on a float
-    coordinate is rejected: floats have no tick to be a fraction of.
-    """
-    anchor = stop if _is_null_scalar(start) else start
-    fraction = _is_fraction_step(step)
-    if is_datetime64(anchor) or is_timedelta64(anchor):
-        if _exact_time_dtype(start, stop, step) is None:
-            return CoordRange
-        return CoordRangeInt
-    int_like = _is_int_scalar(anchor) and (
-        _is_null_scalar(stop) or _is_int_scalar(stop)
-    )
-    if int_like and fraction:
-        return CoordRangeInt
-    if int_like and _is_null_scalar(step):
-        # Without a step the spacing comes from the span and count, and an
-        # uneven division makes floats, as it always has.
-        both = not (_is_null_scalar(start) or _is_null_scalar(stop))
-        length = next(iter(iterate(shape))) if shape is not None else 0
-        if (
-            both
-            and length
-            and (int(_unbox_scalar(stop)) - int(_unbox_scalar(start))) % length
-        ):
-            return CoordRange
-        return CoordRangeInt
-    if int_like and _is_int_scalar(step):
-        return CoordRangeInt
-    if fraction:
-        msg = (
-            "A fraction step requires a datetime64, timedelta64, or integer "
-            f"coordinate, not {np.asarray(anchor).dtype}."
-        )
-        raise CoordError(msg)
-    return CoordRange
-
-
-def _build_range(**attrs) -> CoordRange:
-    """Construct a range coordinate of the class the inputs call for."""
-    cls = _range_class(
-        attrs.get("start"), attrs.get("stop"), attrs.get("step"), attrs.get("shape")
-    )
-    if cls is CoordRange:
-        for name in _EXACT_GRID_FIELDS:
-            attrs.pop(name, None)
-    return cls(**attrs)
-
-
-def _range_from_dump(payload: dict) -> CoordRange:
-    """Rebuild a range coordinate from its model_dump payload, class intact."""
-    if any(payload.get(name) is not None for name in _EXACT_GRID_FIELDS):
-        return CoordRangeInt(**payload)
-    return CoordRange(**payload)
-
-
-def _normalize_grid(num: int, den: int, offset: int) -> tuple[int, int, int]:
-    """
-    Reduce a grid by the common divisor of all three terms.
-
-    Reducing the step alone would move the ideal origin: from (num 3, den 2,
-    offset 1) the stride-two grid (6, 2, 1) must stay as it is, since (3, 1,
-    0) keeps the labels but shifts the origin by half a tick.
-    """
-    g = math.gcd(num, den, offset)
-    if g > 1:
-        num, den, offset = num // g, den // g, offset // g
-    return num, den, offset
-
-
-def _count_from_span(span: int, num: int, den: int, offset: int) -> int:
-    """
-    The number of ideal positions in [start, start + span), either direction.
-
-    Rounded to a tenth of a sample first, as CoordRange has always done, so
-    a stop stated a hair past a sample does not add one.
-    """
-    ratio = Fraction(span * den - offset, num)
-    # Rounded as a float, as the parent does, so halfway cases agree too.
-    return max(1, math.ceil(round(float(ratio), 1)))
-
-
-def _check_grid_fits(start_tick: int, num: int, den: int, count: int, dtype) -> None:
-    """Refuse a grid whose labels would not fit the dtype or int64 arithmetic."""
-    dtype = np.dtype(dtype)
-    info = np.iinfo(np.int64 if dtype.kind in "mM" else cast("Any", dtype))
-    last = start_tick + (count * num) // den
-    low, high = min(start_tick, last), max(start_tick, last)
-    if abs(count * num) + den >= 2**63 or low < info.min or high > info.max:
-        msg = (
-            f"A grid of {count} samples with step {num}/{den} ticks from "
-            f"{start_tick} exceeds the {dtype} range."
-        )
-        raise CoordError(msg)
-
-
-class CoordRangeInt(CoordRange):
-    """
-    A range coordinate on an exact integer grid.
-
-    The class `get_coord` returns for nanosecond datetime64 and timedelta64
-    ranges and for integer ranges. Labels are integer ticks: nanoseconds, or
-    the integers themselves. The ideal grid has a spacing of
-    ``step_numerator / step_denominator`` ticks and an origin
-    ``origin_offset / step_denominator`` ticks after ``start``; each label is
-    the floor of its ideal position. A slice, stride, or reversal therefore
-    reproduces the labels of the original exactly, and a 1024 Hz grid never
-    drifts the way a step rounded to 976562 ns would.
-
-    ``step`` is the nearest whole-tick step (ties to even), kept for every
-    consumer that reads a scalar spacing. ``step_exact`` is the exact
-    spacing in coordinate units (seconds for time). The two agree when the
-    denominator is one, which is every coordinate built from a scalar step.
-
-    Parameters
-    ----------
-    start
-        The first label.
-    stop
-        The exclusive end: the label the grid would place after the last.
-    step
-        The spacing; a scalar, a `Fraction`, or a ``(numerator,
-        denominator)`` tuple in coordinate units.
-    shape
-        The sample count, authoritative when given.
-    step_numerator, step_denominator, origin_offset
-        The exact grid in ticks, normally supplied only when rebuilding a
-        dumped coordinate.
-
-    Notes
-    -----
-    Its repr reads ``CoordRange``; the class is an implementation detail
-    which `isinstance(coord, CoordRange)` continues to cover.
-    """
-
-    step_numerator: int
-    step_denominator: int = 1
-    origin_offset: int = 0
-    _repr_name = "CoordRange"
-
-    @model_validator(mode="before")
-    @classmethod
-    def validate_start_stop_step_len(cls, values):
-        """Resolve the exact grid, then derive stop, step, and dtype from it."""
-        start, stop, step, shape = (
-            _unbox_scalar(values.get(x)) for x in ("start", "stop", "step", "shape")
-        )
-        start = None if _is_null_scalar(start) else start
-        stop = None if _is_null_scalar(stop) else stop
-        step = None if _is_null_scalar(step) else step
-        anchor = start if start is not None else stop
-        if anchor is None:
-            msg = f"CoordRangeInt requires start or stop; you passed {values}."
-            raise CoordError(msg)
-        time_like = is_datetime64(anchor) or is_timedelta64(anchor)
-        if time_like:
-            dtype = _exact_time_dtype(start, stop, step)
-            if dtype is None:
-                msg = f"An exact time grid needs nanoseconds, not {values}."
-                raise CoordError(msg)
-        start_tick = None if start is None else _to_tick(start)
-        stop_tick = None if stop is None else _to_tick(stop)
-        count = None
-        if shape is not None:
-            shape = tuple(iterate(shape))
-            if len(shape) != 1:
-                msg = "Coord range only works for 1D coords."
-                raise CoordError(msg)
-            count = int(shape[0])
-            if count < 1:
-                msg = "A range coordinate needs at least one sample."
-                raise CoordError(msg)
-        # The grid: a fraction step wins, then explicit grid fields, then a
-        # scalar step, then the span divided by the count.
-        offset = int(values.get("origin_offset") or 0)
-        if _is_fraction_step(step):
-            frac = _as_fraction(step)
-            if time_like:
-                frac = frac * _NS_PER_S
-            num, den = frac.numerator, frac.denominator
-        elif values.get("step_numerator") is not None:
-            num = int(values["step_numerator"])
-            den = int(values.get("step_denominator") or 1)
-        elif step is not None:
-            num, den, offset = _to_tick(step), 1, 0
-        else:
-            if start_tick is None or stop_tick is None or count is None:
-                msg = (
-                    "Three of ('start', 'stop', 'step', 'shape') are required "
-                    f"to create CoordRange. You passed {values}"
-                )
-                raise CoordError(msg)
-            frac = Fraction(stop_tick - start_tick, count)
-            num, den, offset = frac.numerator, frac.denominator, 0
-        if den < 1:
-            msg = "step_denominator must be positive."
-            raise CoordError(msg)
-        if 0 < abs(num) < den:
-            msg = "A step smaller than one tick would repeat labels."
-            raise CoordError(msg)
-        if not 0 <= offset < den:
-            msg = f"origin_offset must satisfy 0 <= offset < {den}, got {offset}."
-            raise CoordError(msg)
-        # Resolve start and count.
-        if count is None:
-            if start_tick is None or stop_tick is None:
-                msg = "start, stop, and step, or a shape, are needed."
-                raise CoordError(msg)
-            if num == 0 or start_tick == stop_tick:
-                count = 1
-            else:
-                span = stop_tick - start_tick
-                if (span > 0) != (num > 0):
-                    msg = "Sign of step must match sign of stop - start"
-                    raise CoordError(msg)
-                count = _count_from_span(span, num, den, offset)
-        if start_tick is None:
-            assert stop_tick is not None, "the anchor check above"
-            # The ideal origin is count steps before stop; start is its floor.
-            start_tick, offset = divmod(stop_tick * den - count * num, den)
-        num, den, offset = _normalize_grid(num, den, offset)
-        step_tick = round(Fraction(num, den))
-        end_tick = start_tick + (offset + count * num) // den
-        if time_like:
-            start_value = np.asarray(start_tick, dtype=np.int64).astype(dtype)[()]
-        else:
-            start_value = start if start is not None else start_tick
-            dtype = np.asarray(start_value + step_tick).dtype
-        _check_grid_fits(start_tick, num, den, count, dtype)
-        values.update(
-            start=start_value,
-            stop=np.asarray(end_tick, dtype=np.int64).astype(dtype)[()],
-            step=_step_value(step_tick, dtype),
-            shape=(count,),
-            dtype=dtype,
-            step_numerator=num,
-            step_denominator=den,
-            origin_offset=offset,
-        )
-        return values
-
-    # --- grid arithmetic
-
-    @property
-    @cached_method
-    def _start_tick(self) -> int:
-        return _to_tick(self.start)
-
-    @property
-    def _ideal_origin(self) -> Fraction:
-        """The ideal origin in ticks."""
-        den = self.step_denominator
-        return Fraction(self._start_tick * den + self.origin_offset, den)
-
-    @property
-    def step_exact(self) -> Fraction:
-        """The exact spacing in coordinate units (seconds for time)."""
-        frac = Fraction(self.step_numerator, self.step_denominator)
-        return frac / _NS_PER_S if dtype_time_like(self.dtype) else frac
-
-    def _ticks(self, indices) -> np.ndarray:
-        """The label ticks at these (non-negative) indices."""
-        indices = np.asarray(indices, dtype=np.int64)
-        num, den = self.step_numerator, self.step_denominator
-        if den == 1:
-            return self._start_tick + indices * num
-        return self._start_tick + (self.origin_offset + indices * num) // den
-
-    def _from_ticks(self, ticks) -> np.ndarray:
-        """Ticks to values of the coordinate dtype."""
-        return np.asarray(ticks, dtype=np.int64).astype(self.dtype)
-
-    def _grid(self, start_tick: int, num: int, den: int, offset: int, count: int):
-        """Construct a coordinate on a known grid without re-validation."""
-        num, den, offset = _normalize_grid(num, den, offset)
-        dtype = np.dtype(self.dtype)
-        _check_grid_fits(start_tick, num, den, count, dtype)
-        start = self._from_ticks(start_tick)[()]
-        stop = self._from_ticks(start_tick + (offset + count * num) // den)[()]
-        step_tick = round(Fraction(num, den))
-        step = _step_value(step_tick, dtype)
-        if not dtype_time_like(dtype):
-            step = type(self.step)(step_tick)
-        return self.model_construct(
-            _fields_set=set(self.model_fields_set) | set(_EXACT_GRID_FIELDS),
-            units=self.units,
-            step=step,
-            shape=(count,),
-            dtype=dtype,
-            start=start,
-            stop=stop,
-            step_numerator=num,
-            step_denominator=den,
-            origin_offset=offset,
-        )
-
-    def _new_grid(self, start, step, length: int) -> Self:
-        """A whole-tick grid from a start value and scalar step."""
-        return self._grid(_to_tick(start), _to_tick(step), 1, 0, length)
-
-    def _sliced(self, first: int, stride: int, count: int):
-        """The coordinate of the samples first, first + stride, ... (count)."""
-        num, den = self.step_numerator, self.step_denominator
-        q, offset = divmod(self.origin_offset + first * num, den)
-        return self._grid(self._start_tick + q, stride * num, den, offset, count)
-
-    def _index_of(self, tick: int, forward: bool) -> int:
-        """
-        The sample index a label tick maps to.
-
-        Forward: the first index whose label is at or past ``tick`` in the
-        coordinate's direction. Otherwise the last index whose label is at
-        or before it. Exact, since a label is the floor of its ideal
-        position and ``tick`` is an integer.
-        """
-        num, den = self.step_numerator, self.step_denominator
-        rel = (tick - self._start_tick) * den - self.origin_offset
-        if num > 0:
-            if forward:  # label >= tick  <=>  ideal >= tick
-                return -((-rel) // num)
-            # label <= tick  <=>  ideal < tick + 1
-            return -((-(rel + den)) // num) - 1
-        if forward:  # label <= tick  <=>  ideal < tick + 1
-            return (rel + den) // num + 1
-        # label >= tick  <=>  ideal >= tick
-        return rel // num
-
-    def _indices_of_whole(self, ticks: np.ndarray, forward: bool) -> np.ndarray:
-        """Vectorized ``_index_of`` for a whole-tick grid."""
-        num = self.step_numerator
-        rel = ticks - self._start_tick
-        if num > 0:
-            if forward:
-                return -np.floor_divide(-rel, num)
-            return -np.floor_divide(-(rel + 1), num) - 1
-        if forward:
-            return np.floor_divide(rel + 1, num) + 1
-        return np.floor_divide(rel, num)
-
-    def _bound_ticks(self, values, forward: bool) -> np.ndarray:
-        """
-        The integer ticks an array of query bounds is equivalent to.
-
-        A bound between ticks asks for the labels past it, which are the
-        labels past the next tick in that direction.
-        """
-        values = np.atleast_1d(values)
-        if values.dtype.kind in "mM":  # already nanoseconds, the tick
-            return values.astype("int64")
-        if values.dtype.kind == "f":
-            values = (np.ceil if forward == self.sorted else np.floor)(values)
-        # A bound past the int64 range lies past the coordinate either way.
-        limits = np.iinfo(np.int64)
-        return np.clip(values, limits.min, limits.max).astype(np.int64)
-
-    # --- overrides
-
-    def _fingerprint_components(self) -> tuple[Any, ...]:
-        """The parent's payload, plus the grid when it is not whole ticks."""
-        components = super()._fingerprint_components()
-        if self.step_denominator == 1:
-            return components
-        grid = (self.step_numerator, self.step_denominator, self.origin_offset)
-        return (*components, grid)
-
-    @staticmethod
-    def _coord_identity(coord: BaseCoord) -> str:
-        """Fingerprint as a CoordRange: the grid, not the class, is the identity."""
-        return f"{CoordRange.__module__}.{CoordRange.__qualname__}"
-
-    def _get_fingerprintable_coord(self) -> Self:
-        if self.step_denominator != 1:
-            return self
-        return super()._get_fingerprintable_coord()
-
-    def __getitem__(self, item):
-        if isinstance(item, int | np.integer):
-            if item >= len(self) or item < -len(self):
-                raise IndexError(f"{item} exceeds coord length of {self}")
-            return self._get_index_values(item)[()]
-        if isinstance(item, slice):
-            start = None if item.start is ... else item.start
-            end = None if item.stop is ... else item.stop
-            indices = range(len(self))[slice(start, end, item.step)]
-            if len(indices):
-                return self._sliced(indices.start, indices.step, len(indices))
-            return get_coord(data=np.empty(0, dtype=self.dtype), units=self.units)
-        return get_coord(data=self.values[item], units=self.units)
-
-    def _get_index_values(self, indices):
-        """Evaluate only the requested samples."""
-        indices = np.asarray(indices)
-        indices = np.where(indices < 0, indices + len(self), indices)
-        return self._from_ticks(self._ticks(indices))
-
-    def index(self, indexer, axis: int | None = None) -> BaseCoord:
-        """Index the coordinate; a slice keeps the grid, as ``coord[slice]`` does."""
-        if isinstance(indexer, slice) and not axis:
-            return self[indexer]
-        return super().index(indexer, axis=axis)
-
-    def coord_range(self, extend: bool = True):
-        """The span of the coordinate; extended, its exact exclusive end."""
-        if not extend:
-            return super().coord_range(extend=False)
-        first, last = self._get_index_values([0, len(self)])
-        return np.abs(last - first)
-
-    @property
-    @cached_method
-    def values(self) -> ArrayLike:
-        """Return the values of the coordinate as an array."""
-        return array(self._from_ticks(self._ticks(np.arange(len(self)))))
-
-    def _min(self):
-        """Return min value."""
-        return np.min(self._get_index_values([0, len(self) - 1]))
-
-    def _max(self):
-        """Return max value."""
-        return np.max(self._get_index_values([0, len(self) - 1]))
-
-    @property
-    def sorted(self) -> bool:
-        """Returns true if sorted in ascending order."""
-        return self.step_numerator >= 0
-
-    @property
-    def reverse_sorted(self) -> bool:
-        """Returns true if sorted in descending order."""
-        return self.step_numerator < 0
-
-    def _get_index(self, value, forward=True):
-        """Get the index corresponding to a value."""
-        if (value := self._get_compatible_value(value)) is None:
-            return value
-        if isinstance(value, np.ndarray) and value.ndim == 0:
-            value = value[()]
-        if self.step_numerator == 0:
-            return self._get_zero_step_index(value, forward)
-        if not isinstance(value, Sized):
-            if isinstance(value, float | np.floating) and not math.isfinite(value):
-                # A bound past one end of the coordinate; its sign says
-                # which, and the checks below open that side.
-                out = len(self) if (value > 0) == self.sorted else -1
-            else:
-                tick = int(self._bound_ticks(value, forward)[0])
-                out = self._index_of(tick, forward)
-            if forward and out < 0:
-                return None
-            if not forward and out >= len(self):
-                return None
-            return out
-        ticks = self._bound_ticks(value, forward)
-        if self.step_denominator == 1:
-            return self._indices_of_whole(ticks, forward)
-        return np.asarray(
-            [self._index_of(int(t), forward) for t in ticks], dtype=np.int64
-        )
-
-    def select(
-        self, args, relative=False, samples=False
-    ) -> tuple[BaseCoord, slice | ArrayLike]:
-        """
-        Apply select, return selected coords and index to apply to array.
-
-        Can return a CoordDegenerate if selection is outside of range.
-        """
-        if is_array(args):
-            return self._select_by_array(args, relative=relative, samples=samples)
-        elif samples:
-            return self._select_by_samples(args)
-        args = self.get_slice_tuple(args, relative=relative)
-        start = self._get_index(args[0], forward=self.sorted)
-        stop = self._get_index(args[1], forward=self.reverse_sorted)
-        if self.reverse_sorted:
-            start, stop = stop, start
-        start = None if start == 0 else start
-        data = slice(start, (stop + 1) if stop is not None else stop)
-        if self._slice_degenerate(data):
-            return self.empty(), slice(0, 0)
-        return self[data], data
-
-    def sort(self, reverse=False) -> tuple[BaseCoord, slice | ArrayLike]:
-        """Sort the contents of the coord. Return new coord and slice for sorting."""
-        forward_forward = not reverse and self.sorted
-        reverse_reverse = reverse and self.reverse_sorted
-        if forward_forward or reverse_reverse:
-            return self, slice(None)
-        return self[::-1], slice(None, None, -1)
-
-    @compose_docstring(doc=get_docstring(BaseCoord.change_length))
-    def change_length(self, length: int) -> Self:
-        """
-        {doc}
-        """
-        length = _validate_new_length(length)
-        if len(self) == length:
-            return self
-        return self._grid(
-            self._start_tick,
-            self.step_numerator,
-            self.step_denominator,
-            self.origin_offset,
-            length,
-        )
-
-    def _translated(self, delta_tick: int) -> Self:
-        """Shift every label by whole ticks; the grid moves with them."""
-        return self._grid(
-            self._start_tick + delta_tick,
-            self.step_numerator,
-            self.step_denominator,
-            self.origin_offset,
-            len(self),
-        )
-
-    def _with_step(self, step) -> BaseCoord:
-        """The same start and count on a new cadence."""
-        if _is_fraction_step(step):
-            frac = _as_fraction(step)
-            if dtype_time_like(self.dtype):
-                frac = frac * _NS_PER_S
-            num, den = frac.numerator, frac.denominator
-        else:
-            step = get_compatible_values(step, type(self.step))
-            try:
-                num, den = _to_tick(step), 1
-            except CoordError:
-                # A step this grid cannot hold (a float on integers, a finer
-                # time unit) re-dispatches to the class that can.
-                return get_coord(
-                    start=self.start, step=step, shape=self.shape, units=self.units
-                )
-        if 0 < abs(num) < den:
-            msg = "A step smaller than one tick would repeat labels."
-            raise CoordError(msg)
-        return self._grid(self._start_tick, num, den, 0, len(self))
-
     def _samples_in(self, duration):
-        """How many exact steps a duration spans."""
+        """How many steps a duration spans, unrounded."""
+        if not self._exact:
+            return super()._samples_in(duration)
         if dtype_time_like(self.dtype):
             ticks = Fraction(int(to_int(dc.to_timedelta64(duration))))
         else:
             plain = duration.item() if isinstance(duration, np.generic) else duration
             ticks = Fraction(plain)
-        return ticks / abs(Fraction(self.step_numerator, self.step_denominator))
+        num, den, _ = self._grid_terms
+        return ticks / abs(Fraction(num, den))
 
     def _out_of_bounds_indices(self, array) -> np.ndarray:
-        """Positions past either end, from the exact grid."""
+        """Positions past either end, from the grid."""
+        if not self._exact:
+            return super()._out_of_bounds_indices(array)
         # Toward the coordinate: past the last label its floor position,
         # before the first its ceiling, as the truncating division did.
         past_end = self._get_index(array, forward=False)
@@ -2606,6 +2347,37 @@ class CoordRangeInt(CoordRange):
         beyond = (array > last) if self.sorted else (array < last)
         return np.where(beyond, past_end, before_start).astype(np.int64)
 
+    # --- updates
+
+    def _translated(self, delta) -> Self:
+        """Shift every label by a whole number of ticks; the grid moves with them."""
+        if self._exact:
+            num, den, offset = self._grid_terms
+            start_tick = self._start_tick + _to_tick(delta)
+            return self._grid(start_tick, num, den, offset, len(self))
+        return self._new_grid(self.start + delta, self.step, len(self))
+
+    def _with_step(self, step) -> CoordRange:
+        """The same start and count on a new cadence."""
+        if (frac := _fraction_step(step)) is None:
+            step = get_compatible_values(step, type(self.step))
+        whole_tick = frac is None and (_is_int(step) or is_timedelta64(step))
+        if not self._exact or not (frac is not None or whole_tick):
+            # Re-validate: the class picks the representation the step needs.
+            return CoordRange(
+                start=self.start, step=step, shape=self.shape, units=self.units
+            )
+        if frac is not None:
+            if dtype_time_like(self.dtype):
+                frac = frac * _NS_PER_S
+            num, den = frac.numerator, frac.denominator
+        else:
+            num, den = _to_tick(step), 1
+        if 0 < abs(num) < den:
+            msg = "A step smaller than one tick would repeat labels."
+            raise CoordError(msg)
+        return self._grid(self._start_tick, num, den, 0, len(self))
+
     @compose_docstring(doc=get_docstring(BaseCoord.update_limits))
     def update_limits(self, min=None, max=None, step=None, **kwargs) -> BaseCoord:
         """{doc}."""
@@ -2614,34 +2386,34 @@ class CoordRangeInt(CoordRange):
             raise ValueError(msg)
         out = self
         if min is not None and max is not None:
-            # As for every range: min is the new start, max the new
-            # exclusive stop, and the count is kept. The spacing is exact
-            # when it is at least a tick; below that the labels are floats.
+            # min is the new start, max the new exclusive stop, and the count
+            # is kept. An exact grid keeps an exact spacing when it is at
+            # least a tick; below that the labels become floats.
             min = get_compatible_values(min, self.dtype)
             max = get_compatible_values(max, self.dtype)
-            frac = Fraction(_to_tick(max) - _to_tick(min), len(self))
-            if abs(frac) < 1:
-                new_step = (max - min) / len(self)
-                out = get_coord(start=min, stop=max, step=new_step, units=self.units)
-            else:
+            span = _to_tick(max) - _to_tick(min) if self._exact else 0
+            if abs(frac := Fraction(span, len(self))) >= 1:
                 out = self._grid(
                     _to_tick(min), frac.numerator, frac.denominator, 0, len(self)
                 )
+            else:
+                new_step = (max - min) / len(self)
+                out = get_coord(start=min, stop=max, step=new_step, units=self.units)
             return out.new(**kwargs) if kwargs else out
+        # For other combinations we just apply adjustments sequentially
+        # after ensuring that the types are compatible.
         if step is not None:
-            out = self._with_step(step)
-            if not isinstance(out, CoordRangeInt):  # re-dispatched to another class
-                return out.update_limits(min=min, max=max, **kwargs)
+            out = out._with_step(step)
         if min is not None:
             min = get_compatible_values(min, self.dtype)
-            out = out._translated(_to_tick(min) - _to_tick(out.min()))
+            out = out._translated(min - out.min())
         if max is not None:
             max = get_compatible_values(max, self.dtype)
-            out = out._translated(_to_tick(max) - _to_tick(out.max()))
+            out = out._translated(max - out.max())
         return out.new(**kwargs) if kwargs else out
 
     def new(self, **kwargs):
-        """Update coordinate; the exact grid is kept unless the step changes."""
+        """Update coordinate; an exact grid is kept unless the step changes."""
         if "data" in kwargs or "values" in kwargs:
             return super().new(**kwargs)
         info = self.model_dump(exclude_unset=True, exclude_defaults=True)
@@ -2654,55 +2426,24 @@ class CoordRangeInt(CoordRange):
         info.update(kwargs)
         return get_coord(**info)
 
-    def _convert_units(self, units) -> BaseCoord:  # ty: ignore[invalid-method-override]
-        """Convert units, or set units if none exist; integers become floats."""
+    def _convert_units(self, units) -> Self:
+        """Convert units, or set units if none exist."""
+        # cant convert time units
         if dtype_time_like(self.dtype):
             return self
-        if self.step_denominator != 1:
+        if self._exact and self.step_denominator != 1:
             msg = (
                 "Cannot convert the units of an integer coordinate with a "
                 f"fractional step ({self.step_exact}); the result is not an "
                 "integer grid."
             )
             raise CoordError(msg)
-        # Whole-tick integer grids convert exactly as a CoordRange does,
-        # which turns them into floats.
+        out = dict(units=units)
         start = convert_units(self.start, to_units=units, from_units=self.units)
         stop = convert_units(self.stop, to_units=units, from_units=self.units)
         step = (stop - start) / len(self)
-        return get_coord(start=start, stop=stop, step=step, units=units)
-
-    def to_summary(self, dims=()) -> CoordSummary:
-        """Get the summary info about the coord, exact grid included."""
-        summary = super().to_summary(dims=dims)
-        return summary.model_copy(
-            update=dict(
-                step_numerator=self.step_numerator,
-                step_denominator=self.step_denominator,
-                origin_offset=self.origin_offset,
-            )
-        )
-
-    def _repr_fields(self) -> tuple[tuple[str, Text, bool], ...]:
-        fields = super()._repr_fields()
-        if self.step_denominator == 1:
-            return fields
-        # The rounded step misstates a fractional grid (976562 ns is not
-        # 1024 Hz), so the step is said exactly.
-        exact = self.step_exact
-        text = Text(f"{exact}")
-        if dtype_time_like(self.dtype):
-            rate = 1 / abs(exact)
-            rate_str = (
-                str(rate.numerator) if rate.denominator == 1 else f"{float(rate):g}"
-            )
-            text += Text(" s") + Text(f" ({rate_str} Hz)", dascore_styles["units"])
-        elif self.unit_str:
-            text += Text(f" {self.unit_str}", dascore_styles["units"])
-        return tuple(
-            ("step", text, True) if name == "step" else (name, value, labelled)
-            for name, value, labelled in fields
-        )
+        out["start"], out["stop"], out["step"] = start, stop, step
+        return self.__class__(**out)
 
 
 class CoordArray(BaseCoord):
@@ -2957,7 +2698,7 @@ def _coerce_segment(seg) -> BaseCoord:
         # Round-trip support: rebuild segments from model_dump payloads.
         if seg.get("values") is not None:
             return CoordMonotonicArray(**seg)
-        return _range_from_dump(seg)
+        return CoordRange(**seg)
     msg = f"Segments must be coordinates, got {type(seg)}."
     raise CoordError(msg)
 
@@ -2987,10 +2728,10 @@ def _range_continues(prev: BaseCoord, seg: BaseCoord) -> bool:
         return False
     if prev.step_exact != seg.step_exact:
         return False
-    if isinstance(prev, CoordRangeInt) and isinstance(seg, CoordRangeInt):
+    if prev._exact and seg._exact:
         # The ideal origins must line up, not just the rounded labels.
-        step = Fraction(prev.step_numerator, prev.step_denominator)
-        return seg._ideal_origin == prev._ideal_origin + len(prev) * step
+        num, den, _ = prev._grid_terms
+        return seg._ideal_origin == prev._ideal_origin + len(prev) * Fraction(num, den)
     return bool(prev.step == seg.step and prev.stop == seg.start)
 
 
@@ -3485,7 +3226,7 @@ class CoordSegmented(BaseCoord):
         # Strictly monotonic segments guarantee a nonzero step matching the
         # sort direction.
         assert step != zero and (step > zero) == ascending
-        candidate = _build_range(
+        candidate = CoordRange(
             start=first, stop=last + step, step=step, units=self.units
         ).change_length(n)
         actual = np.concatenate([x.values for x in run])
@@ -3927,7 +3668,7 @@ def get_coord(
         Cannot be combined with other value inputs.
     step_numerator, step_denominator, origin_offset
         The exact grid of an integer or time range in ticks (see
-        [`CoordRangeInt`](`dascore.core.coords.CoordRangeInt`)). Normally
+        [`CoordRange`](`dascore.core.coords.CoordRange`)). Normally
         these come from a dumped coordinate; pass ``step`` as a `Fraction`
         or ``(numerator, denominator)`` tuple to state a fractional step.
 
@@ -4065,15 +3806,17 @@ def get_coord(
         # A 1D shape with two of start/stop/step states a range; anything
         # less (or more dimensions) is a partial coord. A range that then
         # fails to validate is an error, not a partial.
-        stated = sum(not _is_null_scalar(x) for x in (start, stop, step))
+        stated = sum(not _is_null(x) for x in (start, stop, step))
         if len(shape) != 1 or shape[0] == 0 or stated < 2:
             return CoordPartial(**attrs)
         try:
-            return _build_range(**attrs, **grid)
+            return CoordRange(
+                shape=shape, start=start, stop=stop, step=step, units=units, **grid
+            )
         except (ValidationError, CoordError):
             # A float range that cannot be built is still a partial, as it
-            # always was; the exact class raises only for what is wrong.
-            if _range_class(start, stop, step, shape) is CoordRangeInt:
+            # always was; an exact grid raises only for what is wrong.
+            if _exact_dtype(start, stop, step, shape) is not None:
                 raise
             return CoordPartial(**attrs)
 
@@ -4112,13 +3855,13 @@ def get_coord(
         # special case of len 1 array either get range, if step specified
         # or sorted monotonic array if not.
         elif kind == "single":
-            if not _is_null_scalar(step):
+            if not _is_null(step):
                 val = data[0]
-                return _build_range(start=val, shape=(1,), step=step, units=units)
+                return CoordRange(start=val, shape=(1,), step=step, units=units)
             return CoordMonotonicArray(values=data, units=units)
         start, stop, step, monotonic = _maybe_get_start_stop_step(data)
         if start is not None:
-            out = _build_range(start=start, stop=stop, step=step, units=units)
+            out = CoordRange(start=start, stop=stop, step=step, units=units)
             # The change_length call helps with float off by one issues.
             return out.change_length(len(data))
         elif monotonic:
@@ -4142,4 +3885,4 @@ def get_coord(
             )
         return CoordArray(values=data, units=units)
     else:
-        return _build_range(start=start, stop=stop, step=step, units=units, **grid)
+        return CoordRange(start=start, stop=stop, step=step, units=units, **grid)

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -14,6 +14,7 @@ import math
 import re
 from collections.abc import Mapping, Sequence, Sized
 from contextlib import suppress
+from fractions import Fraction
 from functools import cache
 from operator import gt, lt
 from types import EllipsisType
@@ -243,6 +244,15 @@ class CoordSummary(DascoreBaseModel):
     dims: tuple[str, ...] = ()
     len: int | None = None
     fingerprint: str | None = None
+    # The exact grid of a CoordRangeInt, in ticks; None for other coords.
+    step_numerator: int | None = None
+    step_denominator: int | None = None
+    origin_offset: int | None = None
+
+    @property
+    def is_exact_grid(self) -> bool:
+        """Return True when the summary states an exact integer grid."""
+        return self.step_numerator is not None
 
     @property
     def is_range_like(self) -> bool:
@@ -295,17 +305,24 @@ class CoordSummary(DascoreBaseModel):
             raise CoordError(msg)
         step = self.step
         assert step is not None  # is_range_like above rules out a null step
+        if (num := self.step_numerator) is not None:
+            if self.len is None:
+                msg = "An exact grid summary needs its length to rebuild a coord."
+                raise CoordError(msg)
+            return CoordRangeInt(
+                start=self.min if num >= 0 else self.max,
+                shape=(self.len,),
+                step_numerator=num,
+                step_denominator=self.step_denominator or 1,
+                origin_offset=self.origin_offset or 0,
+                units=self.units,
+            )
         # this is a reverse coord
         if np.sign(step) == -1:
             start, stop = self.max, self.min + step
         else:
             start, stop = self.min, self.max + step
-        return CoordRange(
-            start=start,
-            stop=stop,
-            step=step,
-            units=self.units,
-        )
+        return _build_range(start=start, stop=stop, step=step, units=self.units)
 
 
 @cache
@@ -389,6 +406,9 @@ class BaseCoord(RichRepr, DascoreBaseModel, abc.ABC):
             """The coordinate's values."""
 
     _rich_style = dascore_styles["default_coord"]
+    # The name a repr states; a subclass which is an implementation detail
+    # of another coordinate kind states that kind's name.
+    _repr_name: str | None = None
     _evenly_sampled = False
     _sorted = False
     _reverse_sorted = False
@@ -673,7 +693,7 @@ class BaseCoord(RichRepr, DascoreBaseModel, abc.ABC):
     def __rich__(self):
         key_style = dascore_styles["keys"]
         base = Text("")
-        base += Text(self.__class__.__name__, style=self._rich_style)
+        base += Text(self._repr_name or self.__class__.__name__, style=self._rich_style)
         base += Text("(")
         for label, value, labelled in self._repr_fields():
             base += Text(f" {label}: ", key_style) if labelled else Text(" ")
@@ -792,6 +812,23 @@ class BaseCoord(RichRepr, DascoreBaseModel, abc.ABC):
         # math rather than np.prod: the shape is a tuple of ints, and numpy
         # hands back an np.int64 (or a float 1.0 for the empty shape).
         return math.prod(self.shape)
+
+    @property
+    def step_exact(self) -> Fraction | None:
+        """
+        The exact spacing as a fraction in coordinate units, or None.
+
+        A timedelta step is exact in seconds and an integer step in its own
+        units; a float step has no exact form and gives None.
+        """
+        step = self.step
+        if step is None or _is_null_scalar(step):
+            return None
+        if is_timedelta64(step):
+            return Fraction(int(to_int(step)), 10**9)
+        if _is_int_scalar(step):
+            return Fraction(int(step))
+        return None
 
     @property
     def evenly_sampled(self) -> bool:
@@ -1159,11 +1196,7 @@ class BaseCoord(RichRepr, DascoreBaseModel, abc.ABC):
         else:
             compat_val = self._get_compatible_value(value, relative=True)
             duration = compat_val - self.min()
-            # The magnitude of the step, because a window of 30 m is thirty
-            # samples whether the coordinate counts up or down. A descending
-            # coordinate has a negative step, and dividing by it signed would
-            # make the count negative.
-            ratio = duration / np.abs(self.step)
+            ratio = self._samples_in(duration)
             if np.issubdtype(self.dtype, np.floating):
                 nearest = np.round(ratio)
                 # Adding a relative float value to coord.min() and subtracting
@@ -1172,7 +1205,7 @@ class BaseCoord(RichRepr, DascoreBaseModel, abc.ABC):
                 tol = 10 * abs(np.spacing(self.min()) / self.step)
                 if abs(ratio - nearest) <= tol:
                     ratio = nearest
-            samples = int(np.ceil(ratio))
+            samples = math.ceil(ratio)
         if enforce_lt_coord and samples > len(self):
             msg = (
                 f"value of {value} with samples={samples} results in a window "
@@ -1180,6 +1213,18 @@ class BaseCoord(RichRepr, DascoreBaseModel, abc.ABC):
             )
             raise ParameterError(msg)
         return samples
+
+    def _samples_in(self, duration):
+        """How many steps a duration spans, unrounded."""
+        # The magnitude of the step, because a window of 30 m is thirty
+        # samples whether the coordinate counts up or down. A descending
+        # coordinate has a negative step, and dividing by it signed would
+        # make the count negative.
+        return duration / np.abs(self.step)
+
+    def _out_of_bounds_indices(self, array) -> np.ndarray:
+        """The positions values past either end of an evenly sampled coord map to."""
+        return ((array - self.min()) / self.step).astype(np.int64)
 
     def _get_index(self, value, forward=True):
         """
@@ -1258,8 +1303,7 @@ class BaseCoord(RichRepr, DascoreBaseModel, abc.ABC):
                 return array if input_array_like else array[0]
             # For absolute mode with evenly sampled coords, compute index from value
             if hasattr(self, "step") and self.step is not None:
-                # Calculate index: (value - min) / step
-                indices = ((array - min_val) / self.step).astype(np.int64)
+                indices = self._out_of_bounds_indices(array)
                 return indices if input_array_like else indices[0]
 
         # Clamp values to bounds for backward compatibility when not out of bounds
@@ -1918,6 +1962,812 @@ class CoordRange(BaseCoord):
         return self.step < zero
 
 
+_EXACT_GRID_FIELDS = ("step_numerator", "step_denominator", "origin_offset")
+# Seconds in one unit of each fixed-length numpy time unit. Months and
+# years are not fixed, and nothing finer than a nanosecond is supported.
+_SECONDS_PER_UNIT: Mapping[str, Fraction] = {
+    "W": Fraction(604_800),
+    "D": Fraction(86_400),
+    "h": Fraction(3_600),
+    "m": Fraction(60),
+    "s": Fraction(1),
+    "ms": Fraction(1, 10**3),
+    "us": Fraction(1, 10**6),
+    "ns": Fraction(1, 10**9),
+}
+
+
+def _unbox_scalar(value):
+    """Extract the scalar from a 0-d or 1-element array."""
+    if isinstance(value, np.ndarray) and value.size == 1:
+        return value.reshape(-1)[0]
+    return value
+
+
+def _is_int_scalar(value) -> bool:
+    """Return True for a python or numpy integer (not a bool)."""
+    value = _unbox_scalar(value)
+    return isinstance(value, int | np.integer) and not isinstance(
+        value, bool | np.bool_
+    )
+
+
+def _is_fraction_step(step) -> bool:
+    """Return True if step is a Fraction or a (numerator, denominator) tuple."""
+    return isinstance(step, Fraction | tuple)
+
+
+def _as_fraction(step) -> Fraction:
+    """A Fraction or (numerator, denominator) step as a Fraction."""
+    return Fraction(*step) if isinstance(step, tuple) else Fraction(step)
+
+
+def _is_null_scalar(value) -> bool:
+    """Return True for None or a null scalar (NaN, NaT); False for others."""
+    if value is None:
+        return True
+    if _is_fraction_step(value):
+        return False
+    return bool(pd.isnull(_unbox_scalar(value)))
+
+
+def _time_unit(dtype) -> tuple[str, int]:
+    """The unit and count of a time dtype, read from its string form."""
+    match = re.fullmatch(r"[<>|=]?[mM]8\[(\d*)([a-zA-Z]+)\]", np.dtype(dtype).str)
+    if match is None:  # a generic time dtype states no unit
+        return "generic", 1
+    return match.group(2), int(match.group(1) or 1)
+
+
+def _timedelta_dtype(dtype) -> np.dtype:
+    """The timedelta dtype with the unit of a time dtype."""
+    unit, count = _time_unit(dtype)
+    return np.dtype(f"m8[{count if count != 1 else ''}{unit}]")
+
+
+def _seconds_per_tick(dtype) -> Fraction | None:
+    """Seconds in one tick of a time dtype, or None if it has no fixed length."""
+    unit, count = _time_unit(dtype)
+    seconds = _SECONDS_PER_UNIT.get(unit)
+    return None if seconds is None else seconds * count
+
+
+def _tick_seconds(dtype) -> Fraction:
+    """Seconds in one tick of a time dtype known to have a fixed length."""
+    seconds = _seconds_per_tick(dtype)
+    assert seconds is not None, "callers check the unit first"
+    return seconds
+
+
+def _step_value(step_tick: int, dtype: np.dtype):
+    """A whole-tick step as a scalar of the coordinate's step type."""
+    if dtype.kind in "mM":
+        ticks = np.asarray(step_tick, dtype=np.int64)
+        return ticks.astype(_timedelta_dtype(dtype))[()]
+    return step_tick
+
+
+def _time_tick_dtype(start, stop, step) -> np.dtype | None:
+    """
+    The tick dtype an exact time range resolves to, or None to stay legacy.
+
+    A scalar step resolves as `start + step` does, to the finer unit. A
+    fraction step is stated in seconds, and nanoseconds hold it.
+    """
+    ends = [np.asarray(x).dtype for x in (start, stop) if not _is_null_scalar(x)]
+    if _is_fraction_step(step):
+        dtype = np.dtype(f"{ends[0].kind}8[ns]")
+    else:
+        parts = ends if step is None else [*ends, np.asarray(_unbox_scalar(step)).dtype]
+        try:
+            dtype = np.result_type(*parts)
+        except TypeError:  # not all time-like: let the legacy validator say so
+            return None
+    if dtype.kind not in "mM" or _seconds_per_tick(dtype) is None:
+        return None
+    return dtype
+
+
+def _to_tick(value, dtype: np.dtype) -> int:
+    """
+    Return value as an integer tick of ``dtype``: its unit for time, or itself.
+
+    Raises CoordError if the value does not sit on a tick.
+    """
+    value = _unbox_scalar(value)
+    if dtype.kind in "mM":
+        # A step is a timedelta whatever the coordinate holds, so the
+        # target keeps the unit and takes the value's own kind.
+        if is_timedelta64(value) and dtype.kind == "M":
+            dtype = _timedelta_dtype(dtype)
+        try:
+            converted = np.asarray(value).astype(dtype)
+            exact = converted.astype(np.asarray(value).dtype) == np.asarray(value)
+        except (TypeError, ValueError) as e:
+            msg = f"{value!r} is not a {dtype} value."
+            raise CoordError(msg) from e
+        if not exact:
+            msg = f"{value} does not sit on the {dtype} grid."
+            raise CoordError(msg)
+        return int(converted.view(np.int64))
+    if isinstance(value, float | np.floating):
+        if not float(value).is_integer():
+            msg = f"An integer coordinate cannot hold the non-integer value {value}."
+            raise CoordError(msg)
+        return int(value)
+    return int(value)
+
+
+def _range_class(start, stop, step, shape) -> type[CoordRange]:
+    """
+    Pick the range class for these inputs.
+
+    Time and integer inputs get an exact integer grid (CoordRangeInt);
+    everything else stays a plain CoordRange. A fraction step on a float
+    coordinate is rejected: floats have no tick to be a fraction of.
+    """
+    anchor = stop if _is_null_scalar(start) else start
+    fraction = _is_fraction_step(step)
+    if is_datetime64(anchor) or is_timedelta64(anchor):
+        if _time_tick_dtype(start, stop, step) is None:
+            return CoordRange
+        return CoordRangeInt
+    int_like = _is_int_scalar(anchor) and (
+        _is_null_scalar(stop) or _is_int_scalar(stop)
+    )
+    if int_like and fraction:
+        return CoordRangeInt
+    if int_like and _is_null_scalar(step):
+        # Without a step the spacing comes from the span and count, and an
+        # uneven division makes floats, as it always has.
+        both = not (_is_null_scalar(start) or _is_null_scalar(stop))
+        length = next(iter(iterate(shape))) if shape is not None else 0
+        if (
+            both
+            and length
+            and (int(_unbox_scalar(stop)) - int(_unbox_scalar(start))) % length
+        ):
+            return CoordRange
+        return CoordRangeInt
+    if int_like and _is_int_scalar(step):
+        return CoordRangeInt
+    if fraction:
+        msg = (
+            "A fraction step requires a datetime64, timedelta64, or integer "
+            f"coordinate, not {np.asarray(anchor).dtype}."
+        )
+        raise CoordError(msg)
+    return CoordRange
+
+
+def _build_range(**attrs) -> CoordRange:
+    """Construct a range coordinate of the class the inputs call for."""
+    cls = _range_class(
+        attrs.get("start"), attrs.get("stop"), attrs.get("step"), attrs.get("shape")
+    )
+    if cls is CoordRange:
+        for name in _EXACT_GRID_FIELDS:
+            attrs.pop(name, None)
+    return cls(**attrs)
+
+
+def _range_from_dump(payload: dict) -> CoordRange:
+    """Rebuild a range coordinate from its model_dump payload, class intact."""
+    if any(payload.get(name) is not None for name in _EXACT_GRID_FIELDS):
+        return CoordRangeInt(**payload)
+    return CoordRange(**payload)
+
+
+def _normalize_grid(num: int, den: int, offset: int) -> tuple[int, int, int]:
+    """
+    Reduce a grid by the common divisor of all three terms.
+
+    Reducing the step alone would move the ideal origin: from (num 3, den 2,
+    offset 1) the stride-two grid (6, 2, 1) must stay as it is, since (3, 1,
+    0) keeps the labels but shifts the origin by half a tick.
+    """
+    g = math.gcd(num, den, offset)
+    if g > 1:
+        num, den, offset = num // g, den // g, offset // g
+    return num, den, offset
+
+
+def _count_from_span(span: int, num: int, den: int, offset: int) -> int:
+    """
+    The number of ideal positions in [start, start + span), either direction.
+
+    Rounded to a tenth of a sample first, as CoordRange has always done, so
+    a stop stated a hair past a sample does not add one.
+    """
+    ratio = Fraction(span * den - offset, num)
+    # Rounded as a float, as the parent does, so halfway cases agree too.
+    return max(1, math.ceil(round(float(ratio), 1)))
+
+
+def _check_grid_fits(start_tick: int, num: int, den: int, count: int) -> None:
+    """Refuse a grid whose evaluation would overflow int64."""
+    limit = 2**63
+    reach = start_tick + (count * num + den) // den
+    if abs(count * num) + den >= limit or not -limit <= reach < limit:
+        msg = (
+            f"A grid of {count} samples with step {num}/{den} ticks from "
+            f"{start_tick} exceeds the int64 range."
+        )
+        raise CoordError(msg)
+
+
+class CoordRangeInt(CoordRange):
+    """
+    A range coordinate on an exact integer grid.
+
+    The class `get_coord` returns for datetime64, timedelta64, and integer
+    ranges. Labels are integer ticks: the coordinate's time unit
+    (nanoseconds unless coarser inputs say otherwise) or the integers
+    themselves. The ideal grid has a spacing of ``step_numerator /
+    step_denominator`` ticks and an origin ``origin_offset /
+    step_denominator`` ticks after ``start``; each label is the floor of its
+    ideal position. A slice, stride, or reversal therefore reproduces the
+    labels of the original exactly, and a 1024 Hz grid never drifts the way
+    a step rounded to 976562 ns would.
+
+    ``step`` is the nearest whole-tick step (ties to even), kept for every
+    consumer that reads a scalar spacing. ``step_exact`` is the exact
+    spacing in coordinate units (seconds for time). The two agree when the
+    denominator is one, which is every coordinate built from a scalar step.
+
+    Parameters
+    ----------
+    start
+        The first label.
+    stop
+        The exclusive end: the label the grid would place after the last.
+    step
+        The spacing; a scalar, a `Fraction`, or a ``(numerator,
+        denominator)`` tuple in coordinate units.
+    shape
+        The sample count, authoritative when given.
+    step_numerator, step_denominator, origin_offset
+        The exact grid in ticks, normally supplied only when rebuilding a
+        dumped coordinate.
+
+    Notes
+    -----
+    Its repr reads ``CoordRange``; the class is an implementation detail
+    which `isinstance(coord, CoordRange)` continues to cover.
+    """
+
+    step_numerator: int
+    step_denominator: int = 1
+    origin_offset: int = 0
+    _repr_name = "CoordRange"
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_start_stop_step_len(cls, values):
+        """Resolve the exact grid, then derive stop, step, and dtype from it."""
+        start, stop, step, shape = (
+            _unbox_scalar(values.get(x)) for x in ("start", "stop", "step", "shape")
+        )
+        start = None if _is_null_scalar(start) else start
+        stop = None if _is_null_scalar(stop) else stop
+        step = None if _is_null_scalar(step) else step
+        anchor = start if start is not None else stop
+        if anchor is None:
+            msg = f"CoordRangeInt requires start or stop; you passed {values}."
+            raise CoordError(msg)
+        time_like = is_datetime64(anchor) or is_timedelta64(anchor)
+        if time_like:
+            dtype = _time_tick_dtype(start, stop, step)
+            if dtype is None:
+                msg = f"{np.asarray(anchor).dtype} has no fixed tick length."
+                raise CoordError(msg)
+        else:
+            dtype = np.dtype(np.int64)  # placeholder until the step is known
+        start_tick = None if start is None else _to_tick(start, dtype)
+        stop_tick = None if stop is None else _to_tick(stop, dtype)
+        count = None
+        if shape is not None:
+            shape = tuple(iterate(shape))
+            if len(shape) != 1:
+                msg = "Coord range only works for 1D coords."
+                raise CoordError(msg)
+            count = int(shape[0])
+            if count < 1:
+                msg = "A range coordinate needs at least one sample."
+                raise CoordError(msg)
+        # The grid: a fraction step wins, then explicit grid fields, then a
+        # scalar step, then the span divided by the count.
+        offset = int(values.get("origin_offset") or 0)
+        if _is_fraction_step(step):
+            frac = _as_fraction(step)
+            if time_like:
+                frac = frac / _tick_seconds(dtype)
+            num, den = frac.numerator, frac.denominator
+        elif values.get("step_numerator") is not None:
+            num = int(values["step_numerator"])
+            den = int(values.get("step_denominator") or 1)
+        elif step is not None:
+            num, den, offset = _to_tick(step, dtype), 1, 0
+        else:
+            if start_tick is None or stop_tick is None or count is None:
+                msg = (
+                    "Three of ('start', 'stop', 'step', 'shape') are required "
+                    f"to create CoordRange. You passed {values}"
+                )
+                raise CoordError(msg)
+            frac = Fraction(stop_tick - start_tick, count)
+            num, den, offset = frac.numerator, frac.denominator, 0
+        if den < 1:
+            msg = "step_denominator must be positive."
+            raise CoordError(msg)
+        if 0 < abs(num) < den:
+            msg = "A step smaller than one tick would repeat labels."
+            raise CoordError(msg)
+        if not 0 <= offset < den:
+            msg = f"origin_offset must satisfy 0 <= offset < {den}, got {offset}."
+            raise CoordError(msg)
+        # Resolve start and count.
+        if count is None:
+            if start_tick is None or stop_tick is None:
+                msg = "start, stop, and step, or a shape, are needed."
+                raise CoordError(msg)
+            if num == 0 or start_tick == stop_tick:
+                count = 1
+            else:
+                span = stop_tick - start_tick
+                if (span > 0) != (num > 0):
+                    msg = "Sign of step must match sign of stop - start"
+                    raise CoordError(msg)
+                count = _count_from_span(span, num, den, offset)
+        if start_tick is None:
+            assert stop_tick is not None, "the anchor check above"
+            # The ideal origin is count steps before stop; start is its floor.
+            start_tick, offset = divmod(stop_tick * den - count * num, den)
+        num, den, offset = _normalize_grid(num, den, offset)
+        _check_grid_fits(start_tick, num, den, count)
+        step_tick = round(Fraction(num, den))
+        end_tick = start_tick + (offset + count * num) // den
+        if time_like:
+            start_value = np.asarray(start_tick, dtype=np.int64).astype(dtype)[()]
+        else:
+            start_value = start if start is not None else start_tick
+            dtype = np.asarray(start_value + step_tick).dtype
+        values.update(
+            start=start_value,
+            stop=np.asarray(end_tick, dtype=np.int64).astype(dtype)[()],
+            step=_step_value(step_tick, dtype),
+            shape=(count,),
+            dtype=dtype,
+            step_numerator=num,
+            step_denominator=den,
+            origin_offset=offset,
+        )
+        return values
+
+    # --- grid arithmetic
+
+    @property
+    @cached_method
+    def _start_tick(self) -> int:
+        return _to_tick(self.start, np.dtype(self.dtype))
+
+    @property
+    def _ideal_origin(self) -> Fraction:
+        """The ideal origin in ticks."""
+        den = self.step_denominator
+        return Fraction(self._start_tick * den + self.origin_offset, den)
+
+    @property
+    def step_exact(self) -> Fraction:
+        """The exact spacing in coordinate units (seconds for time)."""
+        frac = Fraction(self.step_numerator, self.step_denominator)
+        if dtype_time_like(self.dtype):
+            return frac * _tick_seconds(self.dtype)
+        return frac
+
+    def _ticks(self, indices) -> np.ndarray:
+        """The label ticks at these (non-negative) indices."""
+        indices = np.asarray(indices, dtype=np.int64)
+        num, den = self.step_numerator, self.step_denominator
+        if den == 1:
+            return self._start_tick + indices * num
+        return self._start_tick + (self.origin_offset + indices * num) // den
+
+    def _from_ticks(self, ticks) -> np.ndarray:
+        """Ticks to values of the coordinate dtype."""
+        return np.asarray(ticks, dtype=np.int64).astype(self.dtype)
+
+    def _grid(self, start_tick: int, num: int, den: int, offset: int, count: int):
+        """Construct a coordinate on a known grid without re-validation."""
+        num, den, offset = _normalize_grid(num, den, offset)
+        _check_grid_fits(start_tick, num, den, count)
+        dtype = np.dtype(self.dtype)
+        start = self._from_ticks(start_tick)[()]
+        stop = self._from_ticks(start_tick + (offset + count * num) // den)[()]
+        step_tick = round(Fraction(num, den))
+        step = _step_value(step_tick, dtype)
+        if not dtype_time_like(dtype):
+            step = type(self.step)(step_tick)
+        return self.model_construct(
+            _fields_set=set(self.model_fields_set) | set(_EXACT_GRID_FIELDS),
+            units=self.units,
+            step=step,
+            shape=(count,),
+            dtype=dtype,
+            start=start,
+            stop=stop,
+            step_numerator=num,
+            step_denominator=den,
+            origin_offset=offset,
+        )
+
+    def _new_grid(self, start, step, length: int) -> Self:
+        """A whole-tick grid from a start value and scalar step."""
+        dtype = np.dtype(self.dtype)
+        return self._grid(_to_tick(start, dtype), _to_tick(step, dtype), 1, 0, length)
+
+    def _sliced(self, first: int, stride: int, count: int):
+        """The coordinate of the samples first, first + stride, ... (count)."""
+        num, den = self.step_numerator, self.step_denominator
+        q, offset = divmod(self.origin_offset + first * num, den)
+        return self._grid(self._start_tick + q, stride * num, den, offset, count)
+
+    def _index_of(self, tick: int, forward: bool) -> int:
+        """
+        The sample index a label tick maps to.
+
+        Forward: the first index whose label is at or past ``tick`` in the
+        coordinate's direction. Otherwise the last index whose label is at
+        or before it. Exact, since a label is the floor of its ideal
+        position and ``tick`` is an integer.
+        """
+        num, den = self.step_numerator, self.step_denominator
+        rel = (tick - self._start_tick) * den - self.origin_offset
+        if num > 0:
+            if forward:  # label >= tick  <=>  ideal >= tick
+                return -((-rel) // num)
+            # label <= tick  <=>  ideal < tick + 1
+            return -((-(rel + den)) // num) - 1
+        if forward:  # label <= tick  <=>  ideal < tick + 1
+            return (rel + den) // num + 1
+        # label >= tick  <=>  ideal >= tick
+        return rel // num
+
+    def _indices_of_whole(self, ticks: np.ndarray, forward: bool) -> np.ndarray:
+        """Vectorized ``_index_of`` for a whole-tick grid."""
+        num = self.step_numerator
+        rel = ticks - self._start_tick
+        if num > 0:
+            if forward:
+                return -np.floor_divide(-rel, num)
+            return -np.floor_divide(-(rel + 1), num) - 1
+        if forward:
+            return np.floor_divide(rel + 1, num) + 1
+        return np.floor_divide(rel, num)
+
+    def _bound_ticks(self, values, forward: bool) -> np.ndarray:
+        """
+        The integer ticks an array of query bounds is equivalent to.
+
+        A bound between ticks asks for the labels past it, which are the
+        labels past the next tick in that direction.
+        """
+        values = np.atleast_1d(values)
+        toward_end = forward == self.sorted
+        dtype = np.dtype(self.dtype)
+        if dtype.kind in "mM":
+            ticks = values.astype(dtype)
+            back = ticks.astype(values.dtype)
+            ticks = ticks.view(np.int64)
+            # A bound finer than the tick: below the truncated tick when
+            # the cast went up, above it when the cast went down.
+            floor = np.where(back > values, ticks - 1, ticks)
+            return np.where(back == values, ticks, floor + toward_end)
+        if values.dtype.kind == "f":
+            values = (np.ceil if toward_end else np.floor)(values)
+        return values.astype(np.int64)
+
+    # --- overrides
+
+    def _fingerprint_components(self) -> tuple[Any, ...]:
+        """The parent's payload, plus the grid when it is not whole ticks."""
+        components = super()._fingerprint_components()
+        if self.step_denominator == 1:
+            return components
+        grid = (self.step_numerator, self.step_denominator, self.origin_offset)
+        return (*components, grid)
+
+    @staticmethod
+    def _coord_identity(coord: BaseCoord) -> str:
+        """Fingerprint as a CoordRange: the grid, not the class, is the identity."""
+        return f"{CoordRange.__module__}.{CoordRange.__qualname__}"
+
+    def _get_fingerprintable_coord(self) -> Self:
+        if self.step_denominator != 1:
+            return self
+        return super()._get_fingerprintable_coord()
+
+    def __getitem__(self, item):
+        if isinstance(item, int | np.integer):
+            if item >= len(self) or item < -len(self):
+                raise IndexError(f"{item} exceeds coord length of {self}")
+            return self._get_index_values(item)[()]
+        if isinstance(item, slice):
+            start = None if item.start is ... else item.start
+            end = None if item.stop is ... else item.stop
+            indices = range(len(self))[slice(start, end, item.step)]
+            if len(indices):
+                return self._sliced(indices.start, indices.step, len(indices))
+            return get_coord(data=np.empty(0, dtype=self.dtype), units=self.units)
+        return get_coord(data=self.values[item], units=self.units)
+
+    def _get_index_values(self, indices):
+        """Evaluate only the requested samples."""
+        indices = np.asarray(indices)
+        indices = np.where(indices < 0, indices + len(self), indices)
+        return self._from_ticks(self._ticks(indices))
+
+    @property
+    @cached_method
+    def values(self) -> ArrayLike:
+        """Return the values of the coordinate as an array."""
+        return array(self._from_ticks(self._ticks(np.arange(len(self)))))
+
+    def _min(self):
+        """Return min value."""
+        return np.min(self._get_index_values([0, len(self) - 1]))
+
+    def _max(self):
+        """Return max value."""
+        return np.max(self._get_index_values([0, len(self) - 1]))
+
+    @property
+    def sorted(self) -> bool:
+        """Returns true if sorted in ascending order."""
+        return self.step_numerator >= 0
+
+    @property
+    def reverse_sorted(self) -> bool:
+        """Returns true if sorted in descending order."""
+        return self.step_numerator < 0
+
+    def _get_index(self, value, forward=True):
+        """Get the index corresponding to a value."""
+        if (value := self._get_compatible_value(value)) is None:
+            return value
+        if isinstance(value, np.ndarray) and value.ndim == 0:
+            value = value[()]
+        if self.step_numerator == 0:
+            return self._get_zero_step_index(value, forward)
+        if not isinstance(value, Sized):
+            if isinstance(value, float | np.floating) and not math.isfinite(value):
+                # A bound past one end of the coordinate; its sign says
+                # which, and the checks below open that side.
+                out = len(self) if (value > 0) == self.sorted else -1
+            else:
+                tick = int(self._bound_ticks(value, forward)[0])
+                out = self._index_of(tick, forward)
+            if forward and out < 0:
+                return None
+            if not forward and out >= len(self):
+                return None
+            return out
+        ticks = self._bound_ticks(value, forward)
+        if self.step_denominator == 1:
+            return self._indices_of_whole(ticks, forward)
+        return np.asarray(
+            [self._index_of(int(t), forward) for t in ticks], dtype=np.int64
+        )
+
+    def select(
+        self, args, relative=False, samples=False
+    ) -> tuple[BaseCoord, slice | ArrayLike]:
+        """
+        Apply select, return selected coords and index to apply to array.
+
+        Can return a CoordDegenerate if selection is outside of range.
+        """
+        if is_array(args):
+            return self._select_by_array(args, relative=relative, samples=samples)
+        elif samples:
+            return self._select_by_samples(args)
+        args = self.get_slice_tuple(args, relative=relative)
+        start = self._get_index(args[0], forward=self.sorted)
+        stop = self._get_index(args[1], forward=self.reverse_sorted)
+        if self.reverse_sorted:
+            start, stop = stop, start
+        start = None if start == 0 else start
+        data = slice(start, (stop + 1) if stop is not None else stop)
+        if self._slice_degenerate(data):
+            return self.empty(), slice(0, 0)
+        return self[data], data
+
+    def sort(self, reverse=False) -> tuple[BaseCoord, slice | ArrayLike]:
+        """Sort the contents of the coord. Return new coord and slice for sorting."""
+        forward_forward = not reverse and self.sorted
+        reverse_reverse = reverse and self.reverse_sorted
+        if forward_forward or reverse_reverse:
+            return self, slice(None)
+        return self[::-1], slice(None, None, -1)
+
+    @compose_docstring(doc=get_docstring(BaseCoord.change_length))
+    def change_length(self, length: int) -> Self:
+        """
+        {doc}
+        """
+        length = _validate_new_length(length)
+        if len(self) == length:
+            return self
+        return self._grid(
+            self._start_tick,
+            self.step_numerator,
+            self.step_denominator,
+            self.origin_offset,
+            length,
+        )
+
+    def _translated(self, delta_tick: int) -> Self:
+        """Shift every label by whole ticks; the grid moves with them."""
+        return self._grid(
+            self._start_tick + delta_tick,
+            self.step_numerator,
+            self.step_denominator,
+            self.origin_offset,
+            len(self),
+        )
+
+    def _with_step(self, step) -> BaseCoord:
+        """The same start and count on a new cadence."""
+        dtype = np.dtype(self.dtype)
+        if _is_fraction_step(step):
+            frac = _as_fraction(step)
+            if dtype_time_like(dtype):
+                frac = frac / _tick_seconds(dtype)
+            num, den = frac.numerator, frac.denominator
+        else:
+            step = get_compatible_values(step, type(self.step))
+            try:
+                num, den = _to_tick(step, dtype), 1
+            except CoordError:
+                # A step this grid cannot hold (a float on integers, a finer
+                # time unit) re-dispatches to the class that can.
+                return get_coord(
+                    start=self.start, step=step, shape=self.shape, units=self.units
+                )
+        if 0 < abs(num) < den:
+            msg = "A step smaller than one tick would repeat labels."
+            raise CoordError(msg)
+        return self._grid(self._start_tick, num, den, 0, len(self))
+
+    def _samples_in(self, duration):
+        """How many exact steps a duration spans."""
+        if dtype_time_like(self.dtype):
+            ns = int(to_int(dc.to_timedelta64(duration)))
+            ticks = Fraction(ns) / (_tick_seconds(self.dtype) * 10**9)
+        else:
+            plain = duration.item() if isinstance(duration, np.generic) else duration
+            ticks = Fraction(plain)
+        return ticks / abs(Fraction(self.step_numerator, self.step_denominator))
+
+    def _out_of_bounds_indices(self, array) -> np.ndarray:
+        """Positions past either end, from the exact grid."""
+        # Toward the coordinate: past the last label its floor position,
+        # before the first its ceiling, as the truncating division did.
+        past_end = self._get_index(array, forward=False)
+        before_start = self._get_index(array, forward=True)
+        last = self._get_index_values(len(self) - 1)
+        beyond = (array > last) if self.sorted else (array < last)
+        return np.where(beyond, past_end, before_start).astype(np.int64)
+
+    @compose_docstring(doc=get_docstring(BaseCoord.update_limits))
+    def update_limits(self, min=None, max=None, step=None, **kwargs) -> BaseCoord:
+        """{doc}."""
+        if all(x is not None for x in [min, max, step]):
+            msg = "At most two parameters can be specified in update_limits."
+            raise ValueError(msg)
+        dtype = np.dtype(self.dtype)
+        out = self
+        if min is not None and max is not None:
+            # As for every range: min is the new start, max the new
+            # exclusive stop, and the count is kept. The spacing is exact
+            # when it is at least a tick; below that the labels are floats.
+            min = get_compatible_values(min, self.dtype)
+            max = get_compatible_values(max, self.dtype)
+            frac = Fraction(_to_tick(max, dtype) - _to_tick(min, dtype), len(self))
+            if abs(frac) < 1:
+                new_step = (max - min) / len(self)
+                out = get_coord(start=min, stop=max, step=new_step, units=self.units)
+            else:
+                out = self._grid(
+                    _to_tick(min, dtype), frac.numerator, frac.denominator, 0, len(self)
+                )
+            return out.new(**kwargs) if kwargs else out
+        if step is not None:
+            out = self._with_step(step)
+            if not isinstance(out, CoordRangeInt):  # re-dispatched to another class
+                return out.update_limits(min=min, max=max, **kwargs)
+        if min is not None:
+            min = get_compatible_values(min, self.dtype)
+            out = out._translated(_to_tick(min, dtype) - _to_tick(out.min(), dtype))
+        if max is not None:
+            max = get_compatible_values(max, self.dtype)
+            out = out._translated(_to_tick(max, dtype) - _to_tick(out.max(), dtype))
+        return out.new(**kwargs) if kwargs else out
+
+    def new(self, **kwargs):
+        """Update coordinate; the exact grid is kept unless the step changes."""
+        if "data" in kwargs or "values" in kwargs:
+            return super().new(**kwargs)
+        info = self.model_dump(exclude_unset=True, exclude_defaults=True)
+        # A new stop or step re-derives the count, as a range always has.
+        if "stop" in kwargs or "step" in kwargs:
+            info.pop("shape", None)
+        if "step" in kwargs:
+            for name in _EXACT_GRID_FIELDS:
+                info.pop(name, None)
+        info.update(kwargs)
+        return get_coord(**info)
+
+    def _convert_units(self, units) -> BaseCoord:  # ty: ignore[invalid-method-override]
+        """Convert units, or set units if none exist; integers become floats."""
+        if dtype_time_like(self.dtype):
+            return self
+        if self.step_denominator != 1:
+            msg = (
+                "Cannot convert the units of an integer coordinate with a "
+                f"fractional step ({self.step_exact}); the result is not an "
+                "integer grid."
+            )
+            raise CoordError(msg)
+        # Whole-tick integer grids convert exactly as a CoordRange does,
+        # which turns them into floats.
+        start = convert_units(self.start, to_units=units, from_units=self.units)
+        stop = convert_units(self.stop, to_units=units, from_units=self.units)
+        step = (stop - start) / len(self)
+        return get_coord(start=start, stop=stop, step=step, units=units)
+
+    def to_summary(self, dims=()) -> CoordSummary:
+        """Get the summary info about the coord, exact grid included."""
+        summary = super().to_summary(dims=dims)
+        num, den, offset = (
+            self.step_numerator,
+            self.step_denominator,
+            self.origin_offset,
+        )
+        if dtype_time_like(self.dtype):
+            # A summary holds time in nanoseconds, so the grid is stated in
+            # nanosecond ticks whatever unit the coordinate keeps.
+            scale = _tick_seconds(self.dtype) * 10**9
+            assert scale.denominator == 1, "finer than ns is never exact"
+            num, den, offset = _normalize_grid(
+                num * scale.numerator, den, offset * scale.numerator
+            )
+        return summary.model_copy(
+            update=dict(step_numerator=num, step_denominator=den, origin_offset=offset)
+        )
+
+    def _repr_fields(self) -> tuple[tuple[str, Text, bool], ...]:
+        fields = super()._repr_fields()
+        if self.step_denominator == 1:
+            return fields
+        # The rounded step misstates a fractional grid (976562 ns is not
+        # 1024 Hz), so the step is said exactly.
+        exact = self.step_exact
+        text = Text(f"{exact}")
+        if dtype_time_like(self.dtype):
+            rate = 1 / abs(exact)
+            rate_str = (
+                str(rate.numerator) if rate.denominator == 1 else f"{float(rate):g}"
+            )
+            text += Text(" s") + Text(f" ({rate_str} Hz)", dascore_styles["units"])
+        elif self.unit_str:
+            text += Text(f" {self.unit_str}", dascore_styles["units"])
+        return tuple(
+            ("step", text, True) if name == "step" else (name, value, labelled)
+            for name, value, labelled in fields
+        )
+
+
 class CoordArray(BaseCoord):
     """
     A coordinate with arbitrary values in an array.
@@ -2013,7 +2863,7 @@ class CoordArray(BaseCoord):
         else:
             start, stop = min_v, max_v + step
         # Get potential output, ensure it is the same length as original.
-        out = CoordRange(start=start, stop=stop, step=step, units=self.units)
+        out = get_coord(start=start, stop=stop, step=step, units=self.units)
         return out.change_length(len(self))
 
     @compose_docstring(doc=get_docstring(BaseCoord.update_limits))
@@ -2170,7 +3020,7 @@ def _coerce_segment(seg) -> BaseCoord:
         # Round-trip support: rebuild segments from model_dump payloads.
         if seg.get("values") is not None:
             return CoordMonotonicArray(**seg)
-        return CoordRange(**seg)
+        return _range_from_dump(seg)
     msg = f"Segments must be coordinates, got {type(seg)}."
     raise CoordError(msg)
 
@@ -2184,7 +3034,7 @@ def _maybe_promote_segment(seg: BaseCoord) -> BaseCoord:
     if len(np.unique(diffs)) != 1:
         return seg
     step = diffs[0]
-    candidate = CoordRange(
+    candidate = get_coord(
         start=values[0], stop=values[-1] + step, step=step, units=seg.units
     )
     # Only promote when the range reproduces the values bit-exactly; unlike
@@ -2194,16 +3044,26 @@ def _maybe_promote_segment(seg: BaseCoord) -> BaseCoord:
     return seg
 
 
+def _range_continues(prev: BaseCoord, seg: BaseCoord) -> bool:
+    """Return True if seg is the next samples of prev's grid."""
+    if not (isinstance(prev, CoordRange) and isinstance(seg, CoordRange)):
+        return False
+    if prev.step_exact != seg.step_exact:
+        return False
+    if isinstance(prev, CoordRangeInt) and isinstance(seg, CoordRangeInt):
+        # The ideal origins must line up, not just the rounded labels.
+        step = Fraction(prev.step_numerator, prev.step_denominator)
+        return seg._ideal_origin == prev._ideal_origin + len(prev) * step
+    return bool(prev.step == seg.step and prev.stop == seg.start)
+
+
 def _fuse_segments(segments: tuple[BaseCoord, ...]) -> tuple[BaseCoord, ...]:
     """Fuse adjacent segments that continue exactly (normal form)."""
     out = [segments[0]]
     for seg in segments[1:]:
         prev = out[-1]
-        both_ranges = isinstance(prev, CoordRange) and isinstance(seg, CoordRange)
-        if both_ranges and prev.step == seg.step and prev.stop == seg.start:
-            out[-1] = CoordRange(
-                start=prev.start, stop=seg.stop, step=prev.step, units=prev.units
-            )
+        if _range_continues(prev, seg):
+            out[-1] = prev.change_length(len(prev) + len(seg))
             continue
         both_arrays = isinstance(prev, CoordMonotonicArray) and isinstance(
             seg, CoordMonotonicArray
@@ -2688,7 +3548,7 @@ class CoordSegmented(BaseCoord):
         # Strictly monotonic segments guarantee a nonzero step matching the
         # sort direction.
         assert step != zero and (step > zero) == ascending
-        candidate = CoordRange(
+        candidate = _build_range(
             start=first, stop=last + step, step=step, units=self.units
         ).change_length(n)
         actual = np.concatenate([x.values for x in run])
@@ -3090,6 +3950,9 @@ def get_coord(
     shape: int | tuple[int, ...] | None = None,
     dtype: str | np.dtype | None = None,
     segments: tuple[BaseCoord, ...] | list[BaseCoord] | None = None,
+    step_numerator: int | None = None,
+    step_denominator: int | None = None,
+    origin_offset: int | None = None,
 ) -> BaseCoord:
     """
     Return a coordinate from provided inputs.
@@ -3125,6 +3988,11 @@ def get_coord(
         A sequence of monotonic coordinates to concatenate into one
         coordinate (see [`concat_coords`](`dascore.core.coords.concat_coords`)).
         Cannot be combined with other value inputs.
+    step_numerator, step_denominator, origin_offset
+        The exact grid of an integer or time range in ticks (see
+        [`CoordRangeInt`](`dascore.core.coords.CoordRangeInt`)). Normally
+        these come from a dumped coordinate; pass ``step`` as a `Fraction`
+        or ``(numerator, denominator)`` tuple to state a fractional step.
 
     Notes
     -----
@@ -3161,6 +4029,13 @@ def get_coord(
     >>>
     >>> # Create a partial coordinate of a given shape
     >>> partial_coord = get_coord(shape=(10,))
+    >>>
+    >>> # A time coordinate sampled at exactly 1024 Hz (a fraction of a
+    >>> # nanosecond) never drifts from its grid.
+    >>> time = get_coord(
+    ...     start=np.datetime64("2020-01-01"), step=(1, 1024), shape=(2048,)
+    ... )
+    >>> assert time.step_exact == 1 / 1024 and time[::2].step_exact == 1 / 512
     """
 
     def _check_data_compatibility(data, start, stop, step):
@@ -3241,13 +4116,28 @@ def get_coord(
 
     data = _get_array(data, values)
     shape = _get_shape(shape)
+    grid = dict(
+        step_numerator=step_numerator,
+        step_denominator=step_denominator,
+        origin_offset=origin_offset,
+    )
     if data is None and shape is not None:
         attrs = dict(
             shape=shape, start=start, stop=stop, step=step, units=units, dtype=dtype
         )
-        try:  # This could be a normal RangeCoord
-            return CoordRange(**attrs)
-        except (ValidationError, CoordError):  # If not it's a partial
+        # A 1D shape with two of start/stop/step states a range; anything
+        # less (or more dimensions) is a partial coord. A range that then
+        # fails to validate is an error, not a partial.
+        stated = sum(not _is_null_scalar(x) for x in (start, stop, step))
+        if len(shape) != 1 or shape[0] == 0 or stated < 2:
+            return CoordPartial(**attrs)
+        try:
+            return _build_range(**attrs, **grid)
+        except (ValidationError, CoordError):
+            # A float range that cannot be built is still a partial, as it
+            # always was; the exact class raises only for what is wrong.
+            if _range_class(start, stop, step, shape) is CoordRangeInt:
+                raise
             return CoordPartial(**attrs)
 
     # maybe convert min/max to start stop.
@@ -3285,13 +4175,13 @@ def get_coord(
         # special case of len 1 array either get range, if step specified
         # or sorted monotonic array if not.
         elif kind == "single":
-            if not pd.isnull(step):
+            if not _is_null_scalar(step):
                 val = data[0]
-                return CoordRange(start=val, stop=val + step, step=step, units=units)
+                return _build_range(start=val, shape=(1,), step=step, units=units)
             return CoordMonotonicArray(values=data, units=units)
         start, stop, step, monotonic = _maybe_get_start_stop_step(data)
         if start is not None:
-            out = CoordRange(start=start, stop=stop, step=step, units=units)
+            out = _build_range(start=start, stop=stop, step=step, units=units)
             # The change_length call helps with float off by one issues.
             return out.change_length(len(data))
         elif monotonic:
@@ -3315,4 +4205,4 @@ def get_coord(
             )
         return CoordArray(values=data, units=units)
     else:
-        return CoordRange(start=start, stop=stop, step=step, units=units)
+        return _build_range(start=start, stop=stop, step=step, units=units, **grid)

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -1963,18 +1963,8 @@ class CoordRange(BaseCoord):
 
 
 _EXACT_GRID_FIELDS = ("step_numerator", "step_denominator", "origin_offset")
-# Seconds in one unit of each fixed-length numpy time unit. Months and
-# years are not fixed, and nothing finer than a nanosecond is supported.
-_SECONDS_PER_UNIT: Mapping[str, Fraction] = {
-    "W": Fraction(604_800),
-    "D": Fraction(86_400),
-    "h": Fraction(3_600),
-    "m": Fraction(60),
-    "s": Fraction(1),
-    "ms": Fraction(1, 10**3),
-    "us": Fraction(1, 10**6),
-    "ns": Fraction(1, 10**9),
-}
+# Nanoseconds per second: the tick of every exact time grid.
+_NS_PER_S = 10**9
 
 
 def _unbox_scalar(value):
@@ -2011,91 +2001,47 @@ def _is_null_scalar(value) -> bool:
     return bool(pd.isnull(_unbox_scalar(value)))
 
 
-def _time_unit(dtype) -> tuple[str, int]:
-    """The unit and count of a time dtype, read from its string form."""
-    match = re.fullmatch(r"[<>|=]?[mM]8\[(\d*)([a-zA-Z]+)\]", np.dtype(dtype).str)
-    if match is None:  # a generic time dtype states no unit
-        return "generic", 1
-    return match.group(2), int(match.group(1) or 1)
-
-
-def _timedelta_dtype(dtype) -> np.dtype:
-    """The timedelta dtype with the unit of a time dtype."""
-    unit, count = _time_unit(dtype)
-    return np.dtype(f"m8[{count if count != 1 else ''}{unit}]")
-
-
-def _seconds_per_tick(dtype) -> Fraction | None:
-    """Seconds in one tick of a time dtype, or None if it has no fixed length."""
-    unit, count = _time_unit(dtype)
-    seconds = _SECONDS_PER_UNIT.get(unit)
-    return None if seconds is None else seconds * count
-
-
-def _tick_seconds(dtype) -> Fraction:
-    """Seconds in one tick of a time dtype known to have a fixed length."""
-    seconds = _seconds_per_tick(dtype)
-    assert seconds is not None, "callers check the unit first"
-    return seconds
-
-
-def _step_value(step_tick: int, dtype: np.dtype):
-    """A whole-tick step as a scalar of the coordinate's step type."""
-    if dtype.kind in "mM":
-        ticks = np.asarray(step_tick, dtype=np.int64)
-        return ticks.astype(_timedelta_dtype(dtype))[()]
-    return step_tick
-
-
-def _time_tick_dtype(start, stop, step) -> np.dtype | None:
+def _exact_time_dtype(start, stop, step) -> np.dtype | None:
     """
-    The tick dtype an exact time range resolves to, or None to stay legacy.
+    The nanosecond dtype an exact time range holds, or None to stay legacy.
 
-    A scalar step resolves as `start + step` does, to the finer unit. A
-    fraction step is stated in seconds, and nanoseconds hold it.
+    Ticks are nanoseconds, DASCore's time unit. A scalar step resolves as
+    `start + step` does, so only nanosecond inputs are exact; a fraction
+    step is stated in seconds and always resolves to nanoseconds.
     """
     ends = [np.asarray(x).dtype for x in (start, stop) if not _is_null_scalar(x)]
     if _is_fraction_step(step):
-        dtype = np.dtype(f"{ends[0].kind}8[ns]")
-    else:
-        parts = ends if step is None else [*ends, np.asarray(_unbox_scalar(step)).dtype]
-        try:
-            dtype = np.result_type(*parts)
-        except TypeError:  # not all time-like: let the legacy validator say so
-            return None
-    if dtype.kind not in "mM" or _seconds_per_tick(dtype) is None:
+        return np.dtype(f"{ends[0].kind}8[ns]")
+    parts = ends if step is None else [*ends, np.asarray(_unbox_scalar(step)).dtype]
+    try:
+        dtype = np.result_type(*parts)
+    except TypeError:  # not all time-like: let the legacy validator say so
         return None
-    return dtype
+    return dtype if dtype.kind in "mM" and dtype.str.endswith("[ns]") else None
 
 
-def _to_tick(value, dtype: np.dtype) -> int:
-    """
-    Return value as an integer tick of ``dtype``: its unit for time, or itself.
-
-    Raises CoordError if the value does not sit on a tick.
-    """
+def _to_tick(value) -> int:
+    """Return a time value as nanoseconds, or an integer value as itself."""
     value = _unbox_scalar(value)
-    if dtype.kind in "mM":
-        # A step is a timedelta whatever the coordinate holds, so the
-        # target keeps the unit and takes the value's own kind.
-        if is_timedelta64(value) and dtype.kind == "M":
-            dtype = _timedelta_dtype(dtype)
-        try:
-            converted = np.asarray(value).astype(dtype)
-            exact = converted.astype(np.asarray(value).dtype) == np.asarray(value)
-        except (TypeError, ValueError) as e:
-            msg = f"{value!r} is not a {dtype} value."
-            raise CoordError(msg) from e
-        if not exact:
-            msg = f"{value} does not sit on the {dtype} grid."
-            raise CoordError(msg)
-        return int(converted.view(np.int64))
+    if is_datetime64(value) or is_timedelta64(value):
+        return int(to_int(value))
     if isinstance(value, float | np.floating):
         if not float(value).is_integer():
             msg = f"An integer coordinate cannot hold the non-integer value {value}."
             raise CoordError(msg)
         return int(value)
-    return int(value)
+    try:
+        return int(value)
+    except (TypeError, ValueError) as e:
+        msg = f"{value!r} is not an integer or time value."
+        raise CoordError(msg) from e
+
+
+def _step_value(step_tick: int, dtype: np.dtype):
+    """A whole-tick step as a scalar of the coordinate's step type."""
+    if dtype.kind in "mM":
+        return np.timedelta64(step_tick, "ns")
+    return step_tick
 
 
 def _range_class(start, stop, step, shape) -> type[CoordRange]:
@@ -2109,7 +2055,7 @@ def _range_class(start, stop, step, shape) -> type[CoordRange]:
     anchor = stop if _is_null_scalar(start) else start
     fraction = _is_fraction_step(step)
     if is_datetime64(anchor) or is_timedelta64(anchor):
-        if _time_tick_dtype(start, stop, step) is None:
+        if _exact_time_dtype(start, stop, step) is None:
             return CoordRange
         return CoordRangeInt
     int_like = _is_int_scalar(anchor) and (
@@ -2184,14 +2130,16 @@ def _count_from_span(span: int, num: int, den: int, offset: int) -> int:
     return max(1, math.ceil(round(float(ratio), 1)))
 
 
-def _check_grid_fits(start_tick: int, num: int, den: int, count: int) -> None:
-    """Refuse a grid whose evaluation would overflow int64."""
-    limit = 2**63
-    reach = start_tick + (count * num + den) // den
-    if abs(count * num) + den >= limit or not -limit <= reach < limit:
+def _check_grid_fits(start_tick: int, num: int, den: int, count: int, dtype) -> None:
+    """Refuse a grid whose labels would not fit the dtype or int64 arithmetic."""
+    dtype = np.dtype(dtype)
+    info = np.iinfo(np.int64 if dtype.kind in "mM" else cast("Any", dtype))
+    last = start_tick + (count * num) // den
+    low, high = min(start_tick, last), max(start_tick, last)
+    if abs(count * num) + den >= 2**63 or low < info.min or high > info.max:
         msg = (
             f"A grid of {count} samples with step {num}/{den} ticks from "
-            f"{start_tick} exceeds the int64 range."
+            f"{start_tick} exceeds the {dtype} range."
         )
         raise CoordError(msg)
 
@@ -2200,15 +2148,14 @@ class CoordRangeInt(CoordRange):
     """
     A range coordinate on an exact integer grid.
 
-    The class `get_coord` returns for datetime64, timedelta64, and integer
-    ranges. Labels are integer ticks: the coordinate's time unit
-    (nanoseconds unless coarser inputs say otherwise) or the integers
-    themselves. The ideal grid has a spacing of ``step_numerator /
-    step_denominator`` ticks and an origin ``origin_offset /
-    step_denominator`` ticks after ``start``; each label is the floor of its
-    ideal position. A slice, stride, or reversal therefore reproduces the
-    labels of the original exactly, and a 1024 Hz grid never drifts the way
-    a step rounded to 976562 ns would.
+    The class `get_coord` returns for nanosecond datetime64 and timedelta64
+    ranges and for integer ranges. Labels are integer ticks: nanoseconds, or
+    the integers themselves. The ideal grid has a spacing of
+    ``step_numerator / step_denominator`` ticks and an origin
+    ``origin_offset / step_denominator`` ticks after ``start``; each label is
+    the floor of its ideal position. A slice, stride, or reversal therefore
+    reproduces the labels of the original exactly, and a 1024 Hz grid never
+    drifts the way a step rounded to 976562 ns would.
 
     ``step`` is the nearest whole-tick step (ties to even), kept for every
     consumer that reads a scalar spacing. ``step_exact`` is the exact
@@ -2257,14 +2204,12 @@ class CoordRangeInt(CoordRange):
             raise CoordError(msg)
         time_like = is_datetime64(anchor) or is_timedelta64(anchor)
         if time_like:
-            dtype = _time_tick_dtype(start, stop, step)
+            dtype = _exact_time_dtype(start, stop, step)
             if dtype is None:
-                msg = f"{np.asarray(anchor).dtype} has no fixed tick length."
+                msg = f"An exact time grid needs nanoseconds, not {values}."
                 raise CoordError(msg)
-        else:
-            dtype = np.dtype(np.int64)  # placeholder until the step is known
-        start_tick = None if start is None else _to_tick(start, dtype)
-        stop_tick = None if stop is None else _to_tick(stop, dtype)
+        start_tick = None if start is None else _to_tick(start)
+        stop_tick = None if stop is None else _to_tick(stop)
         count = None
         if shape is not None:
             shape = tuple(iterate(shape))
@@ -2281,13 +2226,13 @@ class CoordRangeInt(CoordRange):
         if _is_fraction_step(step):
             frac = _as_fraction(step)
             if time_like:
-                frac = frac / _tick_seconds(dtype)
+                frac = frac * _NS_PER_S
             num, den = frac.numerator, frac.denominator
         elif values.get("step_numerator") is not None:
             num = int(values["step_numerator"])
             den = int(values.get("step_denominator") or 1)
         elif step is not None:
-            num, den, offset = _to_tick(step, dtype), 1, 0
+            num, den, offset = _to_tick(step), 1, 0
         else:
             if start_tick is None or stop_tick is None or count is None:
                 msg = (
@@ -2324,7 +2269,6 @@ class CoordRangeInt(CoordRange):
             # The ideal origin is count steps before stop; start is its floor.
             start_tick, offset = divmod(stop_tick * den - count * num, den)
         num, den, offset = _normalize_grid(num, den, offset)
-        _check_grid_fits(start_tick, num, den, count)
         step_tick = round(Fraction(num, den))
         end_tick = start_tick + (offset + count * num) // den
         if time_like:
@@ -2332,6 +2276,7 @@ class CoordRangeInt(CoordRange):
         else:
             start_value = start if start is not None else start_tick
             dtype = np.asarray(start_value + step_tick).dtype
+        _check_grid_fits(start_tick, num, den, count, dtype)
         values.update(
             start=start_value,
             stop=np.asarray(end_tick, dtype=np.int64).astype(dtype)[()],
@@ -2349,7 +2294,7 @@ class CoordRangeInt(CoordRange):
     @property
     @cached_method
     def _start_tick(self) -> int:
-        return _to_tick(self.start, np.dtype(self.dtype))
+        return _to_tick(self.start)
 
     @property
     def _ideal_origin(self) -> Fraction:
@@ -2361,9 +2306,7 @@ class CoordRangeInt(CoordRange):
     def step_exact(self) -> Fraction:
         """The exact spacing in coordinate units (seconds for time)."""
         frac = Fraction(self.step_numerator, self.step_denominator)
-        if dtype_time_like(self.dtype):
-            return frac * _tick_seconds(self.dtype)
-        return frac
+        return frac / _NS_PER_S if dtype_time_like(self.dtype) else frac
 
     def _ticks(self, indices) -> np.ndarray:
         """The label ticks at these (non-negative) indices."""
@@ -2380,8 +2323,8 @@ class CoordRangeInt(CoordRange):
     def _grid(self, start_tick: int, num: int, den: int, offset: int, count: int):
         """Construct a coordinate on a known grid without re-validation."""
         num, den, offset = _normalize_grid(num, den, offset)
-        _check_grid_fits(start_tick, num, den, count)
         dtype = np.dtype(self.dtype)
+        _check_grid_fits(start_tick, num, den, count, dtype)
         start = self._from_ticks(start_tick)[()]
         stop = self._from_ticks(start_tick + (offset + count * num) // den)[()]
         step_tick = round(Fraction(num, den))
@@ -2403,8 +2346,7 @@ class CoordRangeInt(CoordRange):
 
     def _new_grid(self, start, step, length: int) -> Self:
         """A whole-tick grid from a start value and scalar step."""
-        dtype = np.dtype(self.dtype)
-        return self._grid(_to_tick(start, dtype), _to_tick(step, dtype), 1, 0, length)
+        return self._grid(_to_tick(start), _to_tick(step), 1, 0, length)
 
     def _sliced(self, first: int, stride: int, count: int):
         """The coordinate of the samples first, first + stride, ... (count)."""
@@ -2453,19 +2395,13 @@ class CoordRangeInt(CoordRange):
         labels past the next tick in that direction.
         """
         values = np.atleast_1d(values)
-        toward_end = forward == self.sorted
-        dtype = np.dtype(self.dtype)
-        if dtype.kind in "mM":
-            ticks = values.astype(dtype)
-            back = ticks.astype(values.dtype)
-            ticks = ticks.view(np.int64)
-            # A bound finer than the tick: below the truncated tick when
-            # the cast went up, above it when the cast went down.
-            floor = np.where(back > values, ticks - 1, ticks)
-            return np.where(back == values, ticks, floor + toward_end)
+        if values.dtype.kind in "mM":  # already nanoseconds, the tick
+            return values.astype("int64")
         if values.dtype.kind == "f":
-            values = (np.ceil if toward_end else np.floor)(values)
-        return values.astype(np.int64)
+            values = (np.ceil if forward == self.sorted else np.floor)(values)
+        # A bound past the int64 range lies past the coordinate either way.
+        limits = np.iinfo(np.int64)
+        return np.clip(values, limits.min, limits.max).astype(np.int64)
 
     # --- overrides
 
@@ -2506,6 +2442,19 @@ class CoordRangeInt(CoordRange):
         indices = np.asarray(indices)
         indices = np.where(indices < 0, indices + len(self), indices)
         return self._from_ticks(self._ticks(indices))
+
+    def index(self, indexer, axis: int | None = None) -> BaseCoord:
+        """Index the coordinate; a slice keeps the grid, as ``coord[slice]`` does."""
+        if isinstance(indexer, slice) and not axis:
+            return self[indexer]
+        return super().index(indexer, axis=axis)
+
+    def coord_range(self, extend: bool = True):
+        """The span of the coordinate; extended, its exact exclusive end."""
+        if not extend:
+            return super().coord_range(extend=False)
+        first, last = self._get_index_values([0, len(self)])
+        return np.abs(last - first)
 
     @property
     @cached_method
@@ -2618,16 +2567,15 @@ class CoordRangeInt(CoordRange):
 
     def _with_step(self, step) -> BaseCoord:
         """The same start and count on a new cadence."""
-        dtype = np.dtype(self.dtype)
         if _is_fraction_step(step):
             frac = _as_fraction(step)
-            if dtype_time_like(dtype):
-                frac = frac / _tick_seconds(dtype)
+            if dtype_time_like(self.dtype):
+                frac = frac * _NS_PER_S
             num, den = frac.numerator, frac.denominator
         else:
             step = get_compatible_values(step, type(self.step))
             try:
-                num, den = _to_tick(step, dtype), 1
+                num, den = _to_tick(step), 1
             except CoordError:
                 # A step this grid cannot hold (a float on integers, a finer
                 # time unit) re-dispatches to the class that can.
@@ -2642,8 +2590,7 @@ class CoordRangeInt(CoordRange):
     def _samples_in(self, duration):
         """How many exact steps a duration spans."""
         if dtype_time_like(self.dtype):
-            ns = int(to_int(dc.to_timedelta64(duration)))
-            ticks = Fraction(ns) / (_tick_seconds(self.dtype) * 10**9)
+            ticks = Fraction(int(to_int(dc.to_timedelta64(duration))))
         else:
             plain = duration.item() if isinstance(duration, np.generic) else duration
             ticks = Fraction(plain)
@@ -2665,7 +2612,6 @@ class CoordRangeInt(CoordRange):
         if all(x is not None for x in [min, max, step]):
             msg = "At most two parameters can be specified in update_limits."
             raise ValueError(msg)
-        dtype = np.dtype(self.dtype)
         out = self
         if min is not None and max is not None:
             # As for every range: min is the new start, max the new
@@ -2673,13 +2619,13 @@ class CoordRangeInt(CoordRange):
             # when it is at least a tick; below that the labels are floats.
             min = get_compatible_values(min, self.dtype)
             max = get_compatible_values(max, self.dtype)
-            frac = Fraction(_to_tick(max, dtype) - _to_tick(min, dtype), len(self))
+            frac = Fraction(_to_tick(max) - _to_tick(min), len(self))
             if abs(frac) < 1:
                 new_step = (max - min) / len(self)
                 out = get_coord(start=min, stop=max, step=new_step, units=self.units)
             else:
                 out = self._grid(
-                    _to_tick(min, dtype), frac.numerator, frac.denominator, 0, len(self)
+                    _to_tick(min), frac.numerator, frac.denominator, 0, len(self)
                 )
             return out.new(**kwargs) if kwargs else out
         if step is not None:
@@ -2688,10 +2634,10 @@ class CoordRangeInt(CoordRange):
                 return out.update_limits(min=min, max=max, **kwargs)
         if min is not None:
             min = get_compatible_values(min, self.dtype)
-            out = out._translated(_to_tick(min, dtype) - _to_tick(out.min(), dtype))
+            out = out._translated(_to_tick(min) - _to_tick(out.min()))
         if max is not None:
             max = get_compatible_values(max, self.dtype)
-            out = out._translated(_to_tick(max, dtype) - _to_tick(out.max(), dtype))
+            out = out._translated(_to_tick(max) - _to_tick(out.max()))
         return out.new(**kwargs) if kwargs else out
 
     def new(self, **kwargs):
@@ -2729,21 +2675,12 @@ class CoordRangeInt(CoordRange):
     def to_summary(self, dims=()) -> CoordSummary:
         """Get the summary info about the coord, exact grid included."""
         summary = super().to_summary(dims=dims)
-        num, den, offset = (
-            self.step_numerator,
-            self.step_denominator,
-            self.origin_offset,
-        )
-        if dtype_time_like(self.dtype):
-            # A summary holds time in nanoseconds, so the grid is stated in
-            # nanosecond ticks whatever unit the coordinate keeps.
-            scale = _tick_seconds(self.dtype) * 10**9
-            assert scale.denominator == 1, "finer than ns is never exact"
-            num, den, offset = _normalize_grid(
-                num * scale.numerator, den, offset * scale.numerator
-            )
         return summary.model_copy(
-            update=dict(step_numerator=num, step_denominator=den, origin_offset=offset)
+            update=dict(
+                step_numerator=self.step_numerator,
+                step_denominator=self.step_denominator,
+                origin_offset=self.origin_offset,
+            )
         )
 
     def _repr_fields(self) -> tuple[tuple[str, Text, bool], ...]:

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -1842,34 +1842,29 @@ class CoordRange(BaseCoord):
     are integer ticks (nanoseconds, or the integers themselves), the ideal
     grid has a spacing of ``step_numerator / step_denominator`` ticks and an
     origin ``origin_offset / step_denominator`` ticks after ``start``, and
-    each label is the floor of its ideal position. A slice, stride, or
-    reversal therefore reproduces the labels of the original exactly, and a
-    1024 Hz grid never drifts the way a step rounded to 976562 ns would.
-    ``step`` reports the nearest whole-tick spacing; ``step_exact`` the
-    fraction, in seconds for time.
+    each label is the floor of its ideal position. Slices, strides,
+    reversals, and selections therefore reproduce the labels of the original
+    exactly, and a 1024 Hz grid never drifts the way a step rounded to
+    976562 ns would. ``step`` reports the nearest whole-tick spacing;
+    ``step_exact`` the fraction, in seconds for time.
 
     Float ranges, and time ranges in units other than nanoseconds, keep a
-    scalar step and evaluate their labels by linear spacing; their grid
-    fields are None.
+    scalar step and linearly spaced labels; their grid fields are None.
 
     Parameters
     ----------
     start
-        The starting value
+        The starting value.
     stop
         The ending value, exclusive.
     step
-        The step between start and stop; for exact grids also a `Fraction`
-        or a ``(numerator, denominator)`` tuple in coordinate units.
+        The step between values; for exact grids also a `Fraction` or a
+        ``(numerator, denominator)`` tuple in coordinate units.
     shape
         The sample count.
     step_numerator, step_denominator, origin_offset
         The exact grid in ticks, normally supplied only when rebuilding a
         dumped coordinate.
-
-    Notes
-    -----
-    Like range and slice, CoordRange is exclusive of stop value.
     """
 
     start: Any = None
@@ -1884,7 +1879,7 @@ class CoordRange(BaseCoord):
     @model_validator(mode="before")
     @classmethod
     def validate_start_stop_step_len(cls, values):
-        """Coerce the needed values from the inputs."""
+        """Resolve the range from any three of start, stop, step, and shape."""
         get = values.get
         dtype = _exact_dtype(get("start"), get("stop"), get("step"), get("shape"))
         fields = (
@@ -1893,7 +1888,7 @@ class CoordRange(BaseCoord):
         values.update(fields)
         return values
 
-    # --- the two primitives every range operation is built from
+    # --- the grid
 
     @property
     def _exact(self) -> bool:
@@ -1919,30 +1914,22 @@ class CoordRange(BaseCoord):
         return Fraction(self._start_tick * den + offset, den)
 
     def _labels(self, indices) -> np.ndarray:
-        """The labels at these (non-negative, possibly out of range) indices."""
+        """The labels at these indices, which may lie outside the coordinate."""
         indices = np.asarray(indices)
         if self._exact:
-            indices = indices.astype(np.int64)
             num, den, offset = self._grid_terms
-            if den == 1:
-                ticks = self._start_tick + indices * num
-            else:
-                ticks = self._start_tick + (offset + indices * num) // den
-            return np.asarray(ticks).astype(self.dtype)
-        if len(self) == 1 or dtype_time_like(self.dtype):
+            ticks = (offset + indices.astype(np.int64) * num) // den
+            return np.asarray(self._start_tick + ticks).astype(self.dtype)
+        if len(self) == 1 or np.dtype(self.dtype).kind in "mMO":
             return np.asarray(self.start + indices * self.step, dtype=self.dtype)
         # Match linspace's inferred floating dtype, rounding, and exact endpoint.
-        stop = self.stop - self.step
-        dtype = np.result_type(self.start, stop, 0.0)
-        delta = np.subtract(stop, self.start, dtype=dtype)
+        last = self.stop - self.step
+        dtype = np.result_type(self.start, last, 0.0)
+        delta = np.subtract(last, self.start, dtype=dtype)
         step = delta / (len(self) - 1)
-        values = indices.astype(dtype)
-        if step == 0:
-            values = (values / (len(self) - 1)) * delta
-        else:
-            values = values * step
-        values = values + self.start
-        values = np.where(indices == len(self) - 1, stop, values)
+        scaled = indices.astype(dtype)
+        scaled = scaled / (len(self) - 1) * delta if step == 0 else scaled * step
+        values = np.where(indices == len(self) - 1, last, scaled + self.start)
         return values.astype(self.dtype)
 
     def _sliced(self, first: int, stride: int, count: int) -> Self:
@@ -1950,50 +1937,27 @@ class CoordRange(BaseCoord):
         if self._exact:
             num, den, offset = self._grid_terms
             q, offset = divmod(offset + first * num, den)
-            return self._grid(self._start_tick + q, stride * num, den, offset, count)
-        return self._new_grid(self.start + first * self.step, self.step * stride, count)
+            fields = _grid_fields(
+                self._start_tick + q, stride * num, den, offset, count, self.dtype
+            )
+        else:
+            start, step = self.start + first * self.step, self.step * stride
+            fields = dict(
+                start=start, stop=start + step * count, step=step, shape=(count,)
+            )
+        return self._construct(fields)
 
-    def _grid(self, start_tick: int, num: int, den: int, offset: int, count: int):
-        """Construct an exact grid without re-validation."""
-        return self.model_construct(
-            _fields_set=set(self.model_fields_set) | set(_EXACT_GRID_FIELDS),
-            units=self.units,
-            **_grid_fields(start_tick, num, den, offset, count, self.dtype),
-        )
-
-    def _new_grid(self, start, step, length: int) -> Self:
-        """
-        Return a CoordRange on an exactly known grid, skipping re-validation.
-
-        `validate_start_stop_step_len` exists to *derive* shape and a
-        normalized stop (always `start + step * length`) from loosely
-        specified inputs. Callers below already know the sample count exactly
-        -- it comes from index arithmetic on an existing, validated coord --
-        so re-deriving it costs ~60us per call and can only reproduce what is
-        passed in here.
-
-        Only use this where start/step come from an already-validated
-        CoordRange and length is computed from indices; anything taking user
-        input must go through the validating constructor.
-        """
-        if self._exact:
-            return self._grid(_to_tick(start), _to_tick(step), 1, 0, length)
+    def _construct(self, fields: dict) -> Self:
+        """Build from fields already on a known grid, skipping re-validation."""
+        # check_time_units forces time-like coords to seconds, testing start
+        # for truthiness; a coord starting at exactly zero is left alone.
+        start, dtype = fields["start"], fields.get("dtype", self.dtype)
         units = self.units
-        # Mirror check_time_units, which forces time-like coords to seconds.
-        # Note it tests `start` for truthiness, so a coord starting at exactly
-        # zero is left alone; that quirk is reproduced here deliberately.
         if start and (is_timedelta64(start) or is_datetime64(start)):
             units = _second_quantity()
         return self.model_construct(
-            # copy; model_construct stores the set by reference.
-            _fields_set=set(self.model_fields_set),
-            units=units,
-            step=step,
-            shape=(length,),
-            # matches what the validator stores for dtype.
-            dtype=np.asarray(start + step).dtype,
-            start=start,
-            stop=start + step * length,
+            _fields_set=set(self.model_fields_set) | set(fields),
+            **{"units": units, "dtype": dtype, **fields},
         )
 
     # --- identity and display
@@ -2004,8 +1968,7 @@ class CoordRange(BaseCoord):
         if not self._exact:
             return super().step_exact
         num, den, _ = self._grid_terms
-        frac = Fraction(num, den)
-        return frac / _NS_PER_S if dtype_time_like(self.dtype) else frac
+        return Fraction(num, den) / (_NS_PER_S if dtype_time_like(self.dtype) else 1)
 
     def _fingerprint_components(self) -> tuple[Any, ...]:
         """The scalar payload of a range, plus the grid when it is not whole ticks."""
@@ -2028,15 +1991,12 @@ class CoordRange(BaseCoord):
         fields = super()._repr_fields()
         if not self._exact or self.step_denominator == 1:
             return fields
-        # The rounded step misstates a fractional grid (976562 ns is not
-        # 1024 Hz), so the step is said exactly.
+        # The rounded step misstates a fractional grid, so it is said exactly.
         exact = cast("Fraction", self.step_exact)
         text = Text(f"{exact}")
         if dtype_time_like(self.dtype):
             rate = 1 / abs(exact)
-            rate_str = (
-                str(rate.numerator) if rate.denominator == 1 else f"{float(rate):g}"
-            )
+            rate_str = str(rate) if rate.denominator == 1 else f"{float(rate):g}"
             text += Text(" s") + Text(f" ({rate_str} Hz)", dascore_styles["units"])
         elif self.unit_str:
             text += Text(f" {self.unit_str}", dascore_styles["units"])
@@ -2060,21 +2020,7 @@ class CoordRange(BaseCoord):
     @cached_method
     def values(self) -> ArrayLike:
         """Return the values of the coordinate as an array."""
-        if self._exact or len(self) == 1:
-            # Cached, so it must be read-only like the other branch.
-            return array(self._labels(np.arange(len(self))))
-        # note: linspace works better for floats that might have slightly
-        # uneven spacing. It ensures the length of the output array is robust
-        # to small deviations in spacing. However, this doesnt work for datetimes.
-        if is_datetime64(self.start) or is_timedelta64(self.start):
-            out = np.arange(self.start, self.stop, self.step)
-        else:
-            out = np.linspace(
-                self.start, self.stop - self.step, num=len(self), dtype=self.dtype
-            )
-        # again, due to round-off error the array can one element longer than
-        # anticipated. The slice here just ensures shape and len match.
-        return array(out[: len(self)])
+        return array(self._labels(np.arange(len(self))))
 
     def _get_index_values(self, indices):
         """Evaluate only requested samples using the same grid as ``values``."""
@@ -2085,20 +2031,13 @@ class CoordRange(BaseCoord):
     def __len__(self):
         return self.shape[0]
 
-    def _ends(self) -> tuple:
-        """The first and last labels, in coordinate order."""
-        if self._exact:
-            return tuple(self._labels([0, len(self) - 1]))
-        # like range, coord range is exclusive of final value.
-        return self.start, self.stop - self.step
-
     def _min(self):
         """Return min value."""
-        return np.min(self._ends())
+        return np.min(self._labels([0, len(self) - 1]))
 
     def _max(self):
         """Return max value in range."""
-        return np.max(self._ends())
+        return np.max(self._labels([0, len(self) - 1]))
 
     @property
     def sorted(self) -> bool:
@@ -2109,8 +2048,7 @@ class CoordRange(BaseCoord):
     @property
     def reverse_sorted(self) -> bool:
         """Returns true if sorted in descending order."""
-        zero = _TD64_ZERO if is_timedelta64(self.step) else 0
-        return self.step < zero
+        return not self.sorted
 
     # --- indexing and selection
 
@@ -2119,13 +2057,10 @@ class CoordRange(BaseCoord):
             if item >= len(self) or item < -len(self):
                 raise IndexError(f"{item} exceeds coord length of {self}")
             return self._get_index_values(item)[()]
-        # handle ... as None
         if isinstance(item, slice):
             start = None if item.start is ... else item.start
             end = None if item.stop is ... else item.stop
-            # A (possibly strided) slice of an evenly sampled range is still
-            # evenly sampled, so preserve the step rather than collapsing to a
-            # CoordMonotonicArray (which loses step for len==1). See #567.
+            # A (strided) slice of a range is still a range; see #567.
             indices = range(len(self))[slice(start, end, item.step)]
             if len(indices):
                 return self._sliced(indices.start, indices.step, len(indices))
@@ -2142,21 +2077,16 @@ class CoordRange(BaseCoord):
         """The span of the coordinate; extended, to its exclusive end."""
         if not extend or not self._exact:
             return super().coord_range(extend=extend)
-        first, last = self._labels([0, len(self)])
-        return np.abs(last - first)
+        first, end = self._labels([0, len(self)])
+        return np.abs(end - first)
 
     @compose_docstring(doc=get_docstring(BaseCoord.change_length))
     def change_length(self, length: int) -> Self:
         """
         {doc}
         """
-        # CoordRange is always 1D by construction; keep as an internal invariant.
-        assert self.ndim == 1, "Can only change length for 1D coords."
         length = _validate_new_length(length)
-        if len(self) == length:
-            return self
-        # Only the sample count changes; start/step are already valid.
-        return self._sliced(0, 1, length)
+        return self if len(self) == length else self._sliced(0, 1, length)
 
     def select(
         self, args, relative=False, samples=False
@@ -2184,9 +2114,7 @@ class CoordRange(BaseCoord):
 
     def sort(self, reverse=False) -> tuple[BaseCoord, slice | ArrayLike]:
         """Sort the contents of the coord. Return new coord and slice for sorting."""
-        forward_forward = not reverse and self.sorted
-        reverse_reverse = reverse and self.reverse_sorted
-        if forward_forward or reverse_reverse:
+        if reverse == self.reverse_sorted:
             return self, slice(None)
         return self[::-1], slice(None, None, -1)
 
@@ -2194,51 +2122,28 @@ class CoordRange(BaseCoord):
         """
         Get the index of a value for a coord with a step of 0.
 
-        Every sample of such a coord equals start, so the index is either the
-        first sample or one just outside the coord, which makes the
-        selection degenerate.
+        Every sample equals start, so the index is the first sample or one
+        just outside the coord, which makes the selection degenerate.
         """
-        start = self.start
         if forward:  # index of the first sample >= value
-            return 0 if value <= start else len(self)
-        return 0 if value >= start else -1
+            return 0 if value <= self.start else len(self)
+        return 0 if value >= self.start else -1
 
-    def _index_of(self, tick: int, forward: bool) -> int:
+    def _index_of(self, ticks, forward: bool):
         """
-        The sample index a label tick of an exact grid maps to.
+        The sample index each label tick of an exact grid maps to.
 
-        Forward: the first index whose label is at or past ``tick`` in the
+        Forward: the first index whose label is at or past the tick in the
         coordinate's direction. Otherwise the last index whose label is at
         or before it. Exact, since a label is the floor of its ideal
-        position and ``tick`` is an integer.
+        position and a tick is an integer; Python integers, so no overflow.
         """
         num, den, offset = self._grid_terms
-        rel = (tick - self._start_tick) * den - offset
-        if num > 0:
-            if forward:  # label >= tick  <=>  ideal >= tick
-                return -((-rel) // num)
-            # label <= tick  <=>  ideal < tick + 1
-            return -((-(rel + den)) // num) - 1
-        if forward:  # label <= tick  <=>  ideal < tick + 1
-            return (rel + den) // num + 1
-        # label >= tick  <=>  ideal >= tick
-        return rel // num
-
-    def _indices_of(self, ticks: np.ndarray, forward: bool) -> np.ndarray:
-        """``_index_of`` for an array of ticks."""
-        if self.step_denominator != 1:
-            return np.asarray(
-                [self._index_of(int(t), forward) for t in ticks], dtype=np.int64
-            )
-        num, _, _ = self._grid_terms
-        rel = ticks - self._start_tick
-        if num > 0:
-            if forward:
-                return -np.floor_divide(-rel, num)
-            return -np.floor_divide(-(rel + 1), num) - 1
-        if forward:
-            return np.floor_divide(rel + 1, num) + 1
-        return np.floor_divide(rel, num)
+        rel = (np.asarray(ticks, dtype=object) - self._start_tick) * den - offset
+        if forward == (num > 0):  # label >= tick  <=>  ideal >= tick
+            return -((-rel) // num) if num > 0 else rel // num
+        # label <= tick  <=>  ideal < tick + 1
+        return -((-(rel + den)) // num) - 1 if num > 0 else (rel + den) // num + 1
 
     def _bound_ticks(self, values, forward: bool) -> np.ndarray:
         """
@@ -2266,62 +2171,45 @@ class CoordRange(BaseCoord):
             return self._get_float_index(value, forward)
         if self.step_numerator == 0:
             return self._get_zero_step_index(value, forward)
-        if not isinstance(value, Sized):
-            if isinstance(value, float | np.floating) and not math.isfinite(value):
-                # A bound past one end of the coordinate; its sign says
-                # which, and the checks below open that side.
-                out = len(self) if (value > 0) == self.sorted else -1
-            else:
-                tick = int(self._bound_ticks(value, forward)[0])
-                out = self._index_of(tick, forward)
-            if forward and out < 0:
-                return None
-            if not forward and out >= len(self):
-                return None
-            return out
-        return self._indices_of(self._bound_ticks(value, forward), forward)
+        if isinstance(value, Sized):
+            ticks = self._bound_ticks(value, forward)
+            return self._index_of(ticks, forward).astype(np.int64)
+        if isinstance(value, float | np.floating) and not math.isfinite(value):
+            # Past one end of the coordinate; the checks below open that side.
+            out = len(self) if (value > 0) == self.sorted else -1
+        else:
+            out = int(self._index_of(self._bound_ticks(value, forward), forward)[0])
+        if (forward and out < 0) or (not forward and out >= len(self)):
+            return None
+        return out
 
     def _get_float_index(self, value, forward=True):
         """Get the index corresponding to a value of a float range."""
         start, step = self.start, self.step
-        if not isinstance(value, Sized):
-            # Scalar fast path; avoids several small-array allocations.
-            # Due to float weirdness we need a little bit of a fudge factor.
-            # (float() first since rounding numpy scalars is ~10x slower)
-            # A step of 0 is handled after the division (python scalars raise,
-            # numpy scalars give inf/nan) since testing a numpy step for
-            # truthiness up front costs ~10x more on this hot path.
-            try:
-                fraction = round(float((value - start) / step), 10)
-            except ZeroDivisionError:
+        if isinstance(value, Sized):
+            func = np.ceil if forward else np.floor
+            # Due to float weirdness we need a little bit of a fudge factor here.
+            fraction = func(
+                np.round((np.atleast_1d(value) - start) / step, decimals=10)
+            )
+            return fraction.astype(np.int64)
+        # Scalar fast path. A zero step is caught after the division: python
+        # scalars raise, numpy scalars give inf/nan, and testing a numpy step
+        # for truthiness up front costs ~10x more on this hot path.
+        try:
+            fraction = round(float((value - start) / step), 10)
+        except ZeroDivisionError:
+            return self._get_zero_step_index(value, forward)
+        if not math.isfinite(fraction):
+            if not step:
                 return self._get_zero_step_index(value, forward)
-            if not math.isfinite(fraction):
-                # A zero step, whose samples all equal start, has a
-                # degenerate but defined index. Ask it by truthiness: a
-                # timedelta step compared to a bare 0 warns (and will
-                # eventually raise) about the generic unit that implies.
-                if not step:
-                    return self._get_zero_step_index(value, forward)
-                # Otherwise the fraction is infinite: a bound past one end of
-                # the coord, either because the bound itself is infinite or
-                # because it sits far enough from start to overflow the
-                # division. Its sign says which end, and the range checks
-                # below turn the end the samples are not on into an open
-                # side. It cannot be NaN; a null bound, NaN and NaT alike,
-                # is already None by the time it gets here.
-                out = len(self) if fraction > 0 else -1
-            else:
-                out = math.ceil(fraction) if forward else math.floor(fraction)
-            if forward and out < 0:
-                return None
-            if not forward and out >= len(self):
-                return None
-            return out
-        array = np.atleast_1d(value)
-        func = np.ceil if forward else np.floor
-        # Due to float weirdness we need a little bit of a fudge factor here.
-        fraction = func(np.round((array - start) / step, decimals=10))
-        return fraction.astype(np.int64)
+            # A bound past one end; its sign says which.
+            out = len(self) if fraction > 0 else -1
+        else:
+            out = math.ceil(fraction) if forward else math.floor(fraction)
+        if (forward and out < 0) or (not forward and out >= len(self)):
+            return None
+        return out
 
     def _samples_in(self, duration):
         """How many steps a duration spans, unrounded."""
@@ -2330,8 +2218,7 @@ class CoordRange(BaseCoord):
         if dtype_time_like(self.dtype):
             ticks = Fraction(int(to_int(dc.to_timedelta64(duration))))
         else:
-            plain = duration.item() if isinstance(duration, np.generic) else duration
-            ticks = Fraction(plain)
+            ticks = Fraction(_maybe_unpack(np.asarray(duration)).item())
         num, den, _ = self._grid_terms
         return ticks / abs(Fraction(num, den))
 
@@ -2339,23 +2226,26 @@ class CoordRange(BaseCoord):
         """Positions past either end, from the grid."""
         if not self._exact:
             return super()._out_of_bounds_indices(array)
-        # Toward the coordinate: past the last label its floor position,
-        # before the first its ceiling, as the truncating division did.
-        past_end = self._get_index(array, forward=False)
-        before_start = self._get_index(array, forward=True)
-        last = self._get_index_values(len(self) - 1)
+        # Past the last label its floor position, before the first its
+        # ceiling, as the truncating division did.
+        last = self._labels(len(self) - 1)
         beyond = (array > last) if self.sorted else (array < last)
-        return np.where(beyond, past_end, before_start).astype(np.int64)
+        return np.where(
+            beyond, self._get_index(array, forward=False), self._get_index(array)
+        ).astype(np.int64)
 
     # --- updates
 
     def _translated(self, delta) -> Self:
-        """Shift every label by a whole number of ticks; the grid moves with them."""
+        """Shift every label; the grid moves with them."""
         if self._exact:
             num, den, offset = self._grid_terms
             start_tick = self._start_tick + _to_tick(delta)
-            return self._grid(start_tick, num, den, offset, len(self))
-        return self._new_grid(self.start + delta, self.step, len(self))
+            fields = _grid_fields(start_tick, num, den, offset, len(self), self.dtype)
+        else:
+            start, stop = self.start + delta, self.stop + delta
+            fields = dict(start=start, stop=stop, step=self.step, shape=self.shape)
+        return self._construct(fields)
 
     def _with_step(self, step) -> CoordRange:
         """The same start and count on a new cadence."""
@@ -2368,15 +2258,17 @@ class CoordRange(BaseCoord):
                 start=self.start, step=step, shape=self.shape, units=self.units
             )
         if frac is not None:
-            if dtype_time_like(self.dtype):
-                frac = frac * _NS_PER_S
-            num, den = frac.numerator, frac.denominator
+            num, den = (
+                frac * (_NS_PER_S if dtype_time_like(self.dtype) else 1)
+            ).as_integer_ratio()
         else:
             num, den = _to_tick(step), 1
         if 0 < abs(num) < den:
             msg = "A step smaller than one tick would repeat labels."
             raise CoordError(msg)
-        return self._grid(self._start_tick, num, den, 0, len(self))
+        return self._construct(
+            _grid_fields(self._start_tick, num, den, 0, len(self), self.dtype)
+        )
 
     @compose_docstring(doc=get_docstring(BaseCoord.update_limits))
     def update_limits(self, min=None, max=None, step=None, **kwargs) -> BaseCoord:
@@ -2393,15 +2285,13 @@ class CoordRange(BaseCoord):
             max = get_compatible_values(max, self.dtype)
             span = _to_tick(max) - _to_tick(min) if self._exact else 0
             if abs(frac := Fraction(span, len(self))) >= 1:
-                out = self._grid(
-                    _to_tick(min), frac.numerator, frac.denominator, 0, len(self)
-                )
+                num, den = frac.as_integer_ratio()
+                fields = _grid_fields(_to_tick(min), num, den, 0, len(self), self.dtype)
+                out = self._construct(fields)
             else:
                 new_step = (max - min) / len(self)
                 out = get_coord(start=min, stop=max, step=new_step, units=self.units)
             return out.new(**kwargs) if kwargs else out
-        # For other combinations we just apply adjustments sequentially
-        # after ensuring that the types are compatible.
         if step is not None:
             out = out._with_step(step)
         if min is not None:
@@ -2423,13 +2313,11 @@ class CoordRange(BaseCoord):
         if "step" in kwargs:
             for name in _EXACT_GRID_FIELDS:
                 info.pop(name, None)
-        info.update(kwargs)
-        return get_coord(**info)
+        return get_coord(**{**info, **kwargs})
 
     def _convert_units(self, units) -> Self:
         """Convert units, or set units if none exist."""
-        # cant convert time units
-        if dtype_time_like(self.dtype):
+        if dtype_time_like(self.dtype):  # time units are fixed
             return self
         if self._exact and self.step_denominator != 1:
             msg = (
@@ -2438,12 +2326,10 @@ class CoordRange(BaseCoord):
                 "integer grid."
             )
             raise CoordError(msg)
-        out = dict(units=units)
         start = convert_units(self.start, to_units=units, from_units=self.units)
         stop = convert_units(self.stop, to_units=units, from_units=self.units)
         step = (stop - start) / len(self)
-        out["start"], out["stop"], out["step"] = start, stop, step
-        return self.__class__(**out)
+        return self.__class__(start=start, stop=stop, step=step, units=units)
 
 
 class CoordArray(BaseCoord):

--- a/dascore/io/ap_sensing/utils.py
+++ b/dascore/io/ap_sensing/utils.py
@@ -4,7 +4,7 @@ Utility functions for AP sensing module.
 
 import dascore as dc
 from dascore.core import get_coord, get_coord_manager
-from dascore.io.utils import build_patches
+from dascore.io.utils import build_patches, step_from_rate
 from dascore.utils.misc import _maybe_unpack, unbyte
 
 
@@ -32,7 +32,7 @@ def _get_time_coord(resource, shape):
     assert trace_count == shape[0], "trace count doesn't match dim shape"
     # Create coord
     start = dc.to_datetime64(start_time_str)
-    step = dc.to_timedelta64(1 / sr)
+    step = step_from_rate(sr)
     return get_coord(start=start, step=step, shape=(trace_count,), units="s")
 
 

--- a/dascore/io/dasdae/utils.py
+++ b/dascore/io/dasdae/utils.py
@@ -163,7 +163,7 @@ def _save_coords(patch, patch_group):
 def _check_storable(patch):
     """Refuse a patch this format cannot store, before touching the file."""
     for name, coord in patch.coords.coord_map.items():
-        if getattr(coord, "step_denominator", 1) != 1:
+        if getattr(coord, "step_denominator", None) not in (None, 1):
             # This format stores one whole-tick step and rebuilds the range
             # from it, which would quietly move every label off its grid.
             msg = (

--- a/dascore/io/dasdae/utils.py
+++ b/dascore/io/dasdae/utils.py
@@ -149,6 +149,14 @@ def _save_coords(patch, patch_group):
         save_name = f"_coord_{name}"
         array_node = _save_array(data, save_name, patch_group)
         step = coord.step
+        if getattr(coord, "step_denominator", 1) != 1:
+            # This format stores one whole-tick step and rebuilds the range
+            # from it, which would quietly move every label off its grid.
+            msg = (
+                f"Coordinate {name!r} has a fractional step "
+                f"({coord.step_exact}) which DASDAE format 1 cannot store."
+            )
+            raise NotImplementedError(msg)
         if step is not None:
             is_td = np.issubdtype(np.asarray(step).dtype, np.timedelta64)
             array_node.attrs["step"] = to_int(step) if is_td else step

--- a/dascore/io/dasdae/utils.py
+++ b/dascore/io/dasdae/utils.py
@@ -149,14 +149,6 @@ def _save_coords(patch, patch_group):
         save_name = f"_coord_{name}"
         array_node = _save_array(data, save_name, patch_group)
         step = coord.step
-        if getattr(coord, "step_denominator", 1) != 1:
-            # This format stores one whole-tick step and rebuilds the range
-            # from it, which would quietly move every label off its grid.
-            msg = (
-                f"Coordinate {name!r} has a fractional step "
-                f"({coord.step_exact}) which DASDAE format 1 cannot store."
-            )
-            raise NotImplementedError(msg)
         if step is not None:
             is_td = np.issubdtype(np.asarray(step).dtype, np.timedelta64)
             array_node.attrs["step"] = to_int(step) if is_td else step
@@ -168,8 +160,22 @@ def _save_coords(patch, patch_group):
         patch_group.attrs[save_name] = ",".join(dims)
 
 
+def _check_storable(patch):
+    """Refuse a patch this format cannot store, before touching the file."""
+    for name, coord in patch.coords.coord_map.items():
+        if getattr(coord, "step_denominator", 1) != 1:
+            # This format stores one whole-tick step and rebuilds the range
+            # from it, which would quietly move every label off its grid.
+            msg = (
+                f"Coordinate {name!r} has a fractional step "
+                f"({coord.step_exact}) which DASDAE format 1 cannot store."
+            )
+            raise NotImplementedError(msg)
+
+
 def _save_patch(patch, wave_group, name):
     """Save the patch to disk."""
+    _check_storable(patch)
     if name in wave_group:
         # Replace the entire patch group so stale datasets/attrs can't survive.
         del wave_group[name]

--- a/dascore/io/mseed/utils.py
+++ b/dascore/io/mseed/utils.py
@@ -119,6 +119,7 @@ class _TraceGroupKey:
     start_ns: int
     sample_rate: float
     sample_count: int
+    origin_offset: int = 0
 
 
 @dataclass(frozen=True)
@@ -142,15 +143,18 @@ def _duration_seconds(sample_rate: float, sample_count: int = 1) -> Fraction:
     return samples / rate if rate > 0 else samples * abs(rate)
 
 
-def _continues(expected_start_ns: int, start_ns: int) -> bool:
+def _continues(expected_start_ns: int, start_ns: int, sample_rate: float) -> bool:
     """
     Whether a record starting at start_ns continues a trace.
 
-    A record's start time is the writer's rounding of a fractional sample
-    time to whole nanoseconds, so it may differ from the expected start by
-    one nanosecond either way (1009 samples at 1024 Hz end at .5 ns).
+    When the sample spacing is not a whole number of nanoseconds, a record's
+    start time is the writer's rounding of a fractional time and may differ
+    from the expected start by one nanosecond either way (1009 samples at
+    1024 Hz end at .5 ns). On a whole-nanosecond grid a nanosecond is a gap.
     """
-    return abs(expected_start_ns - start_ns) <= 1
+    exact = (_duration_seconds(sample_rate) * ONE_BILLION).denominator == 1
+    tolerance = 0 if exact else 1
+    return abs(expected_start_ns - start_ns) <= tolerance
 
 
 def _duration_ns(sample_rate: float, sample_count: int = 1) -> int:
@@ -366,6 +370,7 @@ def _coalesce_source_segments(segments: list[_TraceSegment]) -> list[_TraceSegme
                 and _continues(
                     pending.start_ns + _duration_ns(pending.sample_rate, sample_count),
                     seg.start_ns,
+                    pending.sample_rate,
                 )
                 and pending.data.dtype == seg.data.dtype
                 and pending.encoding == seg.encoding
@@ -392,7 +397,7 @@ def _coalesce_source_summaries(summaries: list[_TraceSummary]) -> list[_TraceSum
         return (
             pending.sample_rate == summary.sample_rate
             and pending.format_version == summary.format_version
-            and _continues(pending.next_start_ns, summary.start_ns)
+            and _continues(pending.next_start_ns, summary.start_ns, pending.sample_rate)
             and pending.dtype == summary.dtype
             and pending.encoding == summary.encoding
         )
@@ -447,6 +452,7 @@ def _get_group_key(segment: _TraceInfo) -> _TraceGroupKey:
         start_ns=segment.start_ns,
         sample_rate=segment.sample_rate,
         sample_count=segment.sample_count,
+        origin_offset=segment.origin_offset,
     )
 
 

--- a/dascore/io/mseed/utils.py
+++ b/dascore/io/mseed/utils.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import struct
 from collections.abc import Callable, Sequence
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from fractions import Fraction
 from itertools import groupby
 from math import ceil, floor
@@ -70,11 +70,19 @@ class _TraceInfo:
     encoding: str
     publication_version: int
     record_length: int
+    # Where the ideal first sample sits after start_ns, in units of the
+    # step's nanosecond denominator; non-zero only after an exact trim.
+    origin_offset: int = field(default=0, kw_only=True)
 
     @property
     def sample_step_ns(self) -> int:
         """Return the sample spacing in nanoseconds."""
         return _duration_ns(self.sample_rate)
+
+    @property
+    def sample_step(self) -> Fraction:
+        """Return the exact sample spacing in seconds."""
+        return _duration_seconds(self.sample_rate)
 
     @property
     def next_start_ns(self) -> int:
@@ -123,16 +131,31 @@ class _PreparedGroup(Generic[_T]):
     attrs: dict
 
 
-def _duration_ns(sample_rate: float, sample_count: int = 1) -> int:
-    """Convert a sample count and MiniSEED sample rate to nanoseconds."""
+def _duration_seconds(sample_rate: float, sample_count: int = 1) -> Fraction:
+    """Convert a sample count and MiniSEED sample rate to exact seconds."""
     if sample_rate == 0:
         msg = "MiniSEED sample rate cannot be zero."
         raise ValueError(msg)
     # MiniSEED negative sample rates encode the sample period in seconds.
     rate = Fraction(str(sample_rate))
     samples = Fraction(sample_count, 1)
-    seconds = samples / rate if rate > 0 else samples * abs(rate)
-    return round(seconds * ONE_BILLION)
+    return samples / rate if rate > 0 else samples * abs(rate)
+
+
+def _continues(expected_start_ns: int, start_ns: int) -> bool:
+    """
+    Whether a record starting at start_ns continues a trace.
+
+    A record's start time is the writer's rounding of a fractional sample
+    time to whole nanoseconds, so it may differ from the expected start by
+    one nanosecond either way (1009 samples at 1024 Hz end at .5 ns).
+    """
+    return abs(expected_start_ns - start_ns) <= 1
+
+
+def _duration_ns(sample_rate: float, sample_count: int = 1) -> int:
+    """Convert a sample count and MiniSEED sample rate to nanoseconds."""
+    return round(_duration_seconds(sample_rate, sample_count) * ONE_BILLION)
 
 
 def _get_time_limits(time=None) -> _TimeLimits:
@@ -256,20 +279,25 @@ def _trim_segment_time(
     start, stop = time_limits
     if start is None and stop is None:
         return segment
-    step = segment.sample_step_ns
-    start_index = (
-        0 if start is None else max(0, ceil((start - segment.start_ns) / step))
-    )
+    # Exact nanosecond arithmetic, so a 1024 Hz trace trimmed at a whole
+    # second keeps the sample on that second, and the trimmed origin stays
+    # on the trace's grid.
+    step = segment.sample_step * ONE_BILLION
+    origin = segment.start_ns + Fraction(segment.origin_offset, step.denominator)
+    start_index = 0 if start is None else max(0, ceil((start - origin) / step))
     stop_index = (
         segment.sample_count
         if stop is None
-        else min(segment.sample_count, floor((stop - segment.start_ns) / step) + 1)
+        else min(segment.sample_count, floor((stop - origin) / step) + 1)
     )
     if stop_index <= start_index:
         return None
+    new_origin = origin + start_index * step
+    start_ns = floor(new_origin)
     return replace(
         segment,
-        start_ns=segment.start_ns + start_index * step,
+        start_ns=start_ns,
+        origin_offset=int((new_origin - start_ns) * step.denominator),
         sample_count=stop_index - start_index,
         data=segment.data[start_index:stop_index].copy(),
     )
@@ -335,8 +363,10 @@ def _coalesce_source_segments(segments: list[_TraceSegment]) -> list[_TraceSegme
             can_merge = (
                 pending.sample_rate == seg.sample_rate
                 and pending.format_version == seg.format_version
-                and pending.start_ns + _duration_ns(pending.sample_rate, sample_count)
-                == seg.start_ns
+                and _continues(
+                    pending.start_ns + _duration_ns(pending.sample_rate, sample_count),
+                    seg.start_ns,
+                )
                 and pending.data.dtype == seg.data.dtype
                 and pending.encoding == seg.encoding
             )
@@ -362,7 +392,7 @@ def _coalesce_source_summaries(summaries: list[_TraceSummary]) -> list[_TraceSum
         return (
             pending.sample_rate == summary.sample_rate
             and pending.format_version == summary.format_version
-            and pending.next_start_ns == summary.start_ns
+            and _continues(pending.next_start_ns, summary.start_ns)
             and pending.dtype == summary.dtype
             and pending.encoding == summary.encoding
         )
@@ -493,11 +523,15 @@ def _get_coords(
         if channel_map is not None
         else tuple(range(len(segments)))
     )
-    step = np.timedelta64(first.sample_step_ns, "ns")
     start = np.datetime64(first.start_ns, "ns")
     return {
         "channel": get_coord(data=np.asarray(channel_values)),
-        "time": get_coord(start=start, step=step, shape=(sample_count,)),
+        "time": get_coord(
+            start=start,
+            step=first.sample_step,
+            shape=(sample_count,),
+            origin_offset=first.origin_offset,
+        ),
         "source_id": (("channel",), source_ids),
         "network": (("channel",), tuple(x.network for x in segments)),
         "station": (("channel",), tuple(x.station for x in segments)),

--- a/dascore/io/segy/utils.py
+++ b/dascore/io/segy/utils.py
@@ -116,7 +116,7 @@ def _get_coords(fi):
 
     # Get time array from SEGY headers
     starttime = _get_time_from_header(header_0)
-    dt = dc.to_timedelta64(header_0[trace_field.TRACE_SAMPLE_INTERVAL] / 1_000_000)
+    dt = np.timedelta64(int(header_0[trace_field.TRACE_SAMPLE_INTERVAL]), "us")
     ns = header_0[trace_field.TRACE_SAMPLE_COUNT]
     time_array = starttime + dt * np.arange(ns)
 

--- a/dascore/io/silixah5/utils.py
+++ b/dascore/io/silixah5/utils.py
@@ -11,6 +11,7 @@ from dascore.io.utils import (
     convert_attr_units,
     drop_blank_attrs,
     get_attr_names,
+    step_from_rate,
 )
 from dascore.utils.misc import maybe_get_items
 
@@ -75,8 +76,7 @@ def _get_time_coord(attr_dict, shape):
     gps_time = _read_time_string(attr_dict["gps_timestamp"])
     cpu_time = _read_time_string(attr_dict["cpu_timestamp"])
     time_min = cpu_time if pd.isnull(gps_time) else gps_time
-    sampling_rate = 1.0 / float(attr_dict["sampling_frequency"])
-    step = dc.to_timedelta64(sampling_rate)
+    step = step_from_rate(float(attr_dict["sampling_frequency"]))
     length = shape[0]
     coord = get_coord(start=time_min, step=step, shape=(length,))
     return coord
@@ -191,7 +191,7 @@ def _get_carina_time_coord(attrs_dict, n_time):
         msg = f"Silixa Carina file has an unusable Samplerate attr ({rate})."
         raise InvalidFiberFileError(msg)
     start = dc.to_datetime64(np.datetime64(start_us, "us"))
-    return get_coord(start=start, step=dc.to_timedelta64(1 / rate), shape=(n_time,))
+    return get_coord(start=start, step=step_from_rate(rate), shape=(n_time,))
 
 
 def _get_carina_distance_coord(attrs_dict, resource, n_columns):

--- a/dascore/io/sintela/utils.py
+++ b/dascore/io/sintela/utils.py
@@ -20,6 +20,7 @@ from dascore.core.attrs import PatchAttrs
 from dascore.core.coordmanager import get_coord_manager
 from dascore.core.coords import get_coord
 from dascore.exceptions import InvalidFiberFileError
+from dascore.io.utils import step_from_rate
 from dascore.utils.misc import get_buffer_size, maybe_mem_map
 
 SYNC_WORD = 0x11223344
@@ -153,7 +154,7 @@ def _get_complete_header(rid):
 def _get_time_coord(header):
     """Get the time coordinate."""
     starttime = np.asarray(header["start_time_ns"]).astype("datetime64[ns]")[()]
-    timestep = dc.to_timedelta64(1 / header["sample_rate"])
+    timestep = step_from_rate(header["sample_rate"])
     total_len = header["num_packets"] * header["num_samples"]
     return get_coord(start=starttime, step=timestep, shape=(total_len,))
 

--- a/dascore/io/tdms/utils.py
+++ b/dascore/io/tdms/utils.py
@@ -12,9 +12,9 @@ import numpy as np
 
 from dascore.core.attrs import PatchAttrs
 from dascore.core.coords import get_coord
-from dascore.io.utils import drop_blank_attrs, get_attr_names
+from dascore.io.utils import drop_blank_attrs, get_attr_names, step_from_rate
 from dascore.utils.misc import get_buffer_size
-from dascore.utils.time import to_datetime64, to_timedelta64
+from dascore.utils.time import to_datetime64
 
 DEFAULT_ATTRS = get_attr_names(PatchAttrs)
 
@@ -119,13 +119,9 @@ def _get_version_str(tdms_file, lead_in_length=28) -> str | Literal[False]:
 
 def _get_time_coord(attrs, num_samps):
     """Get the time array for the file."""
-    dt = to_timedelta64(1 / attrs["SamplingFrequency[Hz]"])
+    dt = step_from_rate(attrs["SamplingFrequency[Hz]"])
     t_min = to_datetime64(str(attrs["GPSTimeStamp"]))
-    # Note: Previously this was:
-    # out["time_min"] + np.timedelta64(
-    t_max = t_min + dt * (num_samps - 1)
-    coord = get_coord(start=t_min, stop=t_max + dt, step=dt, units="s")
-    return coord
+    return get_coord(start=t_min, step=dt, shape=(num_samps,), units="s")
 
 
 def _get_default_attrs(tdms_file, attrs=None):

--- a/dascore/io/utils.py
+++ b/dascore/io/utils.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import warnings
 from collections.abc import Iterable, Mapping, Sequence
+from fractions import Fraction
 from typing import Any, cast
 
 import numpy as np
@@ -33,6 +34,7 @@ from dascore.utils.misc import (
     is_strictly_monotonic,
     unbyte,
 )
+from dascore.utils.time import to_exact_fraction
 
 # Stored coordinate arrays often carry sub-step jitter (e.g. GPS-stamped DAS
 # time). ``CoordSegmented.from_array`` treats every isolated sampling change as
@@ -340,3 +342,33 @@ def _is_over_segmented(values) -> bool:
     in_run[:-1] |= eq_next
     segment_count = int(np.count_nonzero(~in_run)) + 1
     return segment_count > _MAX_SEGMENT_FRACTION * len(values)
+
+
+def step_from_rate(rate) -> Fraction | np.timedelta64:
+    """
+    The time step a file states as a sampling rate in Hz.
+
+    A rate that is a simple number (1024.0, 3000.0, 62.5, 999.9) gives an
+    exact `Fraction` step in seconds, which `get_coord` keeps on its grid;
+    any other rate gives the nearest nanosecond timedelta, as before. A
+    float32 rate recovers only the values it holds exactly, which is the
+    honest reading of it.
+    """
+    frac = to_exact_fraction(rate)
+    if frac is not None and frac > 0:
+        return 1 / frac
+    return dc.to_timedelta64(1 / float(rate))
+
+
+def step_from_interval(seconds) -> Fraction | np.timedelta64:
+    """
+    The time step a file states as a sample interval in seconds.
+
+    The exact `Fraction` when the interval is a simple fraction (``1 /
+    3000``, ``0.004``), otherwise the nearest nanosecond timedelta, as
+    before.
+    """
+    frac = to_exact_fraction(seconds)
+    if frac is not None and frac > 0:
+        return frac
+    return dc.to_timedelta64(float(seconds))

--- a/dascore/io/xml_binary/utils.py
+++ b/dascore/io/xml_binary/utils.py
@@ -16,6 +16,7 @@ from dascore.compat import UPath
 from dascore.core import get_coord, get_coord_manager
 from dascore.io import ScanPayload
 from dascore.io.core import make_scan_payload
+from dascore.io.utils import step_from_rate
 from dascore.models import DateTime64
 from dascore.utils.misc import iterate
 from dascore.utils.pd import adjust_segments, filter_df
@@ -93,7 +94,7 @@ def _make_distance_coord(metadata: XMLBinaryInfo):
 
 def _make_time_coord(file_start_times, metadata: XMLBinaryInfo):
     """Create time coord for each file."""
-    dt = dc.to_timedelta64(1.0 / metadata.output_temporal_sampling_rate)
+    dt = step_from_rate(metadata.output_temporal_sampling_rate)
     nt = metadata.number_of_frames
     for start in file_start_times:
         yield get_coord(start=start, step=dt, shape=(nt,), units="s")

--- a/dascore/proc/basic.py
+++ b/dascore/proc/basic.py
@@ -19,7 +19,7 @@ from dascore.core.coordmanager import (
     CoordManagerInput,
     get_coord_manager,
 )
-from dascore.core.coords import CoordRangeInt, get_coord
+from dascore.core.coords import CoordRange, get_coord
 from dascore.exceptions import ParameterError
 from dascore.models import ArrayLike
 from dascore.units import Quantity, get_quantity
@@ -1037,17 +1037,11 @@ def pad(
         # an integer coordinate to hold a NaN nothing is going to write.
         if not any(pad_tuple):
             return coord
-        if expand_coords and isinstance(coord, CoordRangeInt):
-            # Extend the exact grid itself: rebuilding from the rounded step
-            # would move every label of a fractional grid.
+        if expand_coords and isinstance(coord, CoordRange):
+            # Extend the grid itself: rebuilding from the rounded step would
+            # move every label of a fractional grid.
             total = len(coord) + pad_tuple[0] + pad_tuple[1]
             new_coord = coord._sliced(-pad_tuple[0], 1, total)
-        elif expand_coords and coord.evenly_sampled:
-            new_start = coord.min() - pad_tuple[0] * coord.step
-            new_end = coord.max() + (pad_tuple[1] + 1) * coord.step
-            new_coord = get_coord(
-                start=new_start, stop=new_end, step=coord.step, units=coord.units
-            )
         else:
             old_values = coord.values
             # Need to convert ints to float so NaN can be used.

--- a/dascore/proc/basic.py
+++ b/dascore/proc/basic.py
@@ -19,7 +19,7 @@ from dascore.core.coordmanager import (
     CoordManagerInput,
     get_coord_manager,
 )
-from dascore.core.coords import get_coord
+from dascore.core.coords import CoordRangeInt, get_coord
 from dascore.exceptions import ParameterError
 from dascore.models import ArrayLike
 from dascore.units import Quantity, get_quantity
@@ -1037,10 +1037,14 @@ def pad(
         # an integer coordinate to hold a NaN nothing is going to write.
         if not any(pad_tuple):
             return coord
-        if expand_coords and coord.evenly_sampled:
+        if expand_coords and isinstance(coord, CoordRangeInt):
+            # Extend the exact grid itself: rebuilding from the rounded step
+            # would move every label of a fractional grid.
+            total = len(coord) + pad_tuple[0] + pad_tuple[1]
+            new_coord = coord._sliced(-pad_tuple[0], 1, total)
+        elif expand_coords and coord.evenly_sampled:
             new_start = coord.min() - pad_tuple[0] * coord.step
             new_end = coord.max() + (pad_tuple[1] + 1) * coord.step
-            assert coord.evenly_sampled, "expand_coords requires evenly sampled."
             new_coord = get_coord(
                 start=new_start, stop=new_end, step=coord.step, units=coord.units
             )

--- a/dascore/proc/tile_apply.py
+++ b/dascore/proc/tile_apply.py
@@ -26,7 +26,7 @@ from pydantic import ConfigDict
 import dascore as dc
 from dascore.constants import PatchType
 from dascore.core.coordmanager import get_coord_manager
-from dascore.core.coords import get_coord
+from dascore.core.coords import CoordRangeInt, get_coord
 from dascore.exceptions import (
     MissingOptionalDependencyError,
     ParameterError,
@@ -64,6 +64,8 @@ def _offset_values(coord, offsets: np.ndarray):
     From the first sample, not the minimum: a descending coordinate steps
     down from where it starts.
     """
+    if isinstance(coord, CoordRangeInt):
+        return coord._from_ticks(coord._ticks(np.asarray(offsets)))
     first, step = coord.values[0], coord.step
     if is_datetime64(coord.dtype) or is_timedelta64(coord.dtype):
         return first + dc.to_timedelta64(offsets * to_float(step))

--- a/dascore/proc/tile_apply.py
+++ b/dascore/proc/tile_apply.py
@@ -26,7 +26,7 @@ from pydantic import ConfigDict
 import dascore as dc
 from dascore.constants import PatchType
 from dascore.core.coordmanager import get_coord_manager
-from dascore.core.coords import CoordRangeInt, get_coord
+from dascore.core.coords import get_coord
 from dascore.exceptions import (
     MissingOptionalDependencyError,
     ParameterError,
@@ -41,7 +41,6 @@ from dascore.utils.signal import (
     get_window_nd,
 )
 from dascore.utils.tiles import get_tile_plan
-from dascore.utils.time import is_datetime64, is_timedelta64, to_float
 from dascore.utils.window import Window, resolve_window
 from dascore.workflow.meta import PatchMeta
 from dascore.workflow.processor import PatchProcessor, register_implementation
@@ -62,14 +61,10 @@ def _offset_values(coord, offsets: np.ndarray):
     Return coordinate values `offsets` samples from the coordinate's first sample.
 
     From the first sample, not the minimum: a descending coordinate steps
-    down from where it starts.
+    down from where it starts. Only a range has a step, so only a range
+    gets here.
     """
-    if isinstance(coord, CoordRangeInt):
-        return coord._from_ticks(coord._ticks(np.asarray(offsets)))
-    first, step = coord.values[0], coord.step
-    if is_datetime64(coord.dtype) or is_timedelta64(coord.dtype):
-        return first + dc.to_timedelta64(offsets * to_float(step))
-    return first + offsets * step
+    return coord._labels(offsets)
 
 
 def _engine_for(engine: str, func) -> str:

--- a/dascore/utils/time.py
+++ b/dascore/utils/time.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import math
 from datetime import date, datetime, timedelta
+from fractions import Fraction
 from functools import singledispatch
 from typing import Any, SupportsFloat, cast, overload
 
@@ -570,3 +571,68 @@ def dtype_time_like(dtype_or_array) -> bool:
     if is_timedelta or is_datetime:
         return True
     return False
+
+
+def to_exact_fraction(
+    value, *, max_term: int = 100_000, rel_tol: float = 0.0
+) -> Fraction | None:
+    """
+    Recover the simple fraction a float was rounded from, or None.
+
+    A stored rate of ``1024.0`` or an interval computed as ``1 / 3000`` is
+    the nearest double to a ratio of small integers. This returns that
+    ratio when one whose numerator and denominator are both at most
+    ``max_term`` rounds to the very same double; otherwise None, and the
+    caller should keep the value as given. Exact agreement between small
+    terms is what makes the guess safe: an arbitrary double has about a
+    one-in-a-million chance of matching such a fraction.
+
+    A value stored with fewer digits than a double holds (``0.00033333333``,
+    or a float32) never matches exactly. ``rel_tol`` admits such a value,
+    but loosely: every real number is within a part in a billion of some
+    fraction with terms below a million (pi is 3126535/995207), so pair a
+    tolerance with a small ``max_term``. Never apply this to a derived
+    quantity.
+
+    Parameters
+    ----------
+    value
+        A finite number (int, float, numpy scalar, or Fraction).
+    max_term
+        The largest numerator or denominator considered.
+    rel_tol
+        The relative error allowed between the fraction and ``value``;
+        zero (the default) requires the same double.
+
+    Examples
+    --------
+    >>> from dascore.utils.time import to_exact_fraction
+    >>> to_exact_fraction(1024.0)
+    Fraction(1024, 1)
+    >>> to_exact_fraction(1 / 3000)
+    Fraction(1, 3000)
+    >>> to_exact_fraction(0.00033333333, rel_tol=1e-7, max_term=10_000)
+    Fraction(1, 3000)
+    >>> to_exact_fraction(0.1234567891234) is None
+    True
+    """
+    if isinstance(value, Fraction):
+        return value
+    if isinstance(value, bool | np.bool_):
+        return None
+    try:
+        as_float = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(as_float):
+        return None
+    if as_float == 0:
+        return Fraction(0)
+    frac = Fraction(as_float).limit_denominator(max_term)
+    if abs(frac.numerator) > max_term:
+        return None
+    if rel_tol == 0:
+        return frac if float(frac) == as_float else None
+    if not math.isclose(float(frac), as_float, rel_tol=rel_tol, abs_tol=0.0):
+        return None
+    return frac

--- a/dascore/xarray/patch.py
+++ b/dascore/xarray/patch.py
@@ -45,7 +45,7 @@ def _lazy_temporal_index(name, coord):
         return None
     # The index holds one whole-tick step; a fractional grid would be
     # relabelled by it, so its values travel instead.
-    if getattr(coord, "step_denominator", 1) != 1:
+    if getattr(coord, "step_denominator", None) not in (None, 1):
         return None
     # function-level: xarray is an optional dependency
     from dascore.xarray.index import TemporalRangeIndex  # noqa: PLC0415

--- a/dascore/xarray/patch.py
+++ b/dascore/xarray/patch.py
@@ -43,6 +43,10 @@ def _lazy_temporal_index(name, coord):
         return None
     if np.asarray(step).astype("int64") <= 0:
         return None
+    # The index holds one whole-tick step; a fractional grid would be
+    # relabelled by it, so its values travel instead.
+    if getattr(coord, "step_denominator", 1) != 1:
+        return None
     # function-level: xarray is an optional dependency
     from dascore.xarray.index import TemporalRangeIndex  # noqa: PLC0415
 

--- a/docs/notes/coordinate_internals.qmd
+++ b/docs/notes/coordinate_internals.qmd
@@ -11,8 +11,7 @@ This note explains the current internal coordinate model in DASCore, with partic
 | Type | Purpose |
 |---|---|
 | `CoordPartial` | Shape and optional range metadata when coordinate values are unknown, empty, or entirely missing. |
-| `CoordRange` | A monotonic, evenly sampled coordinate represented by start, stop, and step. |
-| `CoordRangeInt` | The `CoordRange` subclass `get_coord` returns for nanosecond datetime64/timedelta64 ranges and for integer ranges whose step is an integer, a `Fraction`, a tuple, or an evenly dividing span. It holds the exact grid (`step_numerator`, `step_denominator`, `origin_offset` in ticks) so a fractional step such as 1/1024 s never drifts; `step` stays the nearest whole-tick spacing and the repr reads `CoordRange`. Coarser time units, sub-nanosecond units, float steps, and unevenly divided integer spans (`get_coord(start=0, stop=10, shape=3)` is float) keep the plain `CoordRange`, which is unchanged. |
+| `CoordRange` | A monotonic, evenly sampled coordinate represented by start, stop, and step. Nanosecond time and integer ranges also hold their exact grid (`step_numerator`, `step_denominator`, `origin_offset` in ticks), so a fractional step such as 1/1024 s never drifts and `step_exact` reports it; `step` stays the nearest whole-tick spacing. Float ranges, time in coarser or finer units, and integer spans that do not divide by their count (`get_coord(start=0, stop=10, shape=3)` is float) keep a scalar step and linear spacing, with the grid fields None. |
 | `CoordMonotonicArray` | A strictly increasing or decreasing array that is not evenly sampled. |
 | `CoordSegmented` | An ordered composition of non-overlapping monotonic segments whose concatenated values are preserved exactly. |
 | `CoordArray` | Arbitrary numeric, datetime, or timedelta values, including non-monotonic arrays. |
@@ -55,7 +54,7 @@ Slice results remain compact for integer, temporal, and floating coordinates, fo
 
 [`CoordSummary`](`dascore.core.coords.CoordSummary`) contains `min`, `max`, `step`, `dtype`, `units`, associated `dims`, length, and an exact coordinate fingerprint. The canonical construction path is `coord.to_summary()`, which starts from a live coordinate; build one with `get_coord(...)` first when starting from a raw value array.
 
-The summary itself is intentionally lossy. A uniform `CoordRange` has a non-null `step` and can be reconstructed with `summary.to_coord()`; a `CoordRangeInt` also carries `step_numerator`, `step_denominator`, and `origin_offset`, so a fractional grid rebuilds exactly. Irregular, string, and segmented coordinates use `step=None`; their envelopes and fingerprints can support indexing and change detection, but neither field reconstructs their full values or segment boundaries.
+The summary itself is intentionally lossy. A uniform `CoordRange` has a non-null `step` and can be reconstructed with `summary.to_coord()`; an exact grid also carries `step_numerator`, `step_denominator`, and `origin_offset`, so a fractional step rebuilds exactly. Irregular, string, and segmented coordinates use `step=None`; their envelopes and fingerprints can support indexing and change detection, but neither field reconstructs their full values or segment boundaries.
 
 [`PatchSummary`](`dascore.PatchSummary`) keeps non-coordinate `PatchAttrs`, a mapping of coordinate summaries, patch dimensions/shape/dtype, and reload provenance. [`PatchSummary.flat_dump(...)`](`dascore.PatchSummary.flat_dump`) produces fields such as `time_min`, `time_max`, `time_step`, and `time_fingerprint` for dataframes and indexes. Those flattened fields are output records, not supported input for synthesizing a new structured `PatchSummary` or live coordinate.
 

--- a/docs/notes/coordinate_internals.qmd
+++ b/docs/notes/coordinate_internals.qmd
@@ -12,6 +12,7 @@ This note explains the current internal coordinate model in DASCore, with partic
 |---|---|
 | `CoordPartial` | Shape and optional range metadata when coordinate values are unknown, empty, or entirely missing. |
 | `CoordRange` | A monotonic, evenly sampled coordinate represented by start, stop, and step. |
+| `CoordRangeInt` | The `CoordRange` subclass `get_coord` returns for datetime64, timedelta64, and integer ranges. It holds the exact grid (`step_numerator`, `step_denominator`, `origin_offset` in ticks) so a fractional step such as 1/1024 s never drifts; `step` stays the nearest whole-tick spacing and the repr reads `CoordRange`. `CoordRange` built directly is unchanged. |
 | `CoordMonotonicArray` | A strictly increasing or decreasing array that is not evenly sampled. |
 | `CoordSegmented` | An ordered composition of non-overlapping monotonic segments whose concatenated values are preserved exactly. |
 | `CoordArray` | Arbitrary numeric, datetime, or timedelta values, including non-monotonic arrays. |
@@ -54,7 +55,7 @@ Slice results remain compact for integer, temporal, and floating coordinates, fo
 
 [`CoordSummary`](`dascore.core.coords.CoordSummary`) contains `min`, `max`, `step`, `dtype`, `units`, associated `dims`, length, and an exact coordinate fingerprint. The canonical construction path is `coord.to_summary()`, which starts from a live coordinate; build one with `get_coord(...)` first when starting from a raw value array.
 
-The summary itself is intentionally lossy. A uniform `CoordRange` has a non-null `step` and can be reconstructed with `summary.to_coord()`. Irregular, string, and segmented coordinates use `step=None`; their envelopes and fingerprints can support indexing and change detection, but neither field reconstructs their full values or segment boundaries.
+The summary itself is intentionally lossy. A uniform `CoordRange` has a non-null `step` and can be reconstructed with `summary.to_coord()`; a `CoordRangeInt` also carries `step_numerator`, `step_denominator`, and `origin_offset`, so a fractional grid rebuilds exactly. Irregular, string, and segmented coordinates use `step=None`; their envelopes and fingerprints can support indexing and change detection, but neither field reconstructs their full values or segment boundaries.
 
 [`PatchSummary`](`dascore.PatchSummary`) keeps non-coordinate `PatchAttrs`, a mapping of coordinate summaries, patch dimensions/shape/dtype, and reload provenance. [`PatchSummary.flat_dump(...)`](`dascore.PatchSummary.flat_dump`) produces fields such as `time_min`, `time_max`, `time_step`, and `time_fingerprint` for dataframes and indexes. Those flattened fields are output records, not supported input for synthesizing a new structured `PatchSummary` or live coordinate.
 

--- a/docs/notes/coordinate_internals.qmd
+++ b/docs/notes/coordinate_internals.qmd
@@ -12,7 +12,7 @@ This note explains the current internal coordinate model in DASCore, with partic
 |---|---|
 | `CoordPartial` | Shape and optional range metadata when coordinate values are unknown, empty, or entirely missing. |
 | `CoordRange` | A monotonic, evenly sampled coordinate represented by start, stop, and step. |
-| `CoordRangeInt` | The `CoordRange` subclass `get_coord` returns for datetime64, timedelta64, and integer ranges. It holds the exact grid (`step_numerator`, `step_denominator`, `origin_offset` in ticks) so a fractional step such as 1/1024 s never drifts; `step` stays the nearest whole-tick spacing and the repr reads `CoordRange`. `CoordRange` built directly is unchanged. |
+| `CoordRangeInt` | The `CoordRange` subclass `get_coord` returns for nanosecond datetime64/timedelta64 ranges and for integer ranges whose step is an integer, a `Fraction`, a tuple, or an evenly dividing span. It holds the exact grid (`step_numerator`, `step_denominator`, `origin_offset` in ticks) so a fractional step such as 1/1024 s never drifts; `step` stays the nearest whole-tick spacing and the repr reads `CoordRange`. Coarser time units, sub-nanosecond units, float steps, and unevenly divided integer spans (`get_coord(start=0, stop=10, shape=3)` is float) keep the plain `CoordRange`, which is unchanged. |
 | `CoordMonotonicArray` | A strictly increasing or decreasing array that is not evenly sampled. |
 | `CoordSegmented` | An ordered composition of non-overlapping monotonic segments whose concatenated values are preserved exactly. |
 | `CoordArray` | Arbitrary numeric, datetime, or timedelta values, including non-monotonic arrays. |

--- a/docs/tutorial/coords.qmd
+++ b/docs/tutorial/coords.qmd
@@ -42,6 +42,25 @@ Coordinates expose values, units, data type, ordering, sampling regularity, limi
 | `units` | Physical units, if present |
 | `degenerate` | Whether the coordinate is empty or zero-dimensional |
 | `min()`, `max()` | Coordinate limits |
+| `step_exact` | The spacing as an exact `Fraction` (seconds for time), or `None` for float coordinates |
+
+### Exact sampling rates
+
+Time and integer ranges keep their spacing exactly. A step may be given as a `Fraction` or a `(numerator, denominator)` tuple in the coordinate's units, so a 1024 Hz recording is `(1, 1024)` seconds rather than a step rounded to 976562 nanoseconds, which would drift by 1.8 ms an hour. Every label is the nearest tick to its position on the exact grid, and slicing, striding, reversing, and selecting all stay on that grid. `step` still reports the nearest whole-tick spacing for code that expects one.
+
+```{python}
+from fractions import Fraction
+
+t0 = np.datetime64("2020-01-01T00:00:00")
+time = get_coord(start=t0, step=(1, 1024), shape=(3_686_400,))
+
+assert time.step_exact == Fraction(1, 1024)
+assert time[::2].step_exact == Fraction(1, 512)
+assert time.stop == t0 + np.timedelta64(1, "h")
+assert time.step == np.timedelta64(976562, "ns")
+```
+
+Float coordinates have no tick to be exact against, so a fraction step on one raises and their `step_exact` is `None`.
 
 ## Segmented coordinates
 

--- a/tests/test_core/test_coord_range_int.py
+++ b/tests/test_core/test_coord_range_int.py
@@ -103,19 +103,24 @@ class TestDispatch:
         coord = get_coord(start=start, stop=start + step * 10, step=step)
         assert type(coord) is CoordRange
 
-    def test_coarse_units_kept(self):
-        """A microsecond coordinate stays microseconds and works past 2262."""
+    def test_coarse_units_stay_legacy(self):
+        """Only nanosecond time is exact; coarser units keep the legacy class."""
         start = np.datetime64("2500-01-01T00:00:00", "us")
         coord = get_coord(start=start, step=np.timedelta64(2, "us"), shape=(5,))
-        assert isinstance(coord, CoordRangeInt)
+        assert type(coord) is CoordRange
         assert coord.dtype == np.dtype("datetime64[us]")
         assert coord.values[-1] == start + np.timedelta64(8, "us")
         assert coord.step_exact == Fraction(2, 10**6)
+        day = get_coord(start=np.datetime64("2020-01-01"), step=ONE_S, shape=(3,))
+        assert type(day) is CoordRange and day.dtype == np.dtype("datetime64[s]")
 
-    def test_coarse_start_fine_step_resolves_finer(self):
-        """A scalar step resolves the unit as start + step does."""
-        coord = get_coord(start=np.datetime64("2020-01-01"), step=ONE_S, shape=(3,))
-        assert coord.dtype == np.dtype("datetime64[s]")
+    def test_nanosecond_step_resolves_exact(self):
+        """A nanosecond step makes a coarse start resolve to nanoseconds."""
+        coord = get_coord(
+            start=np.datetime64("2020-01-01"), step=np.timedelta64(1, "ns"), shape=(3,)
+        )
+        assert isinstance(coord, CoordRangeInt)
+        assert coord.dtype == np.dtype("datetime64[ns]")
 
     def test_fraction_step_with_coarse_start_uses_nanoseconds(self):
         """A fraction step is in seconds, so nanoseconds hold it."""
@@ -227,9 +232,13 @@ class TestConstruction:
         assert isinstance(coord.select((6, 7))[0], CoordPartial)
 
     def test_overflow_raises(self):
-        """A grid past the int64 range is refused at construction."""
-        with pytest.raises(ValidationError, match="int64"):
+        """A grid past its dtype's range is refused at construction."""
+        with pytest.raises(ValidationError, match="int64 range"):
             get_coord(start=2**62, step=2**40, shape=(2**30,))
+        with pytest.raises(ValidationError, match="int8 range"):
+            get_coord(start=np.int8(120), step=np.int8(2), shape=(10,))
+        small = get_coord(start=np.int8(120), step=np.int8(2), shape=(3,))
+        assert small.dtype == np.dtype("int8") and small.max() == 124
 
     def test_grid_normalized_jointly(self):
         """(6, 2, 1) must not reduce to (3, 1, 0): that moves the origin."""
@@ -721,8 +730,7 @@ class TestStepExact:
     def test_time_units_are_seconds(self, hz_1024):
         """step_exact of a time coordinate is in seconds."""
         assert hz_1024.step_exact == Fraction(1, 1024)
-        start = np.datetime64("2020-01-01", "ms")
-        ms = get_coord(start=start, step=np.timedelta64(4, "ms"), shape=(3,))
+        ms = get_coord(start=T0, step=np.timedelta64(4, "ms"), shape=(3,))
         assert ms.step_exact == Fraction(4, 1000)
 
 
@@ -801,16 +809,9 @@ class TestValidationErrors:
         with pytest.raises(CoordError, match="length"):
             summary.to_coord()
 
-    def test_value_off_grid(self):
-        """A value finer than the tick does not sit on the grid."""
-        start = np.datetime64("2020-01-01T00:00:00.000001", "us")
-        coord = get_coord(start=start, step=np.timedelta64(1, "us"), shape=(4,))
-        with pytest.raises(CoordError, match="does not sit"):
-            coord._new_grid(start + np.timedelta64(1, "ns"), coord.step, 4)
-
     def test_non_time_value_on_time_grid(self):
         """A value that is not a time at all is refused."""
-        with pytest.raises(ValidationError, match="not a"):
+        with pytest.raises(ValidationError, match="not an integer or time"):
             CoordRangeInt(start=T0, stop="tomorrow", step=(1, 2))
 
     def test_non_integer_float(self):
@@ -819,7 +820,7 @@ class TestValidationErrors:
             CoordRangeInt(start=0, stop=10, step=2.5)
 
     def test_month_unit(self):
-        """A month is not a fixed number of seconds; a fraction step uses ns."""
+        """A month step stays legacy; a fraction step resolves to nanoseconds."""
         start = np.datetime64("2020-01", "M")
         from dascore.core.coords import _range_class  # noqa: PLC0415
 
@@ -849,9 +850,8 @@ class TestValidationErrors:
                 step_denominator=2,
                 origin_offset=2,
             )
-        with pytest.raises(ValidationError, match="fixed tick"):
-            month = np.datetime64("2020-01", "M")
-            CoordRangeInt(start=month, step=np.timedelta64(1, "M"), shape=(3,))
+        with pytest.raises(ValidationError, match="needs nanoseconds"):
+            CoordRangeInt(start=np.datetime64("2020-01-01"), step=ONE_S, shape=(3,))
 
     def test_update_limits_step_below_tick(self, int_frac):
         """A new step below one tick is refused."""
@@ -888,15 +888,7 @@ class TestValidationErrors:
 
 
 class TestUnitHelpers:
-    """Time unit parsing behind the exact grid."""
-
-    def test_generic_unit_has_no_tick(self):
-        """A generic time dtype states no unit and so no tick."""
-        from dascore.core.coords import _seconds_per_tick, _time_unit  # noqa: PLC0415
-
-        assert _time_unit(np.dtype("datetime64")) == ("generic", 1)
-        assert _seconds_per_tick(np.dtype("datetime64")) is None
-        assert _seconds_per_tick(np.dtype("datetime64[10us]")) == Fraction(1, 10**5)
+    """Dispatch details behind the exact grid."""
 
     def test_mixed_kinds_stay_legacy(self):
         """A time start with a non-time stop is left to the legacy validator."""
@@ -983,13 +975,12 @@ class TestLegacyCoordRange:
 class TestReviewFindings:
     """Consumers that rebuilt from the rounded step now stay on the grid."""
 
-    def test_summary_keeps_coarse_tick_unit(self):
-        """A microsecond grid summarised in nanoseconds rebuilds its labels."""
-        start = np.datetime64("2020-01-01", "us")
-        coord = get_coord(start=start, step=np.timedelta64(2, "us"), shape=(5,))
+    def test_summary_round_trip_of_odd_grid(self):
+        """A grid with a fractional origin survives the summary."""
+        coord = get_coord(start=T0, step=(3, 2 * 10**9), shape=(6,))[1:]
         rebuilt = coord.to_summary().to_coord()
         assert np.array_equal(rebuilt.values, coord.values)
-        assert rebuilt.step_exact == coord.step_exact
+        assert rebuilt == coord
 
     def test_pad_extends_the_grid(self, hz_1024):
         """Padding a fractional grid keeps every existing label."""
@@ -1011,11 +1002,15 @@ class TestReviewFindings:
         assert type(floats) is CoordRange and floats.step == 0.5
         moved = get_coord(start=0, stop=10, step=1).update_limits(step=0.5, min=1)
         assert type(moved) is CoordRange and moved.min() == 1 and moved.step == 0.5
-        start = np.datetime64("2020-01-01", "ms")
-        ms = get_coord(start=start, step=np.timedelta64(1, "ms"), shape=(4,))
-        finer = ms.update_limits(step=np.timedelta64(500, "us"))
+        legacy = get_coord(
+            start=np.datetime64("2020-01-01", "ms"),
+            step=np.timedelta64(1, "ms"),
+            shape=(4,),
+        )
+        assert type(legacy) is CoordRange
+        exact = get_coord(start=T0, step=np.timedelta64(1, "ms"), shape=(4,))
+        finer = exact.update_limits(step=np.timedelta64(500, "us"))
         assert finer.step_exact == Fraction(1, 2000) and len(finer) == 4
-        assert finer.min() == ms.min()
 
     def test_sample_count_uses_exact_step(self, hz_1024):
         """A second at 1024 Hz is 1024 samples, not 1025."""
@@ -1037,3 +1032,49 @@ class TestReviewFindings:
         out = _offset_values(hz_1024, np.array([0, 1024, 1025]))
         assert out[1] == T0 + ONE_S
         assert np.array_equal(out, hz_1024.values[[0, 1024, 1025]])
+
+
+class TestSecondReviewRound:
+    """Findings from the PR review."""
+
+    def test_decimate_keeps_grid(self, hz_1024):
+        """Decimating a patch on a fractional grid keeps the exact grid."""
+        patch = dc.get_example_patch().update_coords(time=hz_1024[:2000])
+        out = patch.decimate(time=3, filter_type=None)
+        time = out.get_coord("time")
+        assert isinstance(time, CoordRangeInt)
+        assert time.step_exact == Fraction(3, 1024)
+        assert np.array_equal(time.values, hz_1024.values[:2000:3])
+
+    def test_index_with_slice_and_array(self, hz_1024):
+        """index() with a slice keeps the grid; arrays go through values."""
+        assert hz_1024.index(slice(1, 10, 2)) == hz_1024[1:10:2]
+        out = hz_1024.index(np.array([1, 5, 9]))
+        assert np.array_equal(out.values, hz_1024.values[[1, 5, 9]])
+
+    def test_coord_range_uses_exact_end(self):
+        """The extended range reaches the exact exclusive end."""
+        coord = get_coord(start=T0, step=(1, 1024), shape=(1024,))
+        assert coord.coord_range() == np.timedelta64(1, "s")
+        assert coord[::-1].coord_range() == np.timedelta64(1, "s")
+        assert coord.coord_range(extend=False) == coord.max() - coord.min()
+
+    def test_huge_bounds(self):
+        """Bounds past the int64 range select the whole coordinate or nothing."""
+        coord = get_coord(start=0, stop=10, step=1)
+        sub, _ = coord.select((np.uint64(2**63 + 1), None))
+        assert isinstance(sub, CoordPartial)
+        sub, _ = coord.select((2**70, None))
+        assert isinstance(sub, CoordPartial)
+        sub, _ = coord.select((-(2**70), 2**70))
+        assert sub == coord
+
+    def test_dasdae_refuses_before_writing(self, hz_1024, tmp_path):
+        """A refused write leaves the existing file untouched."""
+        path = tmp_path / "keep.h5"
+        good = dc.get_example_patch()
+        good.io.write(path, "dasdae")
+        bad = good.update_coords(time=hz_1024[:2000])
+        with pytest.raises(NotImplementedError, match="fractional step"):
+            bad.io.write(path, "dasdae")
+        assert dc.spool(path)[0] == good

--- a/tests/test_core/test_coord_range_int.py
+++ b/tests/test_core/test_coord_range_int.py
@@ -815,7 +815,7 @@ class TestValidationErrors:
     def test_non_integer_float(self):
         """A non-integer float cannot be a tick of an integer grid."""
         with pytest.raises(CoordError, match="non-integer"):
-            get_coord(start=0, stop=10, step=(5, 2))._new_grid(0.5, 1, 3)
+            get_coord(start=0, stop=10, step=1).update_limits(min=2.5)
 
     def test_month_unit(self):
         """A month step is not exact; a fraction step resolves to nanoseconds."""
@@ -855,11 +855,6 @@ class TestValidationErrors:
         """A new step below one tick is refused."""
         with pytest.raises(CoordError, match="smaller than one tick"):
             int_frac.update_limits(step=(1, 3))
-
-    def test_new_grid_helper(self, int_frac):
-        """The parent's grid constructor builds a whole-tick grid."""
-        out = int_frac._new_grid(4, 2, 5)
-        assert np.array_equal(out.values, [4, 6, 8, 10, 12])
 
     def test_descending_array_index(self):
         """The vectorized index of a descending whole-tick grid."""

--- a/tests/test_core/test_coord_range_int.py
+++ b/tests/test_core/test_coord_range_int.py
@@ -1,0 +1,1039 @@
+"""Tests for exact integer-grid range coordinates (CoordRangeInt)."""
+
+from __future__ import annotations
+
+import pickle
+from fractions import Fraction
+
+import numpy as np
+import pytest
+from pydantic import ValidationError
+
+import dascore as dc
+from dascore.core.coords import (
+    CoordPartial,
+    CoordRange,
+    CoordRangeInt,
+    CoordSegmented,
+    CoordSummary,
+    concat_coords,
+    get_coord,
+)
+from dascore.exceptions import CoordError
+
+T0 = np.datetime64("2020-01-01T00:00:00.000000000")
+ONE_S = np.timedelta64(1, "s")
+
+
+def _floor_labels(start_tick, num, den, offset, count):
+    """The labels the plan defines: start + floor((offset + i*num) / den)."""
+    i = np.arange(count, dtype=np.int64)
+    return start_tick + (offset + i * num) // den
+
+
+@pytest.fixture(scope="session")
+def hz_1024():
+    """An hour at 1024 Hz: the drifting case."""
+    return get_coord(start=T0, step=(1, 1024), shape=(3_686_400,))
+
+
+@pytest.fixture(scope="session")
+def hz_3000():
+    """Ten seconds at 3000 Hz: a step that is not a binary fraction."""
+    return get_coord(start=T0, step=Fraction(1, 3000), shape=(30_000,))
+
+
+@pytest.fixture(scope="session")
+def int_frac():
+    """An integer grid with a three-halves step."""
+    return get_coord(start=-7, step=(3, 2), shape=(50,), units="m")
+
+
+class TestDispatch:
+    """get_coord picks the exact class for time and integer ranges."""
+
+    def test_time_scalar_step(self):
+        """A timedelta step on a datetime start makes a whole-tick exact grid."""
+        coord = get_coord(start=T0, step=ONE_S, shape=(10,))
+        assert isinstance(coord, CoordRangeInt)
+        assert coord.step_denominator == 1
+        assert coord.step == ONE_S
+
+    def test_timedelta(self):
+        """A timedelta coordinate is an exact grid in its own unit."""
+        coord = get_coord(start=np.timedelta64(0, "ns"), step=ONE_S, shape=(3,))
+        assert isinstance(coord, CoordRangeInt)
+        assert coord.dtype == np.dtype("timedelta64[ns]")
+        assert coord.step_exact == 1
+
+    def test_int(self):
+        """Integer ranges are exact grids."""
+        coord = get_coord(start=0, stop=10, step=2)
+        assert isinstance(coord, CoordRangeInt)
+        assert np.array_equal(coord.values, [0, 2, 4, 6, 8])
+
+    def test_float_stays_range(self):
+        """Float ranges keep the plain class."""
+        coord = get_coord(start=0.0, stop=10, step=2.5)
+        assert type(coord) is CoordRange
+
+    def test_int_with_float_step_stays_range(self):
+        """An integer start with a float step is a float range, as before."""
+        coord = get_coord(start=0, stop=10, step=2.5)
+        assert type(coord) is CoordRange
+
+    def test_int_uneven_span_stays_float(self):
+        """Span/count that does not divide makes floats, as before."""
+        coord = get_coord(start=0, stop=10, shape=3)
+        assert type(coord) is CoordRange
+        assert np.allclose(coord.values, [0, 10 / 3, 20 / 3])
+        even = get_coord(start=0, stop=12, shape=3)
+        assert isinstance(even, CoordRangeInt)
+        assert np.array_equal(even.values, [0, 4, 8])
+
+    def test_fraction_on_float_raises(self):
+        """A fraction step has no meaning on a float coordinate."""
+        with pytest.raises(CoordError, match="fraction step"):
+            get_coord(start=0.0, step=(1, 3), shape=(3,))
+
+    def test_sub_nanosecond_stays_range(self):
+        """Finer than nanosecond time keeps the legacy class."""
+        start = np.datetime64("2020-01-01T00:00:00.000000000001")
+        step = np.timedelta64(1000, "ps")
+        coord = get_coord(start=start, stop=start + step * 10, step=step)
+        assert type(coord) is CoordRange
+
+    def test_coarse_units_kept(self):
+        """A microsecond coordinate stays microseconds and works past 2262."""
+        start = np.datetime64("2500-01-01T00:00:00", "us")
+        coord = get_coord(start=start, step=np.timedelta64(2, "us"), shape=(5,))
+        assert isinstance(coord, CoordRangeInt)
+        assert coord.dtype == np.dtype("datetime64[us]")
+        assert coord.values[-1] == start + np.timedelta64(8, "us")
+        assert coord.step_exact == Fraction(2, 10**6)
+
+    def test_coarse_start_fine_step_resolves_finer(self):
+        """A scalar step resolves the unit as start + step does."""
+        coord = get_coord(start=np.datetime64("2020-01-01"), step=ONE_S, shape=(3,))
+        assert coord.dtype == np.dtype("datetime64[s]")
+
+    def test_fraction_step_with_coarse_start_uses_nanoseconds(self):
+        """A fraction step is in seconds, so nanoseconds hold it."""
+        day = np.datetime64("2020-01-01")
+        coord = get_coord(start=day, step=(1, 1024), shape=(4,))
+        assert coord.dtype == np.dtype("datetime64[ns]")
+        assert coord.step_exact == Fraction(1, 1024)
+
+    def test_legacy_construction_untouched(self):
+        """CoordRange built directly still accepts time and has no grid."""
+        coord = CoordRange(start=T0, step=ONE_S, shape=(10,))
+        assert type(coord) is CoordRange
+        assert coord.step_exact == 1
+
+    def test_data_path(self):
+        """Evenly spaced integer and time arrays become exact grids."""
+        coord = get_coord(data=np.arange(10) * 3)
+        assert isinstance(coord, CoordRangeInt)
+        time = get_coord(data=T0 + np.arange(5) * ONE_S)
+        assert isinstance(time, CoordRangeInt)
+
+    def test_single_with_step(self):
+        """A one-sample array with a step is an exact grid."""
+        coord = get_coord(data=[5], step=2)
+        assert isinstance(coord, CoordRangeInt)
+        assert len(coord) == 1 and coord.stop == 7
+
+    def test_partial_fallbacks(self):
+        """Under-specified inputs are partial coordinates, as before."""
+        assert isinstance(get_coord(start=10, shape=10), CoordPartial)
+        assert isinstance(get_coord(shape=10, step=1), CoordPartial)
+
+
+class TestConstruction:
+    """The validator resolves start, stop, step, and shape combinations."""
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            dict(start=0, stop=10, step=2),
+            dict(start=0, step=2, shape=(5,)),
+            dict(stop=10, step=2, shape=(5,)),
+            dict(start=0, stop=10, shape=(5,)),
+        ],
+    )
+    def test_three_of_four(self, kwargs):
+        """Any three of start, stop, step, and shape define the range."""
+        coord = get_coord(**kwargs)
+        assert np.array_equal(coord.values, [0, 2, 4, 6, 8])
+        assert coord.stop == 10
+
+    def test_stop_and_shape_fraction(self):
+        """Start is the floor of the ideal origin count steps before stop."""
+        coord = get_coord(stop=10, step=(3, 2), shape=(4,))
+        # ideal origin = 10 - 4 * 1.5 = 4
+        assert coord.start == 4 and coord.origin_offset == 0
+        assert np.array_equal(coord.values, [4, 5, 7, 8])
+        coord = get_coord(stop=11, step=(3, 2), shape=(4,))
+        # ideal origin 5; labels 5, 6.5->6, 8, 9.5->9
+        assert np.array_equal(coord.values, [5, 6, 8, 9])
+
+    def test_fraction_and_tuple_agree(self):
+        """A Fraction and a tuple state the same step."""
+        a = get_coord(start=T0, step=(1, 1024), shape=(100,))
+        b = get_coord(start=T0, step=Fraction(1, 1024), shape=(100,))
+        assert a == b
+
+    def test_step_rounds_ties_to_even(self, hz_1024):
+        """976562.5 ns rounds to 976562 ns, matching the old np.round."""
+        assert hz_1024.step == np.timedelta64(976562, "ns")
+        odd = get_coord(start=0, step=(5, 2), shape=(3,))  # 2.5 -> 2
+        assert odd.step == 2
+        assert np.array_equal(odd.values, [0, 2, 5])
+
+    def test_below_one_tick_raises(self):
+        """A step below one tick would repeat labels."""
+        with pytest.raises(ValidationError, match="smaller than one tick"):
+            get_coord(start=0, step=(1, 3), shape=(3,))
+        with pytest.raises(ValidationError, match="smaller than one tick"):
+            get_coord(start=0, stop=10, step=(1, 3))
+
+    def test_bad_sign_raises(self):
+        """The step sign must match the span."""
+        with pytest.raises(ValidationError, match="Sign of step"):
+            get_coord(start=0, stop=10, step=-1)
+
+    def test_zero_count_is_partial(self):
+        """A zero-length shape is a partial coordinate."""
+        coord = get_coord(start=0, step=1, shape=(0,))
+        assert isinstance(coord, CoordPartial)
+
+    @pytest.mark.parametrize("ms", [10_020, 10_060, 9_990])
+    def test_stop_rounding_parity(self, ms):
+        """A stop stated a hair off a sample counts as CoordRange always has."""
+        legacy = CoordRange(start=0.0, stop=ms / 1000, step=1.0)
+        exact = get_coord(start=T0, stop=T0 + np.timedelta64(ms, "ms"), step=ONE_S)
+        assert len(exact) == len(legacy)
+
+    def test_start_equals_stop(self):
+        """Equal start and stop give one sample, as before."""
+        coord = get_coord(start=5, stop=5, step=1)
+        assert len(coord) == 1
+
+    def test_zero_step(self):
+        """A zero step is a single repeated label."""
+        coord = get_coord(start=5, stop=5, step=0)
+        assert np.array_equal(coord.values, [5])
+        assert np.array_equal(coord.select((4, 6))[0].values, [5])
+        assert isinstance(coord.select((6, 7))[0], CoordPartial)
+
+    def test_overflow_raises(self):
+        """A grid past the int64 range is refused at construction."""
+        with pytest.raises(ValidationError, match="int64"):
+            get_coord(start=2**62, step=2**40, shape=(2**30,))
+
+    def test_grid_normalized_jointly(self):
+        """(6, 2, 1) must not reduce to (3, 1, 0): that moves the origin."""
+        coord = get_coord(start=0, step=(3, 2), shape=(20,))[1::2]
+        assert (coord.step_numerator, coord.step_denominator) == (6, 2)
+        assert coord.origin_offset == 1
+        assert np.array_equal(coord.values, [1, 4, 7, 10, 13, 16, 19, 22, 25, 28])
+        strided = get_coord(start=0, step=(3, 2), shape=(20,))[::2]
+        assert (strided.step_numerator, strided.step_denominator) == (3, 1)
+        odd_origin = get_coord(start=0, step=(3, 2), shape=(20,))[1:]
+        assert (odd_origin.step_numerator, odd_origin.step_denominator) == (3, 2)
+        assert odd_origin.origin_offset == 1
+        assert (odd_origin[::2].step_numerator, odd_origin[::2].step_denominator) == (
+            6,
+            2,
+        )
+        assert odd_origin[::2].origin_offset == 1
+
+
+class TestLabels:
+    """Labels come from the ideal grid, quantized once."""
+
+    def test_matches_floor_definition(self, hz_1024):
+        """Labels are start + floor((offset + i * num) / den)."""
+        labels = hz_1024.values.astype(np.int64)
+        expected = _floor_labels(int(T0.astype(np.int64)), 1953125, 2, 0, len(hz_1024))
+        assert np.array_equal(labels, expected)
+
+    def test_no_drift_over_an_hour(self, hz_1024):
+        """A rounded 976562 ns step drifts 1.8 ms an hour; the grid does not."""
+        assert hz_1024.max() == T0 + np.timedelta64(3600 * 10**9 - 976563, "ns")
+        assert hz_1024.stop == T0 + np.timedelta64(1, "h")
+
+    def test_3000_hz(self, hz_3000):
+        """A third of a microsecond is held exactly."""
+        assert hz_3000.step_exact == Fraction(1, 3000)
+        assert hz_3000.stop == T0 + np.timedelta64(10, "s")
+        assert hz_3000[-1] == T0 + np.timedelta64(10 * 10**9 - 333_334, "ns")
+
+    def test_negative_origin(self, int_frac):
+        """Floor quantization holds below zero."""
+        expected = _floor_labels(-7, 3, 2, 0, 50)
+        assert np.array_equal(int_frac.values, expected)
+        assert int_frac.min() == -7
+
+    def test_getitem_int(self, hz_3000):
+        """Integer indexing evaluates one label."""
+        assert hz_3000[5] == hz_3000.values[5]
+        assert hz_3000[-1] == hz_3000.values[-1]
+        with pytest.raises(IndexError):
+            _ = hz_3000[len(hz_3000)]
+
+    def test_min_max_descending(self):
+        """Min and max are the end labels whichever way the grid runs."""
+        coord = get_coord(start=10, stop=0, step=-3)
+        assert (coord.min(), coord.max()) == (1, 10)
+        assert coord.reverse_sorted and not coord.sorted
+
+    def test_index_values_negative(self, hz_1024):
+        """Negative indices count from the end."""
+        vals = hz_1024._get_index_values(np.array([-1, 0]))
+        assert vals[0] == hz_1024.max() and vals[1] == hz_1024.min()
+
+
+class TestSlicing:
+    """Slices reproduce the materialized original exactly."""
+
+    @pytest.mark.parametrize(
+        "sl",
+        [
+            slice(None),
+            slice(1, None),
+            slice(3, 1000, 7),
+            slice(None, None, -1),
+            slice(-5, None),
+            slice(999, 3, -5),
+            slice(2, 2000, 3),
+        ],
+    )
+    def test_slice_equals_values(self, hz_1024, hz_3000, int_frac, sl):
+        """Slicing the coordinate equals slicing its values."""
+        for coord in (hz_1024, hz_3000, int_frac):
+            sub = coord[sl]
+            expected = coord.values[sl]
+            if len(expected) == 0:
+                assert isinstance(sub, CoordPartial)
+                continue
+            assert isinstance(sub, CoordRangeInt)
+            assert np.array_equal(sub.values, expected)
+            assert sub.dtype == coord.dtype
+
+    def test_nested(self, hz_1024):
+        """Nested slices and reversals reproduce the values exactly."""
+        a = hz_1024[100:3000][7:2000:3]
+        assert np.array_equal(a.values, hz_1024.values[100:3000][7:2000:3])
+        b = hz_1024[::-1][::2]
+        assert np.array_equal(b.values, hz_1024.values[::-1][::2])
+        assert b.step_exact == Fraction(-1, 512)
+
+    def test_ideal_positions_survive(self, hz_1024):
+        """The origin offset of a slice is compared, not only its labels."""
+        sub = hz_1024[1:]
+        assert sub.origin_offset == 1 and sub.step_denominator == 2
+        assert sub._ideal_origin == hz_1024._ideal_origin + Fraction(1953125, 2)
+
+    def test_random_nested_slices_against_oracle(self):
+        """Random grids and nested slices agree with fraction arithmetic."""
+        rng = np.random.default_rng(0)
+        for _ in range(200):
+            num = int(rng.integers(-40, 40)) or 7
+            den = int(rng.integers(1, 12))
+            if abs(num) < den:
+                num = den * int(np.sign(num) or 1)
+            offset = int(rng.integers(0, den))
+            count = int(rng.integers(1, 60))
+            start = int(rng.integers(-1000, 1000))
+            coord = CoordRangeInt(
+                start=start,
+                shape=(count,),
+                step_numerator=num,
+                step_denominator=den,
+                origin_offset=offset,
+            )
+            values = _floor_labels(start, num, den, offset, count)
+            assert np.array_equal(coord.values, values)
+            for _ in range(3):
+                a, b = sorted(rng.integers(-count - 2, count + 2, size=2))
+                s = int(rng.integers(-4, 5)) or 1
+                sl = slice(int(a), int(b), s)
+                expected = values[sl]
+                sub = coord[sl]
+                if len(expected) == 0:
+                    assert len(sub) == 0
+                    break
+                assert np.array_equal(sub.values, expected)
+                coord, values = sub, expected
+
+    def test_slice_is_metadata_only(self):
+        """A billion-sample grid slices without evaluating its labels."""
+        coord = get_coord(start=T0, step=(1, 1024), shape=(10**9,))
+        sub = coord[10**8 : 9 * 10**8 : 1000]
+        assert len(sub) == 800_000
+        assert sub.min() == coord[10**8]
+        rev = coord[::-1]
+        assert rev.max() == coord.max()
+        assert coord.max() == T0 + np.timedelta64((10**9 - 1) * 1953125 // 2, "ns")
+
+    def test_empty_slice_is_partial(self, hz_1024):
+        """An empty slice is a typed partial coordinate."""
+        out = hz_1024[5:5]
+        assert isinstance(out, CoordPartial)
+        assert out.dtype == hz_1024.dtype
+
+    def test_array_getitem(self, int_frac):
+        """Indexing with an array selects those labels."""
+        out = int_frac[np.array([1, 3, 9])]
+        assert np.array_equal(out.values, int_frac.values[[1, 3, 9]])
+
+    def test_sort(self, hz_1024):
+        """Sorting reverses the grid and back."""
+        rev, sl = hz_1024.sort(reverse=True)
+        assert sl == slice(None, None, -1)
+        assert np.array_equal(rev.values, hz_1024.values[::-1])
+        back, _ = rev.sort()
+        assert back == hz_1024
+
+    def test_change_length(self, hz_1024):
+        """Changing the length keeps the grid and offset."""
+        longer = hz_1024.change_length(len(hz_1024) + 10)
+        assert np.array_equal(longer.values[: len(hz_1024)], hz_1024.values)
+        assert hz_1024[1:].change_length(5).origin_offset == 1
+
+
+class TestSelect:
+    """Value selection is exact on the grid."""
+
+    def test_time_window(self, hz_1024):
+        """A window between two on-grid times selects exactly those samples."""
+        one, two = T0 + ONE_S, T0 + 2 * ONE_S
+        sub, sl = hz_1024.select((one, two))
+        assert sl == slice(1024, 2049)
+        assert sub.min() == one and sub.max() == two
+
+    def test_between_samples(self, hz_1024):
+        """Bounds between samples exclude the samples they fall past."""
+        lo = hz_1024[10] + np.timedelta64(1, "ns")
+        hi = hz_1024[20] - np.timedelta64(1, "ns")
+        sub, sl = hz_1024.select((lo, hi))
+        assert sl == slice(11, 20)
+        assert np.array_equal(sub.values, hz_1024.values[11:20])
+
+    def test_float_bounds_on_int_grid(self, int_frac):
+        """Float bounds on an integer grid round toward the selection."""
+        sub, _ = int_frac.select((0.5, 10.5))
+        values = int_frac.values
+        assert np.array_equal(sub.values, values[(values >= 0.5) & (values <= 10.5)])
+
+    def test_infinite_bounds(self, int_frac):
+        """Infinite bounds open one side."""
+        sub, _ = int_frac.select((3.0, np.inf))
+        assert sub.min() >= 3 and sub.max() == int_frac.max()
+        sub, _ = int_frac.select((-np.inf, 3))
+        assert sub.min() == int_frac.min() and sub.max() <= 3
+
+    def test_descending(self):
+        """Selection on a descending grid."""
+        coord = get_coord(start=10, stop=0, step=-3)  # 10 7 4 1
+        sub, sl = coord.select((2, 8))
+        assert np.array_equal(sub.values, [7, 4])
+        assert sl == slice(1, 3)
+
+    def test_descending_fraction(self):
+        """Selection on a descending fractional grid."""
+        coord = get_coord(start=T0, step=(1, 1024), shape=(2048,))[::-1]
+        lo, hi = coord[1500], coord[100]
+        sub, sl = coord.select((lo, hi))
+        assert sl == slice(100, 1501)
+        assert sub.max() == hi and sub.min() == lo
+
+    def test_degenerate(self, int_frac):
+        """A window past the coordinate is degenerate."""
+        sub, sl = int_frac.select((1000, 2000))
+        assert sl == slice(0, 0)
+        assert isinstance(sub, CoordPartial)
+
+    def test_open_ended(self, hz_1024):
+        """None and Ellipsis open a side."""
+        _, sl = hz_1024.select((None, hz_1024[10]))
+        assert sl == slice(None, 11)
+        _, sl = hz_1024.select((hz_1024[10], ...))
+        assert sl == slice(10, None)
+
+    def test_relative(self, hz_1024):
+        """Relative bounds are durations from the ends."""
+        _, sl = hz_1024.select((1, 2), relative=True)
+        assert sl == slice(1024, 2049)
+
+    def test_samples(self, hz_1024):
+        """Sample bounds are positions."""
+        sub, _ = hz_1024.select((10, 20), samples=True)
+        assert np.array_equal(sub.values, hz_1024.values[10:20])
+
+    def test_array_bounds(self, int_frac):
+        """The array path of _get_index agrees with the scalar path."""
+        probes = np.array([-100, -7, -6, 0, 1, 2, 60, 100])
+        for forward in (True, False):
+            arr = int_frac._get_index(probes, forward=forward)
+            for probe, got in zip(probes, arr):
+                scalar = int_frac._index_of(int(probe), forward)
+                assert got == scalar
+
+    def test_get_next_index(self, hz_1024):
+        """The next index past a value between samples."""
+        idx = hz_1024.get_next_index(hz_1024[100] + np.timedelta64(1, "ns"))
+        assert idx == 101
+
+
+class TestUpdateLimits:
+    """update_limits translates or re-grids, and keeps the exact grid."""
+
+    def test_min_translates(self, hz_1024):
+        """A new min translates the grid."""
+        out = hz_1024.update_limits(min=T0 + ONE_S)
+        assert out.min() == T0 + ONE_S
+        assert out.step_exact == hz_1024.step_exact
+        assert len(out) == len(hz_1024)
+
+    def test_max_translates(self, hz_1024):
+        """A new max translates the grid."""
+        out = hz_1024.update_limits(max=T0)
+        assert out.max() == T0
+        assert np.array_equal(
+            out.values - out.values[0], hz_1024.values - hz_1024.values[0]
+        )
+
+    def test_descending_min_max(self):
+        """Limits on a descending grid are inclusive and keep the direction."""
+        coord = get_coord(start=10, stop=0, step=-1)
+        assert coord.update_limits(max=20).values.tolist() == list(range(20, 10, -1))
+        assert coord.update_limits(min=100).values.tolist() == list(range(109, 99, -1))
+
+    def test_step_scalar(self, hz_1024):
+        """A scalar step re-grids from the same start."""
+        out = hz_1024.update_limits(step=np.timedelta64(2, "ms"))
+        assert out.step_exact == Fraction(1, 500)
+        assert out.min() == hz_1024.min() and len(out) == len(hz_1024)
+
+    def test_step_fraction(self, hz_1024):
+        """A fraction step re-grids from the same start."""
+        out = hz_1024.update_limits(step=(1, 512))
+        assert out.step_exact == Fraction(1, 512)
+
+    def test_step_and_min(self, hz_1024):
+        """A step and a min apply in turn."""
+        out = hz_1024.update_limits(step=(1, 512), min=T0 + ONE_S)
+        assert out.step_exact == Fraction(1, 512) and out.min() == T0 + ONE_S
+
+    def test_both_limits_exact(self):
+        """Both limits keep the count; the spacing becomes exact."""
+        coord = get_coord(start=T0, step=ONE_S, shape=(10,))
+        out = coord.update_limits(min=T0, max=T0 + np.timedelta64(65, "s"))
+        assert len(out) == 10
+        assert out.stop == T0 + np.timedelta64(65, "s")
+        assert out.step_exact == Fraction(65, 10)
+
+    def test_both_limits_below_tick_makes_floats(self):
+        """Both limits closer than a tick per sample make floats, as before."""
+        coord = get_coord(start=0, stop=10, step=1)
+        out = coord.update_limits(min=2, max=8)
+        assert type(out) is CoordRange and len(out) == 10
+
+    def test_too_many(self, hz_1024):
+        """All three parameters is an error."""
+        with pytest.raises(ValueError, match="At most two"):
+            hz_1024.update_limits(min=T0, max=T0, step=ONE_S)
+
+    def test_update_via_coordmanager(self, hz_1024):
+        """The patch-level update keeps the exact grid."""
+        patch = dc.get_example_patch().update_coords(time=hz_1024.change_length(2000))
+        out = patch.update_coords(time_min=T0 + ONE_S)
+        assert out.get_coord("time").step_exact == Fraction(1, 1024)
+        assert out.get_coord("time").min() == T0 + ONE_S
+
+
+class TestNewAndRoundTrips:
+    """Dumps, summaries, pickles, and `new` keep the grid."""
+
+    def test_model_dump_round_trip(self, hz_1024):
+        """A dumped coordinate rebuilds itself through get_coord."""
+        sub = hz_1024[1:]
+        assert get_coord(**sub.model_dump()) == sub
+
+    def test_new_translation_keeps_offset(self, hz_1024):
+        """New with a shifted start and stop keeps the grid."""
+        sub = hz_1024[1:]
+        out = sub.new(start=sub.start + ONE_S, stop=sub.stop + ONE_S)
+        assert out.origin_offset == 1 and out.step_exact == sub.step_exact
+        assert len(out) == len(sub)
+
+    def test_new_stop_changes_count(self, hz_1024):
+        """New with a stop re-derives the count."""
+        out = hz_1024.new(stop=hz_1024[100])
+        assert len(out) == 100
+
+    def test_new_step_replaces_grid(self, hz_1024):
+        """New with a step drops the old grid."""
+        out = hz_1024[1:].new(step=ONE_S)
+        assert out.step_denominator == 1 and out.origin_offset == 0
+        assert out.step == ONE_S
+
+    def test_new_units(self, int_frac):
+        """New with units keeps the grid."""
+        out = int_frac.new(units="ft")
+        assert out.units == dc.get_quantity("ft") and out.step_exact == Fraction(3, 2)
+
+    def test_summary(self, hz_1024):
+        """The summary carries the grid and rebuilds the coordinate."""
+        summary = hz_1024[1:].to_summary(dims=("time",))
+        assert summary.is_exact_grid
+        assert summary.step_numerator == 1953125
+        assert summary.step_denominator == 2
+        assert summary.origin_offset == 1
+        assert summary.to_coord() == hz_1024[1:]
+
+    def test_summary_descending(self, hz_1024):
+        """A descending grid survives the summary."""
+        rev = hz_1024[::-1]
+        assert rev.to_summary().to_coord() == rev
+
+    def test_summary_without_grid_rebuilds_exact_class(self):
+        """A legacy summary rebuilds onto the exact class."""
+        summary = CoordSummary(min=T0, max=T0 + 9 * ONE_S, step=ONE_S, len=10)
+        coord = summary.to_coord()
+        assert isinstance(coord, CoordRangeInt) and len(coord) == 10
+
+    def test_pickle(self, hz_1024):
+        """Pickling keeps the grid."""
+        out = pickle.loads(pickle.dumps(hz_1024[3:]))
+        assert out == hz_1024[3:]
+
+    def test_patch_round_trip_through_coords(self, hz_1024):
+        """A patch holding a fractional grid selects on it exactly."""
+        patch = dc.get_example_patch().update_coords(time=hz_1024[:2000])
+        assert patch.get_coord("time").step_exact == Fraction(1, 1024)
+        sub = patch.select(time=(T0 + ONE_S, None))
+        assert sub.get_coord("time").min() == T0 + ONE_S
+        assert np.array_equal(
+            sub.get_coord("time").values, patch.get_coord("time").values[1024:]
+        )
+
+
+class TestIdentity:
+    """Equality and fingerprints compare the grid, never the class."""
+
+    def test_legacy_fingerprint_parity(self):
+        """A whole-tick grid fingerprints as the legacy class does."""
+        legacy = CoordRange(start=T0, step=ONE_S, shape=(10,))
+        exact = get_coord(start=T0, step=ONE_S, shape=(10,))
+        assert legacy.fingerprint() == exact.fingerprint()
+        legacy = CoordRange(start=0, stop=10, step=2, units="m")
+        exact = get_coord(start=0, stop=10, step=2, units="m")
+        assert legacy.fingerprint() == exact.fingerprint()
+
+    def test_fraction_grid_changes_fingerprint(self, hz_1024):
+        """A fractional grid is a different identity from its rounding."""
+        rounded = get_coord(start=T0, step=hz_1024.step, shape=(len(hz_1024),))
+        assert rounded.fingerprint() != hz_1024.fingerprint()
+        assert hz_1024[1:].fingerprint() != hz_1024[:-1].fingerprint()
+
+    def test_fingerprint_stable(self, hz_1024):
+        """The fingerprint survives a no-op slice and a summary round trip."""
+        assert hz_1024.fingerprint() == hz_1024[:].fingerprint()
+        assert hz_1024.fingerprint() == hz_1024.to_summary().to_coord().fingerprint()
+
+    def test_equality_is_field_equality(self):
+        """== stays pydantic field equality."""
+        legacy = CoordRange(start=0, stop=10, step=2)
+        exact = get_coord(start=0, stop=10, step=2)
+        assert exact == get_coord(data=np.arange(0, 10, 2))
+        assert legacy != exact  # different classes, as pydantic sees it
+
+
+class TestUnits:
+    """Unit conversion of integer grids."""
+
+    def test_time_units_fixed(self, hz_1024):
+        """Time coordinates do not convert units."""
+        assert hz_1024.convert_units("s") is hz_1024
+        assert hz_1024.units == dc.get_quantity("s")
+
+    def test_whole_tick_converts_to_floats(self):
+        """A whole-tick integer grid converts to floats, as before."""
+        coord = get_coord(start=0, stop=10, step=2, units="m")
+        out = coord.convert_units("km")
+        assert type(out) is CoordRange
+        assert np.allclose(out.values, coord.values / 1000)
+
+    def test_fraction_grid_refuses(self, int_frac):
+        """A fractional integer grid refuses conversion but accepts set_units."""
+        with pytest.raises(CoordError, match="fractional step"):
+            int_frac.convert_units("km")
+        assert int_frac.set_units("ft").units == dc.get_quantity("ft")
+
+    def test_fraction_grid_fingerprints(self, int_frac):
+        """A fractional grid fingerprints without converting units."""
+        assert int_frac.fingerprint() == int_frac.set_units("m").fingerprint()
+
+
+class TestRepr:
+    """The class split does not leak into text."""
+
+    def test_header_is_coord_range(self, hz_1024):
+        """The repr header reads CoordRange and states the exact step."""
+        text = str(hz_1024)
+        assert text.startswith("CoordRange(")
+        assert "CoordRangeInt" not in text
+        assert "1/1024 s" in text and "1024 Hz" in text
+
+    def test_whole_tick_repr_unchanged(self):
+        """A whole-tick grid prints as the legacy class does."""
+        legacy = CoordRange(start=T0, step=ONE_S, shape=(10,))
+        exact = get_coord(start=T0, step=ONE_S, shape=(10,))
+        assert str(legacy) == str(exact)
+
+    def test_int_fraction_repr(self, int_frac):
+        """An integer fraction step is stated with its units."""
+        assert "3/2 m" in str(int_frac)
+
+    def test_coord_manager_repr(self, hz_1024):
+        """The coordinate manager states the range kind, not the class."""
+        patch = dc.get_example_patch().update_coords(time=hz_1024[:2000])
+        assert "CoordRangeInt" not in str(patch.coords)
+
+
+class TestStepExact:
+    """step_exact on every coordinate kind."""
+
+    def test_legacy_range(self):
+        """Timedelta and integer steps are exact; float steps are not."""
+        assert CoordRange(start=T0, step=ONE_S, shape=(3,)).step_exact == 1
+        assert CoordRange(start=0, stop=10, step=2).step_exact == 2
+        assert CoordRange(start=0.0, stop=1.0, step=0.1).step_exact is None
+
+    def test_partial_and_array(self):
+        """Coordinates without a step have no exact step."""
+        assert get_coord(shape=(3,)).step_exact is None
+        assert get_coord(data=[1.0, 2.5, 3.0]).step_exact is None
+
+    def test_time_units_are_seconds(self, hz_1024):
+        """step_exact of a time coordinate is in seconds."""
+        assert hz_1024.step_exact == Fraction(1, 1024)
+        start = np.datetime64("2020-01-01", "ms")
+        ms = get_coord(start=start, step=np.timedelta64(4, "ms"), shape=(3,))
+        assert ms.step_exact == Fraction(4, 1000)
+
+
+class TestSegments:
+    """Exact grids inside segmented coordinates."""
+
+    def test_adjacent_fraction_runs_fuse(self, hz_1024):
+        """Adjacent runs of one grid fuse back into it."""
+        a, b = hz_1024[:1000], hz_1024[1000:2000]
+        out = concat_coords(a, b)
+        assert isinstance(out, CoordRangeInt)
+        assert out == hz_1024[:2000]
+
+    def test_off_grid_neighbours_do_not_fuse(self, hz_1024):
+        """A run a tick off the grid stays a separate segment."""
+        a = hz_1024[:1000]
+        b = hz_1024[1000:2000].update_limits(min=a.stop + np.timedelta64(1, "ns"))
+        out = concat_coords(a, b)
+        assert isinstance(out, CoordSegmented)
+
+    def test_same_labels_different_origin_do_not_fuse(self):
+        """Labels can align while the ideal origins do not."""
+        a = get_coord(start=0, step=(3, 2), shape=(4,))  # 0 1 3 4, stop 6
+        b = get_coord(start=6, step=(3, 2), shape=(4,))[:]
+        fused = concat_coords(a, b)
+        assert isinstance(fused, CoordRangeInt)
+        shifted = CoordRangeInt(
+            start=6, shape=(4,), step_numerator=3, step_denominator=2, origin_offset=1
+        )
+        out = concat_coords(a, shifted)
+        assert isinstance(out, CoordSegmented)
+
+    def test_segment_dump_round_trip(self, hz_1024):
+        """Segments rebuild onto the exact class."""
+        seg = concat_coords(hz_1024[:10], hz_1024[20:30])
+        assert isinstance(seg, CoordSegmented)
+        rebuilt = get_coord(**seg.model_dump())
+        assert rebuilt == seg
+        assert all(isinstance(s, CoordRangeInt) for s in rebuilt.segments)
+
+
+class TestPersistenceGuards:
+    """Formats that cannot hold the grid say so instead of rounding it."""
+
+    def test_dasdae_v1_refuses_fraction(self, hz_1024, tmp_path):
+        """DASDAE format 1 refuses a fractional step rather than rounding it."""
+        patch = dc.get_example_patch().update_coords(time=hz_1024[:2000])
+        with pytest.raises(NotImplementedError, match="fractional step"):
+            patch.io.write(tmp_path / "frac.h5", "dasdae")
+
+    def test_dasdae_v1_writes_whole_ticks(self, tmp_path):
+        """Whole-tick grids round-trip through DASDAE."""
+        patch = dc.get_example_patch()
+        assert isinstance(patch.get_coord("time"), CoordRangeInt)
+        path = tmp_path / "whole.h5"
+        patch.io.write(path, "dasdae")
+        assert dc.spool(path)[0].get_coord("time") == patch.get_coord("time")
+
+    def test_xarray_lazy_index_skipped(self, hz_1024):
+        """A fractional grid travels to xarray as values, not a rounded index."""
+        pytest.importorskip("xarray")
+        from dascore.xarray.patch import patch_to_xarray  # noqa: PLC0415
+
+        patch = dc.get_example_patch().update_coords(time=hz_1024[:2000])
+        array = patch_to_xarray(patch, lazy_coords={"time"})
+        assert type(array.xindexes["time"]).__name__ != "TemporalRangeIndex"
+        assert np.array_equal(array["time"].values, patch.get_coord("time").values)
+
+
+class TestValidationErrors:
+    """Every refusal of the exact class states why."""
+
+    def test_summary_needs_length(self, hz_1024):
+        """An exact summary without a length cannot rebuild."""
+        summary = hz_1024.to_summary().model_copy(update=dict(len=None))
+        with pytest.raises(CoordError, match="length"):
+            summary.to_coord()
+
+    def test_value_off_grid(self):
+        """A value finer than the tick does not sit on the grid."""
+        start = np.datetime64("2020-01-01T00:00:00.000001", "us")
+        coord = get_coord(start=start, step=np.timedelta64(1, "us"), shape=(4,))
+        with pytest.raises(CoordError, match="does not sit"):
+            coord._new_grid(start + np.timedelta64(1, "ns"), coord.step, 4)
+
+    def test_non_time_value_on_time_grid(self):
+        """A value that is not a time at all is refused."""
+        with pytest.raises(ValidationError, match="not a"):
+            CoordRangeInt(start=T0, stop="tomorrow", step=(1, 2))
+
+    def test_non_integer_float(self):
+        """A non-integer float cannot be a tick of an integer grid."""
+        with pytest.raises(ValidationError, match="non-integer"):
+            CoordRangeInt(start=0, stop=10, step=2.5)
+
+    def test_month_unit(self):
+        """A month is not a fixed number of seconds; a fraction step uses ns."""
+        start = np.datetime64("2020-01", "M")
+        from dascore.core.coords import _range_class  # noqa: PLC0415
+
+        assert _range_class(start, None, np.timedelta64(1, "M"), (3,)) is CoordRange
+        exact = get_coord(start=start, step=(1, 2), shape=(3,))
+        assert exact.dtype == np.dtype("datetime64[ns]")
+
+    def test_direct_construction_errors(self):
+        """The class itself refuses what get_coord would turn into a partial."""
+        with pytest.raises(ValidationError, match="requires start or stop"):
+            CoordRangeInt(step=1, shape=(3,))
+        with pytest.raises(ValidationError, match="1D"):
+            CoordRangeInt(start=0, step=1, shape=(2, 3))
+        with pytest.raises(ValidationError, match="at least one sample"):
+            CoordRangeInt(start=0, step=1, shape=(0,))
+        with pytest.raises(ValidationError, match="Three of"):
+            CoordRangeInt(start=0, shape=(3,))
+        with pytest.raises(ValidationError, match=r"Three of|are needed"):
+            CoordRangeInt(start=0, step=1)
+        with pytest.raises(ValidationError, match="positive"):
+            CoordRangeInt(start=0, shape=(3,), step_numerator=1, step_denominator=-2)
+        with pytest.raises(ValidationError, match="origin_offset"):
+            CoordRangeInt(
+                start=0,
+                shape=(3,),
+                step_numerator=3,
+                step_denominator=2,
+                origin_offset=2,
+            )
+        with pytest.raises(ValidationError, match="fixed tick"):
+            month = np.datetime64("2020-01", "M")
+            CoordRangeInt(start=month, step=np.timedelta64(1, "M"), shape=(3,))
+
+    def test_update_limits_step_below_tick(self, int_frac):
+        """A new step below one tick is refused."""
+        with pytest.raises(CoordError, match="smaller than one tick"):
+            int_frac.update_limits(step=(1, 3))
+
+    def test_new_grid_helper(self, int_frac):
+        """The parent's grid constructor builds a whole-tick grid."""
+        out = int_frac._new_grid(4, 2, 5)
+        assert np.array_equal(out.values, [4, 6, 8, 10, 12])
+
+    def test_descending_array_index(self):
+        """The vectorized index of a descending whole-tick grid."""
+        coord = get_coord(start=10, stop=0, step=-3)  # 10 7 4 1
+        probes = np.array([11, 10, 8, 7, 1, 0])
+        for forward in (True, False):
+            got = coord._get_index(probes, forward=forward)
+            expected = [coord._index_of(int(p), forward) for p in probes]
+            assert got.tolist() == expected
+
+    def test_integral_float_is_a_tick(self):
+        """A float that is a whole number sits on an integer grid."""
+        coord = CoordRangeInt(start=0, stop=10.0, step=2)
+        assert np.array_equal(coord.values, [0, 2, 4, 6, 8])
+
+    def test_time_units_do_not_convert(self, hz_1024):
+        """Time coordinates hand themselves back from unit conversion."""
+        assert hz_1024._convert_units("ms") is hz_1024
+
+    def test_float_range_failure_is_still_partial(self):
+        """A float range that cannot validate stays a partial, as before."""
+        out = get_coord(start=0.0, stop=10.0, step=-1.0, shape=(10,))
+        assert isinstance(out, CoordPartial)
+
+
+class TestUnitHelpers:
+    """Time unit parsing behind the exact grid."""
+
+    def test_generic_unit_has_no_tick(self):
+        """A generic time dtype states no unit and so no tick."""
+        from dascore.core.coords import _seconds_per_tick, _time_unit  # noqa: PLC0415
+
+        assert _time_unit(np.dtype("datetime64")) == ("generic", 1)
+        assert _seconds_per_tick(np.dtype("datetime64")) is None
+        assert _seconds_per_tick(np.dtype("datetime64[10us]")) == Fraction(1, 10**5)
+
+    def test_mixed_kinds_stay_legacy(self):
+        """A time start with a non-time stop is left to the legacy validator."""
+        from dascore.core.coords import _range_class  # noqa: PLC0415
+
+        assert _range_class(T0, "tomorrow", ONE_S, None) is CoordRange
+
+
+class TestLegacyCoordRange:
+    """CoordRange built directly keeps its time and integer behaviour."""
+
+    @pytest.fixture(scope="class")
+    def legacy_time(self):
+        """A time CoordRange built without get_coord."""
+        return CoordRange(start=T0, stop=T0 + 10 * ONE_S, step=ONE_S)
+
+    @pytest.fixture(scope="class")
+    def legacy_int(self):
+        """An integer CoordRange built without get_coord."""
+        return CoordRange(start=0, stop=10, step=1)
+
+    def test_one_element_arrays_unbox(self):
+        """One-element arrays are accepted as scalars."""
+        coord = CoordRange(start=np.array([0]), stop=np.array([10]), step=np.array([2]))
+        assert len(coord) == 5
+
+    def test_needs_three_values(self):
+        """Fewer than three of start, stop, step, shape is an error."""
+        with pytest.raises(ValidationError, match="Three of"):
+            CoordRange(start=0, step=1)
+
+    def test_getitem(self, legacy_time, legacy_int):
+        """Integer and slice indexing on legacy ranges."""
+        assert legacy_time[3] == T0 + 3 * ONE_S
+        assert np.array_equal(legacy_time[2:5].values, legacy_time.values[2:5])
+        assert np.array_equal(legacy_int[::3].values, [0, 3, 6, 9])
+        with pytest.raises(IndexError):
+            _ = legacy_time[10]
+
+    def test_index_values(self, legacy_time, legacy_int):
+        """Requested samples evaluate on the same grid as values."""
+        assert np.array_equal(
+            legacy_time._get_index_values([0, 9]), legacy_time.values[[0, 9]]
+        )
+        assert np.array_equal(legacy_int._get_index_values([0, 9]), [0, 9])
+
+    def test_time_units_fixed(self, legacy_time):
+        """Time coordinates do not convert units."""
+        assert legacy_time._convert_units("ms") is legacy_time
+
+    def test_zero_d_array_bound(self, legacy_int):
+        """A 0-d array bound is unboxed."""
+        assert legacy_int._get_index(np.array(4)) == 4
+
+    def test_update_limits(self, legacy_time, legacy_int):
+        """Translation, both limits, and the three-argument error."""
+        assert legacy_int.update_limits(max=20).values.tolist() == list(range(11, 21))
+        both = legacy_int.update_limits(min=2, max=8)
+        assert len(both) == 10 and both.stop == 8
+        assert legacy_time.update_limits(max=T0).max() == T0
+        with pytest.raises(ValueError, match="At most two"):
+            legacy_time.update_limits(min=T0, max=T0, step=ONE_S)
+
+    def test_out_of_bounds_index(self):
+        """Positions past the ends of a float range use the rounded step."""
+        coord = CoordRange(start=0.0, stop=10.0, step=1.0)
+        assert coord.get_next_index(12.0, allow_out_of_bounds=True) == 12
+
+    def test_tile_offsets(self, legacy_time):
+        """Tile offsets on a legacy time range step from the first sample."""
+        from dascore.proc.tile_apply import _offset_values  # noqa: PLC0415
+
+        out = _offset_values(legacy_time, np.array([0, 2]))
+        assert np.array_equal(out, legacy_time.values[[0, 2]])
+
+    def test_select_and_sort(self, legacy_time):
+        """Selection and sorting work as they always have."""
+        sub, sl = legacy_time.select((T0 + ONE_S, T0 + 3 * ONE_S))
+        assert sl == slice(1, 4) and len(sub) == 3
+        rev, _ = legacy_time.sort(reverse=True)
+        assert rev.values[0] == legacy_time.max()
+
+
+class TestReviewFindings:
+    """Consumers that rebuilt from the rounded step now stay on the grid."""
+
+    def test_summary_keeps_coarse_tick_unit(self):
+        """A microsecond grid summarised in nanoseconds rebuilds its labels."""
+        start = np.datetime64("2020-01-01", "us")
+        coord = get_coord(start=start, step=np.timedelta64(2, "us"), shape=(5,))
+        rebuilt = coord.to_summary().to_coord()
+        assert np.array_equal(rebuilt.values, coord.values)
+        assert rebuilt.step_exact == coord.step_exact
+
+    def test_pad_extends_the_grid(self, hz_1024):
+        """Padding a fractional grid keeps every existing label."""
+        patch = dc.get_example_patch().update_coords(time=hz_1024[:2000])
+        out = patch.pad(time=(3, 1), expand_coords=True)
+        time = out.get_coord("time")
+        assert time.step_exact == Fraction(1, 1024)
+        assert time.min() == T0 - 3 * ONE_S
+        assert np.array_equal(time.values[3072:5072], hz_1024[:2000].values)
+
+    def test_halfway_count_parity(self):
+        """A span of 1.05 steps rounds as a float did: to two samples."""
+        assert len(get_coord(start=0, stop=21, step=20)) == 2
+        assert len(get_coord(start=0.0, stop=21.0, step=20.0)) == 2
+
+    def test_step_update_redispatches(self):
+        """A step the grid cannot hold hands over to the class that can."""
+        floats = get_coord(start=0, stop=10, step=1).update_limits(step=0.5)
+        assert type(floats) is CoordRange and floats.step == 0.5
+        moved = get_coord(start=0, stop=10, step=1).update_limits(step=0.5, min=1)
+        assert type(moved) is CoordRange and moved.min() == 1 and moved.step == 0.5
+        start = np.datetime64("2020-01-01", "ms")
+        ms = get_coord(start=start, step=np.timedelta64(1, "ms"), shape=(4,))
+        finer = ms.update_limits(step=np.timedelta64(500, "us"))
+        assert finer.step_exact == Fraction(1, 2000) and len(finer) == 4
+        assert finer.min() == ms.min()
+
+    def test_sample_count_uses_exact_step(self, hz_1024):
+        """A second at 1024 Hz is 1024 samples, not 1025."""
+        assert hz_1024.get_sample_count(1) == 1024
+        assert hz_1024.get_sample_count(dc.to_timedelta64(0.5)) == 512
+        assert hz_1024.get_sample_count(np.timedelta64(1, "ns")) == 1
+        assert get_coord(start=0, stop=10, step=1).get_sample_count(0.1) == 1
+
+    def test_out_of_bounds_index_uses_grid(self):
+        """Positions past the ends come from the grid, not the rounded step."""
+        coord = get_coord(start=0, step=(3, 2), shape=(5,))  # 0 1 3 4 6
+        assert coord.get_next_index(9, allow_out_of_bounds=True) == 6
+        assert coord.get_next_index(-3, allow_out_of_bounds=True) == -2
+
+    def test_tile_offsets_on_grid(self, hz_1024):
+        """Tile coordinates evaluate offsets on the exact grid."""
+        from dascore.proc.tile_apply import _offset_values  # noqa: PLC0415
+
+        out = _offset_values(hz_1024, np.array([0, 1024, 1025]))
+        assert out[1] == T0 + ONE_S
+        assert np.array_equal(out, hz_1024.values[[0, 1024, 1025]])

--- a/tests/test_core/test_coord_range_int.py
+++ b/tests/test_core/test_coord_range_int.py
@@ -1,4 +1,4 @@
-"""Tests for exact integer-grid range coordinates (CoordRangeInt)."""
+"""Tests for the exact integer grids of range coordinates."""
 
 from __future__ import annotations
 
@@ -13,7 +13,6 @@ import dascore as dc
 from dascore.core.coords import (
     CoordPartial,
     CoordRange,
-    CoordRangeInt,
     CoordSegmented,
     CoordSummary,
     concat_coords,
@@ -55,40 +54,40 @@ class TestDispatch:
     def test_time_scalar_step(self):
         """A timedelta step on a datetime start makes a whole-tick exact grid."""
         coord = get_coord(start=T0, step=ONE_S, shape=(10,))
-        assert isinstance(coord, CoordRangeInt)
+        assert coord._exact
         assert coord.step_denominator == 1
         assert coord.step == ONE_S
 
     def test_timedelta(self):
         """A timedelta coordinate is an exact grid in its own unit."""
         coord = get_coord(start=np.timedelta64(0, "ns"), step=ONE_S, shape=(3,))
-        assert isinstance(coord, CoordRangeInt)
+        assert coord._exact
         assert coord.dtype == np.dtype("timedelta64[ns]")
         assert coord.step_exact == 1
 
     def test_int(self):
         """Integer ranges are exact grids."""
         coord = get_coord(start=0, stop=10, step=2)
-        assert isinstance(coord, CoordRangeInt)
+        assert coord._exact
         assert np.array_equal(coord.values, [0, 2, 4, 6, 8])
 
     def test_float_stays_range(self):
         """Float ranges keep the plain class."""
         coord = get_coord(start=0.0, stop=10, step=2.5)
-        assert type(coord) is CoordRange
+        assert not coord._exact
 
     def test_int_with_float_step_stays_range(self):
         """An integer start with a float step is a float range, as before."""
         coord = get_coord(start=0, stop=10, step=2.5)
-        assert type(coord) is CoordRange
+        assert not coord._exact
 
     def test_int_uneven_span_stays_float(self):
         """Span/count that does not divide makes floats, as before."""
         coord = get_coord(start=0, stop=10, shape=3)
-        assert type(coord) is CoordRange
+        assert not coord._exact
         assert np.allclose(coord.values, [0, 10 / 3, 20 / 3])
         even = get_coord(start=0, stop=12, shape=3)
-        assert isinstance(even, CoordRangeInt)
+        assert even._exact
         assert np.array_equal(even.values, [0, 4, 8])
 
     def test_fraction_on_float_raises(self):
@@ -101,25 +100,25 @@ class TestDispatch:
         start = np.datetime64("2020-01-01T00:00:00.000000000001")
         step = np.timedelta64(1000, "ps")
         coord = get_coord(start=start, stop=start + step * 10, step=step)
-        assert type(coord) is CoordRange
+        assert not coord._exact
 
     def test_coarse_units_stay_legacy(self):
         """Only nanosecond time is exact; coarser units keep the legacy class."""
         start = np.datetime64("2500-01-01T00:00:00", "us")
         coord = get_coord(start=start, step=np.timedelta64(2, "us"), shape=(5,))
-        assert type(coord) is CoordRange
+        assert not coord._exact
         assert coord.dtype == np.dtype("datetime64[us]")
         assert coord.values[-1] == start + np.timedelta64(8, "us")
         assert coord.step_exact == Fraction(2, 10**6)
         day = get_coord(start=np.datetime64("2020-01-01"), step=ONE_S, shape=(3,))
-        assert type(day) is CoordRange and day.dtype == np.dtype("datetime64[s]")
+        assert not day._exact and day.dtype == np.dtype("datetime64[s]")
 
     def test_nanosecond_step_resolves_exact(self):
         """A nanosecond step makes a coarse start resolve to nanoseconds."""
         coord = get_coord(
             start=np.datetime64("2020-01-01"), step=np.timedelta64(1, "ns"), shape=(3,)
         )
-        assert isinstance(coord, CoordRangeInt)
+        assert coord._exact
         assert coord.dtype == np.dtype("datetime64[ns]")
 
     def test_fraction_step_with_coarse_start_uses_nanoseconds(self):
@@ -129,23 +128,23 @@ class TestDispatch:
         assert coord.dtype == np.dtype("datetime64[ns]")
         assert coord.step_exact == Fraction(1, 1024)
 
-    def test_legacy_construction_untouched(self):
-        """CoordRange built directly still accepts time and has no grid."""
+    def test_direct_construction_is_exact_too(self):
+        """CoordRange built directly resolves the same grid as get_coord."""
         coord = CoordRange(start=T0, step=ONE_S, shape=(10,))
-        assert type(coord) is CoordRange
-        assert coord.step_exact == 1
+        assert coord._exact
+        assert coord == get_coord(start=T0, step=ONE_S, shape=(10,))
 
     def test_data_path(self):
         """Evenly spaced integer and time arrays become exact grids."""
         coord = get_coord(data=np.arange(10) * 3)
-        assert isinstance(coord, CoordRangeInt)
+        assert coord._exact
         time = get_coord(data=T0 + np.arange(5) * ONE_S)
-        assert isinstance(time, CoordRangeInt)
+        assert time._exact
 
     def test_single_with_step(self):
         """A one-sample array with a step is an exact grid."""
         coord = get_coord(data=[5], step=2)
-        assert isinstance(coord, CoordRangeInt)
+        assert coord._exact
         assert len(coord) == 1 and coord.stop == 7
 
     def test_partial_fallbacks(self):
@@ -326,7 +325,7 @@ class TestSlicing:
             if len(expected) == 0:
                 assert isinstance(sub, CoordPartial)
                 continue
-            assert isinstance(sub, CoordRangeInt)
+            assert sub._exact
             assert np.array_equal(sub.values, expected)
             assert sub.dtype == coord.dtype
 
@@ -355,7 +354,7 @@ class TestSlicing:
             offset = int(rng.integers(0, den))
             count = int(rng.integers(1, 60))
             start = int(rng.integers(-1000, 1000))
-            coord = CoordRangeInt(
+            coord = CoordRange(
                 start=start,
                 shape=(count,),
                 step_numerator=num,
@@ -548,7 +547,7 @@ class TestUpdateLimits:
         """Both limits closer than a tick per sample make floats, as before."""
         coord = get_coord(start=0, stop=10, step=1)
         out = coord.update_limits(min=2, max=8)
-        assert type(out) is CoordRange and len(out) == 10
+        assert not out._exact and len(out) == 10
 
     def test_too_many(self, hz_1024):
         """All three parameters is an error."""
@@ -612,7 +611,7 @@ class TestNewAndRoundTrips:
         """A legacy summary rebuilds onto the exact class."""
         summary = CoordSummary(min=T0, max=T0 + 9 * ONE_S, step=ONE_S, len=10)
         coord = summary.to_coord()
-        assert isinstance(coord, CoordRangeInt) and len(coord) == 10
+        assert coord._exact and len(coord) == 10
 
     def test_pickle(self, hz_1024):
         """Pickling keeps the grid."""
@@ -654,11 +653,11 @@ class TestIdentity:
         assert hz_1024.fingerprint() == hz_1024.to_summary().to_coord().fingerprint()
 
     def test_equality_is_field_equality(self):
-        """== stays pydantic field equality."""
-        legacy = CoordRange(start=0, stop=10, step=2)
+        """== stays pydantic field equality; the grid fields are fields."""
         exact = get_coord(start=0, stop=10, step=2)
         assert exact == get_coord(data=np.arange(0, 10, 2))
-        assert legacy != exact  # different classes, as pydantic sees it
+        assert exact == CoordRange(start=0, stop=10, step=2)
+        assert exact != get_coord(start=0, step=(3, 2), shape=(5,))
 
 
 class TestUnits:
@@ -673,7 +672,7 @@ class TestUnits:
         """A whole-tick integer grid converts to floats, as before."""
         coord = get_coord(start=0, stop=10, step=2, units="m")
         out = coord.convert_units("km")
-        assert type(out) is CoordRange
+        assert not out._exact
         assert np.allclose(out.values, coord.values / 1000)
 
     def test_fraction_grid_refuses(self, int_frac):
@@ -694,7 +693,6 @@ class TestRepr:
         """The repr header reads CoordRange and states the exact step."""
         text = str(hz_1024)
         assert text.startswith("CoordRange(")
-        assert "CoordRangeInt" not in text
         assert "1/1024 s" in text and "1024 Hz" in text
 
     def test_whole_tick_repr_unchanged(self):
@@ -708,9 +706,9 @@ class TestRepr:
         assert "3/2 m" in str(int_frac)
 
     def test_coord_manager_repr(self, hz_1024):
-        """The coordinate manager states the range kind, not the class."""
+        """The coordinate manager states the exact step too."""
         patch = dc.get_example_patch().update_coords(time=hz_1024[:2000])
-        assert "CoordRangeInt" not in str(patch.coords)
+        assert "1/1024 s" in str(patch.coords)
 
 
 class TestStepExact:
@@ -741,7 +739,7 @@ class TestSegments:
         """Adjacent runs of one grid fuse back into it."""
         a, b = hz_1024[:1000], hz_1024[1000:2000]
         out = concat_coords(a, b)
-        assert isinstance(out, CoordRangeInt)
+        assert out._exact
         assert out == hz_1024[:2000]
 
     def test_off_grid_neighbours_do_not_fuse(self, hz_1024):
@@ -756,8 +754,8 @@ class TestSegments:
         a = get_coord(start=0, step=(3, 2), shape=(4,))  # 0 1 3 4, stop 6
         b = get_coord(start=6, step=(3, 2), shape=(4,))[:]
         fused = concat_coords(a, b)
-        assert isinstance(fused, CoordRangeInt)
-        shifted = CoordRangeInt(
+        assert fused._exact
+        shifted = CoordRange(
             start=6, shape=(4,), step_numerator=3, step_denominator=2, origin_offset=1
         )
         out = concat_coords(a, shifted)
@@ -769,7 +767,7 @@ class TestSegments:
         assert isinstance(seg, CoordSegmented)
         rebuilt = get_coord(**seg.model_dump())
         assert rebuilt == seg
-        assert all(isinstance(s, CoordRangeInt) for s in rebuilt.segments)
+        assert all(s._exact for s in rebuilt.segments)
 
 
 class TestPersistenceGuards:
@@ -784,7 +782,7 @@ class TestPersistenceGuards:
     def test_dasdae_v1_writes_whole_ticks(self, tmp_path):
         """Whole-tick grids round-trip through DASDAE."""
         patch = dc.get_example_patch()
-        assert isinstance(patch.get_coord("time"), CoordRangeInt)
+        assert patch.get_coord("time")._exact
         path = tmp_path / "whole.h5"
         patch.io.write(path, "dasdae")
         assert dc.spool(path)[0].get_coord("time") == patch.get_coord("time")
@@ -812,46 +810,46 @@ class TestValidationErrors:
     def test_non_time_value_on_time_grid(self):
         """A value that is not a time at all is refused."""
         with pytest.raises(ValidationError, match="not an integer or time"):
-            CoordRangeInt(start=T0, stop="tomorrow", step=(1, 2))
+            CoordRange(start=T0, stop="tomorrow", step=(1, 2))
 
     def test_non_integer_float(self):
         """A non-integer float cannot be a tick of an integer grid."""
-        with pytest.raises(ValidationError, match="non-integer"):
-            CoordRangeInt(start=0, stop=10, step=2.5)
+        with pytest.raises(CoordError, match="non-integer"):
+            get_coord(start=0, stop=10, step=(5, 2))._new_grid(0.5, 1, 3)
 
     def test_month_unit(self):
-        """A month step stays legacy; a fraction step resolves to nanoseconds."""
+        """A month step is not exact; a fraction step resolves to nanoseconds."""
         start = np.datetime64("2020-01", "M")
-        from dascore.core.coords import _range_class  # noqa: PLC0415
+        from dascore.core.coords import _exact_dtype  # noqa: PLC0415
 
-        assert _range_class(start, None, np.timedelta64(1, "M"), (3,)) is CoordRange
+        assert _exact_dtype(start, None, np.timedelta64(1, "M"), (3,)) is None
         exact = get_coord(start=start, step=(1, 2), shape=(3,))
         assert exact.dtype == np.dtype("datetime64[ns]")
 
     def test_direct_construction_errors(self):
         """The class itself refuses what get_coord would turn into a partial."""
-        with pytest.raises(ValidationError, match="requires start or stop"):
-            CoordRangeInt(step=1, shape=(3,))
-        with pytest.raises(ValidationError, match="1D"):
-            CoordRangeInt(start=0, step=1, shape=(2, 3))
-        with pytest.raises(ValidationError, match="at least one sample"):
-            CoordRangeInt(start=0, step=1, shape=(0,))
         with pytest.raises(ValidationError, match="Three of"):
-            CoordRangeInt(start=0, shape=(3,))
-        with pytest.raises(ValidationError, match=r"Three of|are needed"):
-            CoordRangeInt(start=0, step=1)
+            CoordRange(step=1, shape=(3,))
+        with pytest.raises(ValidationError, match="1D"):
+            CoordRange(start=0, step=1, shape=(2, 3))
+        with pytest.raises(ValidationError, match="at least one sample"):
+            CoordRange(start=0, step=1, shape=(0,))
+        with pytest.raises(ValidationError, match="Three of"):
+            CoordRange(start=0, shape=(3,))
+        with pytest.raises(ValidationError, match="are needed"):
+            CoordRange(start=0, step=1)
         with pytest.raises(ValidationError, match="positive"):
-            CoordRangeInt(start=0, shape=(3,), step_numerator=1, step_denominator=-2)
+            CoordRange(start=0, shape=(3,), step_numerator=1, step_denominator=-2)
         with pytest.raises(ValidationError, match="origin_offset"):
-            CoordRangeInt(
+            CoordRange(
                 start=0,
                 shape=(3,),
                 step_numerator=3,
                 step_denominator=2,
                 origin_offset=2,
             )
-        with pytest.raises(ValidationError, match="needs nanoseconds"):
-            CoordRangeInt(start=np.datetime64("2020-01-01"), step=ONE_S, shape=(3,))
+        coarse = CoordRange(start=np.datetime64("2020-01-01"), step=ONE_S, shape=(3,))
+        assert not coarse._exact
 
     def test_update_limits_step_below_tick(self, int_frac):
         """A new step below one tick is refused."""
@@ -874,7 +872,7 @@ class TestValidationErrors:
 
     def test_integral_float_is_a_tick(self):
         """A float that is a whole number sits on an integer grid."""
-        coord = CoordRangeInt(start=0, stop=10.0, step=2)
+        coord = CoordRange(start=0, stop=10.0, step=2)
         assert np.array_equal(coord.values, [0, 2, 4, 6, 8])
 
     def test_time_units_do_not_convert(self, hz_1024):
@@ -890,86 +888,119 @@ class TestValidationErrors:
 class TestUnitHelpers:
     """Dispatch details behind the exact grid."""
 
-    def test_mixed_kinds_stay_legacy(self):
-        """A time start with a non-time stop is left to the legacy validator."""
-        from dascore.core.coords import _range_class  # noqa: PLC0415
+    def test_mixed_kinds_are_not_exact(self):
+        """A time start with a non-time stop is left to the float validator."""
+        from dascore.core.coords import _exact_dtype  # noqa: PLC0415
 
-        assert _range_class(T0, "tomorrow", ONE_S, None) is CoordRange
+        assert _exact_dtype(T0, "tomorrow", ONE_S, None) is None
 
 
-class TestLegacyCoordRange:
-    """CoordRange built directly keeps its time and integer behaviour."""
-
-    @pytest.fixture(scope="class")
-    def legacy_time(self):
-        """A time CoordRange built without get_coord."""
-        return CoordRange(start=T0, stop=T0 + 10 * ONE_S, step=ONE_S)
+class TestFloatRepresentation:
+    """Ranges without an exact grid: floats and time in coarser units."""
 
     @pytest.fixture(scope="class")
-    def legacy_int(self):
-        """An integer CoordRange built without get_coord."""
-        return CoordRange(start=0, stop=10, step=1)
+    def coarse_time(self):
+        """A one-second time range held as a float-style range."""
+        start = np.datetime64("2020-01-01T00:00:00", "s")
+        coord = CoordRange(
+            start=start,
+            stop=start + np.timedelta64(10, "s"),
+            step=np.timedelta64(1, "s"),
+        )
+        assert not coord._exact
+        return coord
+
+    @pytest.fixture(scope="class")
+    def floats(self):
+        """A float range."""
+        return CoordRange(start=0.0, stop=10.0, step=1.0)
 
     def test_one_element_arrays_unbox(self):
         """One-element arrays are accepted as scalars."""
-        coord = CoordRange(start=np.array([0]), stop=np.array([10]), step=np.array([2]))
+        coord = CoordRange(
+            start=np.array([0.0]), stop=np.array([10.0]), step=np.array([2.0])
+        )
         assert len(coord) == 5
 
     def test_needs_three_values(self):
         """Fewer than three of start, stop, step, shape is an error."""
         with pytest.raises(ValidationError, match="Three of"):
-            CoordRange(start=0, step=1)
+            CoordRange(start=0.0, step=1.0)
+        with pytest.raises(ValidationError, match="1D"):
+            CoordRange(start=0.0, step=1.0, shape=(2, 3))
+        from_stop = CoordRange(stop=10.0, step=1.0, shape=(10,))
+        assert from_stop.start == 0.0
 
-    def test_getitem(self, legacy_time, legacy_int):
-        """Integer and slice indexing on legacy ranges."""
-        assert legacy_time[3] == T0 + 3 * ONE_S
-        assert np.array_equal(legacy_time[2:5].values, legacy_time.values[2:5])
-        assert np.array_equal(legacy_int[::3].values, [0, 3, 6, 9])
+    def test_zero_step(self):
+        """A zero float step is a single repeated label."""
+        coord = CoordRange(start=5.0, stop=5.0, step=0.0)
+        assert np.array_equal(coord.select((4.0, 6.0))[0].values, [5.0])
+
+    def test_float_limit_on_integer_grid(self):
+        """An integer grid accepts a whole-number float limit."""
+        coord = get_coord(start=0, stop=10, step=1)
+        assert coord.update_limits(min=2.0).min() == 2
+
+    def test_getitem(self, coarse_time, floats):
+        """Integer and slice indexing."""
+        assert coarse_time[3] == coarse_time.start + np.timedelta64(3, "s")
+        assert np.array_equal(coarse_time[2:5].values, coarse_time.values[2:5])
+        assert np.array_equal(floats[::3].values, [0.0, 3.0, 6.0, 9.0])
         with pytest.raises(IndexError):
-            _ = legacy_time[10]
+            _ = coarse_time[10]
 
-    def test_index_values(self, legacy_time, legacy_int):
+    def test_index_values(self, coarse_time, floats):
         """Requested samples evaluate on the same grid as values."""
         assert np.array_equal(
-            legacy_time._get_index_values([0, 9]), legacy_time.values[[0, 9]]
+            coarse_time._get_index_values([0, 9]), coarse_time.values[[0, 9]]
         )
-        assert np.array_equal(legacy_int._get_index_values([0, 9]), [0, 9])
+        assert np.array_equal(floats._get_index_values([0, 9]), [0.0, 9.0])
 
-    def test_time_units_fixed(self, legacy_time):
+    def test_time_units_fixed(self, coarse_time):
         """Time coordinates do not convert units."""
-        assert legacy_time._convert_units("ms") is legacy_time
+        assert coarse_time._convert_units("ms") is coarse_time
 
-    def test_zero_d_array_bound(self, legacy_int):
+    def test_zero_d_array_bound(self, floats):
         """A 0-d array bound is unboxed."""
-        assert legacy_int._get_index(np.array(4)) == 4
+        assert floats._get_index(np.array(4.0)) == 4
 
-    def test_update_limits(self, legacy_time, legacy_int):
+    def test_update_limits(self, coarse_time, floats):
         """Translation, both limits, and the three-argument error."""
-        assert legacy_int.update_limits(max=20).values.tolist() == list(range(11, 21))
-        both = legacy_int.update_limits(min=2, max=8)
-        assert len(both) == 10 and both.stop == 8
-        assert legacy_time.update_limits(max=T0).max() == T0
+        assert floats.update_limits(max=20.0).values.tolist() == list(range(11, 21))
+        both = floats.update_limits(min=2.0, max=8.0)
+        assert len(both) == 10 and both.stop == 8.0
+        assert (
+            coarse_time.update_limits(max=coarse_time.start).max() == coarse_time.start
+        )
         with pytest.raises(ValueError, match="At most two"):
-            legacy_time.update_limits(min=T0, max=T0, step=ONE_S)
+            floats.update_limits(min=0.0, max=1.0, step=1.0)
 
-    def test_out_of_bounds_index(self):
-        """Positions past the ends of a float range use the rounded step."""
-        coord = CoordRange(start=0.0, stop=10.0, step=1.0)
-        assert coord.get_next_index(12.0, allow_out_of_bounds=True) == 12
+    def test_out_of_bounds_index(self, floats):
+        """Positions past the ends of a float range use the step."""
+        assert floats.get_next_index(12.0, allow_out_of_bounds=True) == 12
 
-    def test_tile_offsets(self, legacy_time):
-        """Tile offsets on a legacy time range step from the first sample."""
+    def test_tile_offsets(self, coarse_time):
+        """Tile offsets on a coarse time range step from the first sample."""
         from dascore.proc.tile_apply import _offset_values  # noqa: PLC0415
 
-        out = _offset_values(legacy_time, np.array([0, 2]))
-        assert np.array_equal(out, legacy_time.values[[0, 2]])
+        out = _offset_values(coarse_time, np.array([0, 2]))
+        assert np.array_equal(out, coarse_time.values[[0, 2]])
 
-    def test_select_and_sort(self, legacy_time):
+    def test_select_and_sort(self, coarse_time):
         """Selection and sorting work as they always have."""
-        sub, sl = legacy_time.select((T0 + ONE_S, T0 + 3 * ONE_S))
+        one = np.timedelta64(1, "s")
+        sub, sl = coarse_time.select(
+            (coarse_time.start + one, coarse_time.start + 3 * one)
+        )
         assert sl == slice(1, 4) and len(sub) == 3
-        rev, _ = legacy_time.sort(reverse=True)
-        assert rev.values[0] == legacy_time.max()
+        rev, _ = coarse_time.sort(reverse=True)
+        assert rev.values[0] == coarse_time.max()
+
+    def test_pad_extends(self, floats):
+        """Padding a float range extends it by whole steps."""
+        patch = dc.get_example_patch().update_coords(distance=floats.change_length(300))
+        out = patch.pad(distance=(2, 1), expand_coords=True)
+        assert out.get_coord("distance").min() == -2.0
 
 
 class TestReviewFindings:
@@ -999,15 +1030,15 @@ class TestReviewFindings:
     def test_step_update_redispatches(self):
         """A step the grid cannot hold hands over to the class that can."""
         floats = get_coord(start=0, stop=10, step=1).update_limits(step=0.5)
-        assert type(floats) is CoordRange and floats.step == 0.5
+        assert not floats._exact and floats.step == 0.5
         moved = get_coord(start=0, stop=10, step=1).update_limits(step=0.5, min=1)
-        assert type(moved) is CoordRange and moved.min() == 1 and moved.step == 0.5
+        assert not moved._exact and moved.min() == 1 and moved.step == 0.5
         legacy = get_coord(
             start=np.datetime64("2020-01-01", "ms"),
             step=np.timedelta64(1, "ms"),
             shape=(4,),
         )
-        assert type(legacy) is CoordRange
+        assert not legacy._exact
         exact = get_coord(start=T0, step=np.timedelta64(1, "ms"), shape=(4,))
         finer = exact.update_limits(step=np.timedelta64(500, "us"))
         assert finer.step_exact == Fraction(1, 2000) and len(finer) == 4
@@ -1042,7 +1073,7 @@ class TestSecondReviewRound:
         patch = dc.get_example_patch().update_coords(time=hz_1024[:2000])
         out = patch.decimate(time=3, filter_type=None)
         time = out.get_coord("time")
-        assert isinstance(time, CoordRangeInt)
+        assert time._exact
         assert time.step_exact == Fraction(3, 1024)
         assert np.array_equal(time.values, hz_1024.values[:2000:3])
 

--- a/tests/test_io/test_dasdae/test_dasdae.py
+++ b/tests/test_io/test_dasdae/test_dasdae.py
@@ -14,7 +14,7 @@ import pytest
 import dascore as dc
 from dascore.compat import random_state
 from dascore.config import config_context
-from dascore.core.coords import CoordString
+from dascore.core.coords import CoordRange, CoordString
 from dascore.exceptions import (
     InvalidFiberFileError,
     MissingPatchError,
@@ -882,7 +882,7 @@ class TestDASDAEInternalHelpers:
             coords = _get_coords(group, ("time",), {})
 
         coord = coords.get_coord("time")
-        assert coord.__class__.__name__ == "CoordRange"
+        assert isinstance(coord, CoordRange)
         assert len(coord) == 3
         assert coord.start == 10
         assert coord.step == 10

--- a/tests/test_io/test_io_core.py
+++ b/tests/test_io/test_io_core.py
@@ -7,6 +7,7 @@ import io
 import os
 import shutil
 import threading
+from fractions import Fraction
 from pathlib import Path
 from typing import ClassVar, Literal, TypeVar
 
@@ -57,6 +58,8 @@ from dascore.io.utils import (
     get_exact_coord,
     resolve_keyed_source,
     slice_dataset,
+    step_from_interval,
+    step_from_rate,
     windows_to_slices,
 )
 from dascore.utils.downloader import fetch
@@ -2450,3 +2453,45 @@ class TestResolveKeyedSource:
         """A resource naming one key twice is ambiguous, never the last one."""
         with pytest.raises(PatchAttributeError, match="more than once"):
             resolve_keyed_source([("a", 1), ("a", 2)], "a")
+
+
+class TestStepFromRate:
+    """Readers turn a stated rate or interval into an exact step when they can."""
+
+    def test_exact_rates(self):
+        """Simple rates give exact steps."""
+        assert step_from_rate(1024.0) == Fraction(1, 1024)
+        assert step_from_rate(3000) == Fraction(1, 3000)
+        assert step_from_rate(1000.0) == Fraction(1, 1000)
+
+    def test_inexact_rate_keeps_nanoseconds(self):
+        """An arbitrary rate keeps the rounded nanosecond step."""
+        rate = 1234.56789012345
+        out = step_from_rate(rate)
+        assert isinstance(out, np.timedelta64)
+        assert out == dc.to_timedelta64(1 / rate)
+
+    def test_float32_rate(self):
+        """A float32 rate recovers only what it holds exactly."""
+        assert step_from_rate(np.float32(1024.0)) == Fraction(1, 1024)
+        assert step_from_rate(np.float32(62.5)) == Fraction(2, 125)
+        # A float32 999.9 is 999.9000244; nothing is claimed for it.
+        assert isinstance(step_from_rate(np.float32(999.9)), np.timedelta64)
+        assert step_from_rate(999.9) == Fraction(10, 9999)
+
+    def test_interval(self):
+        """Simple intervals give exact steps."""
+        assert step_from_interval(0.004) == Fraction(1, 250)
+        assert step_from_interval(1 / 3000) == Fraction(1, 3000)
+        assert isinstance(step_from_interval(0.0012345678912345), np.timedelta64)
+
+    def test_nonpositive_falls_back(self):
+        """A non-positive rate is not a grid."""
+        assert isinstance(step_from_rate(-100.0), np.timedelta64)
+
+    def test_coordinate_from_step(self):
+        """The step feeds straight into get_coord."""
+        t0 = np.datetime64("2020-01-01T00:00:00", "ns")
+        coord = get_coord(start=t0, step=step_from_rate(1024.0), shape=(1024,))
+        assert coord.step_exact == Fraction(1, 1024)
+        assert coord.stop == t0 + np.timedelta64(1, "s")

--- a/tests/test_io/test_mseed/test_mseed.py
+++ b/tests/test_io/test_mseed/test_mseed.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from fractions import Fraction
 from typing import Any
 
 import numpy as np
@@ -266,6 +267,45 @@ class TestMiniSeedRead:
         assert patch.shape == (2, 4)
         assert np.all(patch.get_coord("channel").values == np.array([1, 2]))
         assert patch.get_coord("time").min() == time_min
+
+    def test_fractional_rate_is_exact(self, tmp_path):
+        """A 40 Hz trace gets an exact 1/40 s step, not a rounded one."""
+        path = _write_mseed(tmp_path / "forty.mseed", sample_rates=[40.0] * 3)
+        patch = dc.read(path, file_format="MSEED", file_version="3")[0]
+        time = patch.get_coord("time")
+        assert time.step_exact == Fraction(1, 40)
+        assert time.step == np.timedelta64(25_000_000, "ns")
+        path = _write_mseed(tmp_path / "third.mseed", sample_rates=[3000.0] * 3)
+        time = dc.read(path, file_format="MSEED", file_version="3")[0].get_coord("time")
+        assert time.step_exact == Fraction(1, 3000)
+        assert time.stop == time.min() + np.timedelta64(10 * 10**9 // 3000, "ns")
+
+    def test_trim_keeps_grid_and_boundary_sample(self, tmp_path):
+        """Trimming at a whole second keeps that sample and the grid's phase."""
+        pymseed = pytest.importorskip("pymseed")
+        start = pymseed.timestr2nstime("2024-01-01T00:00:00Z")
+        data = [np.arange(3000, dtype=np.int32)] * 3
+        path = _write_mseed(
+            tmp_path / "trim.mseed", sample_rates=[1024.0] * 3, data_samples=data
+        )
+        full = dc.read(path, file_format="MSEED", file_version="3")[0]
+        t0 = np.datetime64(start, "ns")
+        lo, hi = t0 + np.timedelta64(1, "s"), t0 + np.timedelta64(2, "s")
+        trimmed = dc.read(path, file_format="MSEED", file_version="3", time=(lo, hi))[0]
+        time = trimmed.get_coord("time")
+        assert time.min() == lo and time.max() == hi
+        assert time.step_exact == Fraction(1, 1024)
+        # The trim discards the first record, so the grid is anchored on the
+        # writer's rounded start of the second; labels agree to the ns.
+        expected = full.get_coord("time").values[1024:2049]
+        assert np.all(np.abs(time.values - expected) <= np.timedelta64(1, "ns"))
+        odd = dc.read(
+            path,
+            file_format="MSEED",
+            file_version="3",
+            time=(full.get_coord("time")[3], None),
+        )[0].get_coord("time")
+        assert np.array_equal(odd.values, full.get_coord("time").values[3:])
 
     def test_incompatible_sample_rates_are_separate_patches(self, tmp_path):
         """Incompatible traces are returned as separate patches."""

--- a/tests/test_io/test_mseed/test_mseed.py
+++ b/tests/test_io/test_mseed/test_mseed.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from fractions import Fraction
 from typing import Any
 
@@ -306,6 +307,21 @@ class TestMiniSeedRead:
             time=(full.get_coord("time")[3], None),
         )[0].get_coord("time")
         assert np.array_equal(odd.values, full.get_coord("time").values[3:])
+
+    def test_nanosecond_gap_on_whole_grid_is_not_merged(self):
+        """A one-nanosecond offset on a whole-nanosecond grid is a real gap."""
+        assert mseed_utils._continues(1_000_000, 1_000_000, 1000.0)
+        assert not mseed_utils._continues(1_000_000, 1_000_001, 1000.0)
+        assert mseed_utils._continues(985_351_562, 985_351_563, 1024.0)
+        assert not mseed_utils._continues(985_351_562, 985_351_565, 1024.0)
+
+    def test_group_key_includes_phase(self, tmp_path):
+        """Segments trimmed onto different phases are not stacked together."""
+        path = _write_mseed(tmp_path / "phase.mseed", sample_rates=[1024.0] * 3)
+        segments = mseed_utils._read_segments(path, pytest.importorskip("pymseed"))
+        shifted = replace(segments[1], origin_offset=1)
+        keys = {mseed_utils._get_group_key(s) for s in (segments[0], shifted)}
+        assert len(keys) == 2
 
     def test_incompatible_sample_rates_are_separate_patches(self, tmp_path):
         """Incompatible traces are returned as separate patches."""

--- a/tests/test_utils/test_display.py
+++ b/tests/test_utils/test_display.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 import time
+import unicodedata
 from decimal import Decimal
 from fractions import Fraction
 from html import unescape
@@ -915,9 +916,11 @@ class TestRateText:
         What is printed is rounded to the figures it was chosen at.
 
         A day step is 11.57 µHz; the shortest exact form of the float
-        behind it is 11.569999999999999.
+        behind it is 11.569999999999999. The micro prefix is compared after
+        NFKC normalization: pint 0.26 prints the Greek mu, 0.25 the micro sign.
         """
-        assert "11.57 µHz" in str(rate_text(np.timedelta64(1, "D")))
+        text = unicodedata.normalize("NFKC", str(rate_text(np.timedelta64(1, "D"))))
+        assert "11.57 μHz" in text
 
     def test_a_rate_never_reads_in_exponent_notation(self):
         """250 Hz needs two figures, and `g` prints those as 2.5e+02."""

--- a/tests/test_utils/test_time.py
+++ b/tests/test_utils/test_time.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import warnings
 from datetime import date, datetime, timedelta
 from decimal import Decimal
+from fractions import Fraction
 
 import numpy as np
 import pandas as pd
@@ -22,6 +23,7 @@ from dascore.utils.time import (
     is_datetime64,
     is_timedelta64,
     to_datetime64,
+    to_exact_fraction,
     to_float,
     to_int,
     to_timedelta64,
@@ -748,3 +750,59 @@ class TestIsTimeDelta:
         d2 = np.array([1, 2]).astype("timedelta64[ms]").dtype
         assert not is_timedelta64(d1)
         assert is_timedelta64(d2)
+
+
+class TestToExactFraction:
+    """Recovering the simple fraction a float states."""
+
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            (1024.0, Fraction(1024)),
+            (3000, Fraction(3000)),
+            (62.5, Fraction(125, 2)),
+            (1 / 3000, Fraction(1, 3000)),
+            (1 / 1024, Fraction(1, 1024)),
+            (0.004, Fraction(1, 250)),
+            (np.float64(0.0005), Fraction(1, 2000)),
+            (Fraction(7, 3), Fraction(7, 3)),
+            (0.0, Fraction(0)),
+        ],
+    )
+    def test_recovers(self, value, expected):
+        """Simple fractions are recovered from their doubles."""
+        assert to_exact_fraction(value) == expected
+
+    @pytest.mark.parametrize(
+        "value", [0.1234567891234, np.pi, 1e-12, float("nan"), float("inf"), "s", True]
+    )
+    def test_declines(self, value):
+        """Anything else is declined."""
+        assert to_exact_fraction(value) is None
+
+    def test_lower_precision_needs_looser_tolerance(self):
+        """A truncated or float32 value is recovered only when allowed."""
+        assert to_exact_fraction(0.00033333333) is None
+        loose = dict(rel_tol=1e-7, max_term=10_000)
+        assert to_exact_fraction(0.00033333333, **loose) == Fraction(1, 3000)
+        assert to_exact_fraction(np.float32(1 / 3000)) is None
+        assert to_exact_fraction(np.float32(1 / 3000), **loose) == Fraction(1, 3000)
+
+    def test_tolerance_still_declines(self):
+        """A tolerance admits only what lands inside it."""
+        assert to_exact_fraction(np.pi, rel_tol=1e-9, max_term=1000) is None
+        assert to_exact_fraction(np.pi, rel_tol=1e-6, max_term=1000) == Fraction(
+            355, 113
+        )
+
+    def test_max_term(self):
+        """Fractions with terms past the limit are declined."""
+        assert to_exact_fraction(1 / 3000, max_term=1000) is None
+        assert to_exact_fraction(3000.0, max_term=1000) is None
+        assert to_exact_fraction(200_000.0) is None
+
+    def test_strict_defaults_reject_arbitrary_doubles(self):
+        """Arbitrary doubles are not simple fractions."""
+        rng = np.random.default_rng(1)
+        values = 10 ** rng.uniform(-6, 5, size=5000)
+        assert all(to_exact_fraction(v) is None for v in values)


### PR DESCRIPTION
## Description

First PR of the coordinates series (exact grids). Time and integer range coordinates now hold their sampling grid exactly.

`CoordRange` has two representations, chosen by its validator. Nanosecond datetime64/timedelta64 ranges and integer ranges hold an exact integer grid: `step_numerator`, `step_denominator`, and `origin_offset` in ticks, with each label the floor of its ideal position. A step may be given as a `Fraction` or a `(numerator, denominator)` tuple, so a 1024 Hz recording is `step=(1, 1024)` seconds rather than a step rounded to 976562 ns that drifts 1.8 ms per hour. Slicing, striding, reversing, selecting, `update_limits`, decimation, padding, and concatenation all stay on the grid; `coord[a:b:s].values == coord.values[a:b:s]` exactly. `step` keeps reporting the nearest whole-tick spacing for existing consumers, and `step_exact` reports the fraction (in seconds for time). Float ranges, and time in any other unit, keep the scalar step and linear spacing they have today; their grid fields are None.

Every range operation is written once over two primitives, `_labels(indices)` and `_sliced(first, stride, count)`, each with an exact and a float branch. Whole-tick grids fingerprint byte-identically to dev, so existing indexes dedup unchanged.

Supporting pieces:

- `CoordSummary` carries the grid so summaries rebuild the coordinate exactly; `get_coord` accepts the three grid keywords so `get_coord(**coord.model_dump())` round-trips.
- `dascore.utils.time.to_exact_fraction` recovers the simple fraction a stored float states, accepting only a fraction with small terms that rounds to the very same double (the looser tolerance first planned accepts pi as 3126535/995207). `step_from_rate` / `step_from_interval` in `dascore.io.utils` wrap it; the silixa, tdms, sintela, ap_sensing, xml_binary, and mseed readers declare their stated rates exactly, and segy uses its microsecond interval as whole ticks.
- DASDAE format 1 raises on writing a fractional step, and the lazy xarray index is skipped for one, instead of rounding the grid. Both are lifted by the persistence PR (schema 16 / DASDAE v2), which must land before a release ships this.
- Both-limit `update_limits` keeps its semantics but uses an exact spacing; min-only and max-only translate the grid, which also fixes the descending-axis limit bugs for the new class.
- Consumers that rebuilt coordinates from the rounded `step` now stay on the grid: `pad(expand_coords=True)`, `get_sample_count`, out-of-bounds `get_next_index`, tile coordinates, and MiniSEED time trimming (which also gains a one-nanosecond record-contiguity tolerance, since writers round record start times).

Design doc: `.scratch/coordinates.md` (untracked). Part of the work toward #706 and #990.

## Changelog

- added: Time and integer range coordinates hold an exact sampling grid; `get_coord` accepts a `Fraction` or `(numerator, denominator)` step and coordinates expose `step_exact`.
- added: `dascore.utils.time.to_exact_fraction` recovers a simple fraction from a stored float.
- changed: Readers for Silixa, TDMS, Sintela, AP Sensing, XML binary, and MiniSEED files declare their stated sampling rates exactly.
- changed: Writing a coordinate with a fractional step to DASDAE format 1 raises instead of rounding it.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [ ] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Coordinate ranges now preserve exact fractional spacing through slicing, indexing, reversing, conversion, and serialization.
  * File readers more accurately retain sample timing, including fractional-rate grids and sub-nanosecond alignment.
  * Added utilities for deriving precise time steps from sampling rates and intervals.

* **Bug Fixes**
  * Improved coordinate construction across supported file formats.
  * DASDAE exports now validate unsupported fractional grids before writing.
  * Coordinate representations consistently display their concrete type names.

* **Documentation**
  * Added guidance and examples for exact sampling rates and coordinate spacing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->