### PR TITLE
Add spectral descriptors transforms

### DIFF
--- a/dascore/core/patch.py
+++ b/dascore/core/patch.py
@@ -576,6 +576,13 @@ class Patch(NamespaceOwner):
     hilbert = transform.hilbert
     envelope = transform.envelope
     phase_weighted_stack = transform.phase_weighted_stack
+    median_frequency = transform.median_frequency
+    spectral_centroid = transform.spectral_centroid
+    spectral_peak_frequency = transform.spectral_peak_frequency
+    spectral_peak_amplitude = transform.spectral_peak_amplitude
+    spectral_entropy = transform.spectral_entropy
+    spectral_kurtosis = transform.spectral_kurtosis
+    spectral_flatness = transform.spectral_flatness
 
     # --- Method Namespaces
     # Note: these can't be cached_property (from functools) or references

--- a/dascore/transform/__init__.py
+++ b/dascore/transform/__init__.py
@@ -17,3 +17,12 @@ from .taup import tau_p
 from .stalta import stalta
 from .fbe import fbe
 from .kurtosis import kurtosis
+from .spectral_descriptors import (
+    median_frequency,
+    spectral_centroid,
+    spectral_entropy,
+    spectral_flatness,
+    spectral_kurtosis,
+    spectral_peak_frequency,
+    spectral_peak_amplitude,
+)

--- a/dascore/transform/spectral_descriptors.py
+++ b/dascore/transform/spectral_descriptors.py
@@ -1,0 +1,780 @@
+"""Spectral descriptor transforms for DASCore patches."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+import numpy as np
+
+import dascore as dc
+from dascore.constants import PatchType
+from dascore.units import Quantity
+from dascore.utils.patch import patch_function
+
+SpectralFormat = Literal["auto", "fft", "amplitude", "power", "density"]
+NegativeFrequencies = Literal["auto", "drop", "raise", "keep"]
+
+_SPECTRAL_FORMAT_ALIASES = {
+    "auto": "auto",
+    "fft": "fft",
+    "fourier": "fft",
+    "fourier transform": "fft",
+    "as": "amplitude",
+    "amplitude": "amplitude",
+    "amplitude spectrum": "amplitude",
+    "ps": "power",
+    "power": "power",
+    "power spectrum": "power",
+    "psd": "density",
+    "density": "density",
+    "spectral density": "density",
+}
+_DFT_OUTPUT_TO_FORMAT = {
+    "FFT": "fft",
+    "AS": "amplitude",
+    "PS": "power",
+    "PSD": "density",
+}
+
+
+def _get_frequency_dim(patch: PatchType, dim: str | None) -> str:
+    """Return the Fourier frequency dimension to use."""
+    ft_dims = tuple(x for x in patch.dims if x.startswith("ft_"))
+    stft_dim = patch.attrs.get("_stft_frequency_dimension")
+    if dim is None:
+        if stft_dim in patch.dims:
+            return stft_dim
+        if len(ft_dims) == 1:
+            return ft_dims[0]
+        if not ft_dims:
+            msg = (
+                "Spectral descriptors require Fourier-domain input from "
+                "Patch.dft or Patch.stft."
+            )
+            raise ValueError(msg)
+        msg = (
+            "Multiple Fourier dimensions found. Pass dim= with the original "
+            "dimension name, such as 'time', or the Fourier dimension name, "
+            "such as 'ft_time'."
+        )
+        raise ValueError(msg)
+
+    freq_dim = dim if dim.startswith("ft_") else f"ft_{dim}"
+    if freq_dim not in patch.dims:
+        msg = f"Fourier dimension {freq_dim!r} was not found in patch dims."
+        raise ValueError(msg)
+    return freq_dim
+
+
+def _normalize_spectral_format(
+    patch: PatchType,
+    spectral_format: SpectralFormat,
+) -> str:
+    """Determine how patch data should be converted to spectral power."""
+    format_key = str(spectral_format).lower()
+    if format_key not in _SPECTRAL_FORMAT_ALIASES:
+        msg = (
+            f"Unknown spectral_format={spectral_format!r}. Expected one of "
+            "'auto', 'fft', 'amplitude', 'power', or 'density'."
+        )
+        raise ValueError(msg)
+    out = _SPECTRAL_FORMAT_ALIASES[format_key]
+    if out != "auto":
+        return out
+
+    dft_output = patch.attrs.get("_dft_output")
+    if dft_output in _DFT_OUTPUT_TO_FORMAT:
+        return _DFT_OUTPUT_TO_FORMAT[dft_output]
+    if patch.attrs.get("_stft_performed", False):
+        return "fft"
+
+    data_type = patch.attrs.get("data_type")
+    type_key = "" if data_type is None else str(data_type).lower()
+    if type_key in _SPECTRAL_FORMAT_ALIASES:
+        return _SPECTRAL_FORMAT_ALIASES[type_key]
+    if np.iscomplexobj(patch.data):
+        return "fft"
+
+    msg = (
+        "Could not infer spectral data representation from patch metadata. "
+        "Pass spectral_format='amplitude', 'power', or 'density'."
+    )
+    raise ValueError(msg)
+
+
+def _ensure_not_db_scaled(patch: PatchType) -> None:
+    """Raise if the spectrum appears to be log-scaled."""
+    units = str(patch.attrs.get("data_units", ""))
+    if "dB" in units:
+        msg = (
+            "Spectral descriptors require linear spectra. Decibel-scaled DFT "
+            "outputs cannot be converted back to power."
+        )
+        raise ValueError(msg)
+
+
+def _get_power(patch: PatchType, spectral_format: SpectralFormat) -> np.ndarray:
+    """Convert known Fourier representations to spectral power."""
+    fmt = _normalize_spectral_format(patch, spectral_format)
+    data = np.asarray(patch.data)
+    _ensure_not_db_scaled(patch)
+
+    if fmt == "fft":
+        if not np.iscomplexobj(data):
+            msg = (
+                "spectral_format='fft' requires complex Fourier coefficients. "
+                "For real-valued spectra, pass spectral_format='amplitude', "
+                "'power', or 'density'."
+            )
+            raise ValueError(msg)
+        return np.abs(data) ** 2
+
+    if np.iscomplexobj(data):
+        msg = f"spectral_format={fmt!r} requires real-valued spectral data."
+        raise ValueError(msg)
+
+    data = data.astype(float, copy=False)
+    if fmt == "amplitude":
+        if np.any(data < 0):
+            msg = "Amplitude spectra must be non-negative."
+            raise ValueError(msg)
+        return data**2
+    if fmt in {"power", "density"}:
+        if np.any(data < 0):
+            msg = "Power spectra and spectral densities must be non-negative."
+            raise ValueError(msg)
+        return data
+
+    raise AssertionError(f"Unhandled spectral format {fmt!r}.")
+
+
+def _power_has_symmetric_frequencies(
+    freqs: np.ndarray,
+    power: np.ndarray,
+    freq_axis: int,
+) -> bool:
+    """Return True if negative-frequency power mirrors positive power."""
+    neg_inds = np.flatnonzero(freqs < 0)
+    if not len(neg_inds):
+        return True
+    spacing = np.min(np.abs(np.diff(freqs))) if len(freqs) > 1 else 0
+    atol = max(float(spacing) * 1e-6, np.finfo(float).eps)
+
+    for neg_ind in neg_inds:
+        pos_inds = np.flatnonzero(np.isclose(freqs, -freqs[neg_ind], atol=atol))
+        if not len(pos_inds):
+            continue
+        neg_power = np.take(power, neg_ind, axis=freq_axis)
+        pos_power = np.take(power, pos_inds[0], axis=freq_axis)
+        if not np.allclose(neg_power, pos_power):
+            return False
+    return True
+
+
+def _get_spectral_power(
+    patch: PatchType,
+    dim: str | None = None,
+    fmin: float | None = None,
+    fmax: float | None = None,
+    spectral_format: SpectralFormat = "auto",
+    negative_frequencies: NegativeFrequencies = "auto",
+) -> tuple[np.ndarray, np.ndarray, str]:
+    """
+    Return frequency coordinates and spectral power from DFT or STFT input.
+
+    The returned power is always linear, non-negative, and trimmed according
+    to ``negative_frequencies``, ``fmin``, and ``fmax``.
+    """
+    if negative_frequencies not in {"auto", "drop", "raise", "keep"}:
+        msg = (
+            "negative_frequencies must be one of 'auto', 'drop', 'raise', " "or 'keep'."
+        )
+        raise ValueError(msg)
+
+    freq_dim = _get_frequency_dim(patch, dim)
+    freq_axis = patch.dims.index(freq_dim)
+    freqs = np.asarray(patch.get_array(freq_dim), dtype=float)
+    power = _get_power(patch, spectral_format)
+
+    mask = np.ones(freqs.shape, dtype=bool)
+    has_negative = np.any(freqs < 0)
+    if negative_frequencies == "raise" and has_negative:
+        msg = (
+            "Fourier coordinate contains negative frequencies. Use "
+            "negative_frequencies='auto', 'drop', or 'keep' to choose how to "
+            "handle them."
+        )
+        raise ValueError(msg)
+    if negative_frequencies == "auto" and has_negative:
+        if not _power_has_symmetric_frequencies(freqs, power, freq_axis):
+            msg = (
+                "Fourier coordinate contains negative frequencies with "
+                "non-symmetric power. Pass negative_frequencies='drop' to use "
+                "only non-negative bins, or 'keep' to include all bins."
+            )
+            raise ValueError(msg)
+        mask &= freqs >= 0
+    if negative_frequencies == "drop":
+        mask &= freqs >= 0
+    if fmin is not None:
+        mask &= freqs >= fmin
+    if fmax is not None:
+        mask &= freqs <= fmax
+
+    if not np.any(mask):
+        raise ValueError("Frequency limits exclude all Fourier frequency bins.")
+
+    freqs = freqs[mask]
+    power = np.take(power, np.flatnonzero(mask), axis=freq_axis)
+
+    return freqs, power, freq_dim
+
+
+def _prepare_output(
+    patch: PatchType,
+    data: np.ndarray,
+    freq_dim: str,
+    data_type: str,
+    data_units: str | Quantity | None,
+) -> PatchType:
+    """Return a patch with the frequency dimension removed."""
+    dims = tuple(dim for dim in patch.dims if dim != freq_dim)
+    coords = {dim: patch.get_array(dim) for dim in dims}
+    attrs = {"data_type": data_type, "data_units": data_units}
+    return dc.Patch(data=data, dims=dims, coords=coords, attrs=attrs)
+
+
+def _broadcast_freqs(
+    freqs: np.ndarray,
+    ndim: int,
+    freq_axis: int,
+) -> np.ndarray:
+    """Broadcast frequency vector against an STFT power array."""
+    shape = [1] * ndim
+    shape[freq_axis] = freqs.size
+    return freqs.reshape(shape)
+
+
+@patch_function()
+def spectral_centroid(
+    patch: PatchType,
+    dim: str | None = None,
+    fmin: float | None = None,
+    fmax: float | None = None,
+    spectral_format: SpectralFormat = "auto",
+    negative_frequencies: NegativeFrequencies = "auto",
+) -> PatchType:
+    """
+    Compute the spectral centroid of a Fourier-domain patch.
+
+    This represents the center of gravity of the signal's power spectrum, and
+    is sometimes called the mean frequency. The input patch must already be
+    transformed with [Patch.dft](`dascore.Patch.dft`) or
+    [Patch.stft](`dascore.Patch.stft`). STFT inputs produce rolling descriptors;
+    DFT inputs produce descriptors over the remaining non-frequency dimensions.
+
+    See for more detail:
+        - @Phinyomark12
+        - [Online version of the Phinyomark publication](
+            https://www.intechopen.com/chapters/40123)
+        - [Matlab's meanfreq](https://se.mathworks.com/help/signal/ref/meanfreq.html)
+
+    Parameters
+    ----------
+    patch
+        Fourier-domain DASCore patch from ``dft`` or ``stft``.
+    dim
+        Frequency dimension over which to compute the descriptor. This can be
+        either the original dimension name, such as ``"time"``, or the Fourier
+        dimension name, such as ``"ft_time"``. If omitted, a single Fourier
+        dimension is inferred.
+    fmin
+        Optional lower frequency bound.
+    fmax
+        Optional upper frequency bound.
+    spectral_format
+        Representation of the spectral data. ``"auto"`` uses DASCore DFT/STFT
+        metadata when available. Other options are ``"fft"`` for complex Fourier
+        coefficients, ``"amplitude"`` for amplitude spectra, ``"power"`` for
+        power spectra, and ``"density"`` for power spectral densities.
+    negative_frequencies
+        How to handle negative frequency bins. ``"auto"`` drops negative bins
+        only when power is symmetric, ``"drop"`` always uses non-negative
+        frequencies, ``"raise"`` rejects spectra with negative bins, and
+        ``"keep"`` includes them in the calculation.
+
+    Returns
+    -------
+        The Patch instance with the mean-frequency as data.
+
+    Example
+    -------
+    >>> import dascore as dc
+    >>> import matplotlib.pyplot as plt
+    >>>
+    >>> patch = dc.examples.get_example_patch('example_event_2')
+    >>>
+    >>> fig, axs = plt.subplots(1,2, layout='constrained', figsize=(12,4))
+    >>> ax = patch.viz.waterfall(cmap='seismic', ax=axs[0])
+    >>>
+    >>> spec = patch.stft(time=.02, overlap=.019, taper_window="boxcar")
+    >>> centroid = spec.spectral_centroid(fmin=50, fmax=300)
+    >>> ax = centroid.viz.waterfall(cmap='turbo', ax=axs[1])
+
+    """
+    freqs, power, freq_dim = _get_spectral_power(
+        patch,
+        dim=dim,
+        fmin=fmin,
+        fmax=fmax,
+        spectral_format=spectral_format,
+        negative_frequencies=negative_frequencies,
+    )
+
+    freq_axis = patch.dims.index(freq_dim)
+    freqs_b = _broadcast_freqs(freqs, power.ndim, freq_axis)
+
+    numerator = np.sum(freqs_b * power, axis=freq_axis)
+    denominator = np.sum(power, axis=freq_axis)
+
+    out = np.divide(
+        numerator,
+        denominator,
+        out=np.full_like(numerator, np.nan, dtype=float),
+        where=denominator > 0,
+    )
+    data_units = patch.get_coord(freq_dim).units
+    data_type = "Spectral Centroid"
+    return _prepare_output(patch, out, freq_dim, data_type, data_units)
+
+
+@patch_function()
+def median_frequency(
+    patch: PatchType,
+    dim: str | None = None,
+    fmin: float | None = None,
+    fmax: float | None = None,
+    spectral_format: SpectralFormat = "auto",
+    negative_frequencies: NegativeFrequencies = "auto",
+) -> PatchType:
+    """
+    Compute the median frequency of a Fourier-domain patch.
+
+    This measure divides a signal's power spectrum into two regions of equal
+    total power. The input patch must already be transformed with
+    [Patch.dft](`dascore.Patch.dft`) or [Patch.stft](`dascore.Patch.stft`).
+
+    See for more detail:
+        - @Phinyomark12
+        - [Online version of the Phinyomark publication](
+            https://www.intechopen.com/chapters/40123)
+        - [Matlab's medfreq](https://se.mathworks.com/help/signal/ref/medfreq.html)
+
+    Parameters
+    ----------
+    patch
+        Fourier-domain DASCore patch from ``dft`` or ``stft``.
+    dim
+        Frequency dimension over which to compute the descriptor. This can be
+        either the original dimension name or the Fourier dimension name.
+    fmin
+        Optional lower frequency bound.
+    fmax
+        Optional upper frequency bound.
+    spectral_format
+        Representation of the spectral data: ``"auto"``, ``"fft"``,
+        ``"amplitude"``, ``"power"``, or ``"density"``.
+    negative_frequencies
+        How to handle negative frequency bins: ``"auto"``, ``"drop"``,
+        ``"raise"``, or ``"keep"``.
+
+    Returns
+    -------
+        The Patch instance with the median-frequency as data.
+
+
+    Example
+    -------
+    >>> import dascore as dc
+    >>> import matplotlib.pyplot as plt
+    >>>
+    >>> patch = dc.examples.get_example_patch('example_event_2')
+    >>>
+    >>> fig, axs = plt.subplots(1,2, layout='constrained', figsize=(12,4))
+    >>> ax = patch.viz.waterfall(cmap='seismic', ax=axs[0])
+    >>>
+    >>> spec = patch.stft(time=.02, overlap=.019, taper_window="boxcar")
+    >>> med = spec.median_frequency(fmin=50, fmax=300)
+    >>> ax = med.viz.waterfall(cmap='turbo', ax=axs[1], scale=[0,1])
+    """
+    freqs, power, freq_dim = _get_spectral_power(
+        patch,
+        dim=dim,
+        fmin=fmin,
+        fmax=fmax,
+        spectral_format=spectral_format,
+        negative_frequencies=negative_frequencies,
+    )
+
+    freq_axis = patch.dims.index(freq_dim)
+
+    # Move frequency axis to front for easier cumulative-power calculation.
+    power_f = np.moveaxis(power, freq_axis, 0)
+
+    cumulative_power = np.cumsum(power_f, axis=0)
+    total_power = cumulative_power[-1, ...]
+    half_power = 0.5 * total_power
+
+    # First frequency bin where cumulative power >= half total power.
+    idx = np.argmax(cumulative_power >= half_power[None, ...], axis=0)
+
+    out = freqs[idx]
+
+    # No valid power -> NaN
+    out = np.where(total_power > 0, out, np.nan)
+
+    data_units = patch.get_coord(freq_dim).units
+    data_type = "Median Frequency"
+    return _prepare_output(patch, out, freq_dim, data_type, data_units)
+
+
+@patch_function()
+def spectral_peak_frequency(
+    patch: PatchType,
+    dim: str | None = None,
+    fmin: float | None = None,
+    fmax: float | None = None,
+    spectral_format: SpectralFormat = "auto",
+    negative_frequencies: NegativeFrequencies = "auto",
+) -> PatchType:
+    """
+    Compute the peak frequency of a Fourier-domain patch.
+
+    The peak frequency is the frequency bin with maximum spectral power
+    within the selected frequency range. This is the global maximum, not
+    a search for multiple local peaks. Ties select the first bin in coordinate
+    order.
+    The input patch must already be transformed with
+    [Patch.dft](`dascore.Patch.dft`) or [Patch.stft](`dascore.Patch.stft`).
+
+    Parameters
+    ----------
+    patch
+        Fourier-domain DASCore patch from ``dft`` or ``stft``.
+    dim
+        Frequency dimension over which to compute the descriptor. This can be
+        either the original dimension name or the Fourier dimension name.
+    fmin
+        Optional lower frequency limit.
+    fmax
+        Optional upper frequency limit.
+    spectral_format
+        Representation of the spectral data: ``"auto"``, ``"fft"``,
+        ``"amplitude"``, ``"power"``, or ``"density"``.
+    negative_frequencies
+        How to handle negative frequency bins: ``"auto"``, ``"drop"``,
+        ``"raise"``, or ``"keep"``.
+
+    Returns
+    -------
+    PatchType
+        Patch containing the frequency corresponding to the maximum
+        spectral power.
+    """
+    freqs, power, freq_dim = _get_spectral_power(
+        patch, dim, fmin, fmax, spectral_format, negative_frequencies
+    )
+
+    freq_axis = patch.dims.index(freq_dim)
+
+    power_f = np.moveaxis(power, freq_axis, 0)
+
+    idx = np.argmax(power_f, axis=0)
+
+    out = freqs[idx]
+
+    data_units = patch.get_coord(freq_dim).units
+    data_type = "Frequency at Maximum"
+    return _prepare_output(patch, out, freq_dim, data_type, data_units)
+
+
+@patch_function()
+def spectral_peak_amplitude(
+    patch: PatchType,
+    dim: str | None = None,
+    fmin: float | None = None,
+    fmax: float | None = None,
+    spectral_format: SpectralFormat = "auto",
+    negative_frequencies: NegativeFrequencies = "auto",
+) -> PatchType:
+    """
+    Compute the peak spectral amplitude of a Fourier-domain patch.
+
+    The input patch must already be transformed with
+    [Patch.dft](`dascore.Patch.dft`) or [Patch.stft](`dascore.Patch.stft`).
+    The descriptor returns the largest linear spectral amplitude along the
+    requested Fourier dimension within the selected frequency range. This is
+    the global maximum, not a search for multiple local peaks.
+
+    Parameters
+    ----------
+    patch
+        Fourier-domain DASCore patch from ``dft`` or ``stft``.
+    dim
+        Frequency dimension over which to compute the descriptor. This can be
+        either the original dimension name or the Fourier dimension name.
+    fmin
+        Optional lower frequency limit.
+    fmax
+        Optional upper frequency limit.
+    spectral_format
+        Representation of the spectral data: ``"auto"``, ``"fft"``,
+        ``"amplitude"``, ``"power"``, or ``"density"``.
+    negative_frequencies
+        How to handle negative frequency bins: ``"auto"``, ``"drop"``,
+        ``"raise"``, or ``"keep"``.
+
+    Returns
+    -------
+    PatchType
+        Patch containing the maximum spectral amplitude.
+    """
+    _freqs, power, freq_dim = _get_spectral_power(
+        patch, dim, fmin, fmax, spectral_format, negative_frequencies
+    )
+
+    freq_axis = patch.dims.index(freq_dim)
+    amplitude = np.sqrt(power)
+    out = np.max(amplitude, axis=freq_axis)
+
+    data_units = patch.attrs.get("data_units")
+    data_type = "Maximum Spectral Amplitude"
+    return _prepare_output(patch, out, freq_dim, data_type, data_units)
+
+
+@patch_function()
+def spectral_entropy(
+    patch: PatchType,
+    dim: str | None = None,
+    fmin: float | None = None,
+    fmax: float | None = None,
+    normalize: bool = True,
+    spectral_format: SpectralFormat = "auto",
+    negative_frequencies: NegativeFrequencies = "auto",
+) -> PatchType:
+    """
+    Compute spectral entropy from a Fourier-domain patch.
+
+    Spectral entropy measures the disorder of the spectral power
+    distribution. Low values indicate concentrated spectral energy,
+    while high values indicate broadband or noisy spectra. The input patch
+    must already be transformed with [Patch.dft](`dascore.Patch.dft`) or
+    [Patch.stft](`dascore.Patch.stft`).
+
+    Parameters
+    ----------
+    patch
+        Fourier-domain DASCore patch from ``dft`` or ``stft``.
+    dim
+        Frequency dimension over which to compute the descriptor. This can be
+        either the original dimension name or the Fourier dimension name.
+    fmin
+        Optional lower frequency limit.
+    fmax
+        Optional upper frequency limit.
+    normalize
+        If True, normalize entropy to [0, 1]. Defaults to True.
+    spectral_format
+        Representation of the spectral data: ``"auto"``, ``"fft"``,
+        ``"amplitude"``, ``"power"``, or ``"density"``.
+    negative_frequencies
+        How to handle negative frequency bins: ``"auto"``, ``"drop"``,
+        ``"raise"``, or ``"keep"``.
+
+    Returns
+    -------
+    PatchType
+        Patch containing spectral entropy.
+    """
+    freqs, power, freq_dim = _get_spectral_power(
+        patch, dim, fmin, fmax, spectral_format, negative_frequencies
+    )
+
+    freq_axis = patch.dims.index(freq_dim)
+
+    total_power = np.sum(power, axis=freq_axis, keepdims=True)
+
+    p = np.divide(
+        power,
+        total_power,
+        out=np.zeros_like(power),
+        where=total_power > 0,
+    )
+
+    entropy = -np.sum(
+        p * np.log2(p, out=np.zeros_like(p), where=p > 0),
+        axis=freq_axis,
+    )
+
+    if normalize:
+        entropy /= np.log2(freqs.size)
+
+    data_units = None
+    data_type = "Spectral Entropy"
+    return _prepare_output(patch, entropy, freq_dim, data_type, data_units)
+
+
+@patch_function()
+def spectral_kurtosis(
+    patch: PatchType,
+    dim: str | None = None,
+    fmin: float | None = None,
+    fmax: float | None = None,
+    spectral_format: SpectralFormat = "auto",
+    negative_frequencies: NegativeFrequencies = "auto",
+) -> PatchType:
+    """
+    Compute spectral kurtosis from a Fourier-domain patch.
+
+    Spectral kurtosis measures the peakedness of the spectral power
+    distribution.
+
+    Large values indicate highly concentrated spectral energy.
+    Lower values indicate broader spectral distributions. The input patch
+    must already be transformed with [Patch.dft](`dascore.Patch.dft`) or
+    [Patch.stft](`dascore.Patch.stft`).
+
+    Parameters
+    ----------
+    patch
+        Fourier-domain DASCore patch from ``dft`` or ``stft``.
+    dim
+        Frequency dimension over which to compute the descriptor. This can be
+        either the original dimension name or the Fourier dimension name.
+    fmin
+        Optional lower frequency limit.
+    fmax
+        Optional upper frequency limit.
+    spectral_format
+        Representation of the spectral data: ``"auto"``, ``"fft"``,
+        ``"amplitude"``, ``"power"``, or ``"density"``.
+    negative_frequencies
+        How to handle negative frequency bins: ``"auto"``, ``"drop"``,
+        ``"raise"``, or ``"keep"``.
+
+    Returns
+    -------
+    PatchType
+        Patch containing spectral kurtosis.
+    """
+    freqs, power, freq_dim = _get_spectral_power(
+        patch, dim, fmin, fmax, spectral_format, negative_frequencies
+    )
+
+    freq_axis = patch.dims.index(freq_dim)
+
+    total_power = np.sum(power, axis=freq_axis, keepdims=True)
+
+    p = np.divide(
+        power,
+        total_power,
+        out=np.zeros_like(power),
+        where=total_power > 0,
+    )
+
+    shape = [1] * power.ndim
+    shape[freq_axis] = freqs.size
+
+    f = freqs.reshape(shape)
+
+    mean_f = np.sum(f * p, axis=freq_axis, keepdims=True)
+
+    var_f = np.sum(
+        ((f - mean_f) ** 2) * p,
+        axis=freq_axis,
+        keepdims=True,
+    )
+
+    kurt = np.divide(
+        np.sum(
+            ((f - mean_f) ** 4) * p,
+            axis=freq_axis,
+        ),
+        np.squeeze(var_f, axis=freq_axis) ** 2,
+        out=np.full_like(
+            np.squeeze(var_f, axis=freq_axis),
+            np.nan,
+        ),
+        where=np.squeeze(var_f, axis=freq_axis) > 0,
+    )
+
+    data_units = None
+    data_type = "Spectral Kurtosis"
+    return _prepare_output(patch, kurt, freq_dim, data_type, data_units)
+
+
+@patch_function()
+def spectral_flatness(
+    patch: PatchType,
+    dim: str | None = None,
+    fmin: float | None = None,
+    fmax: float | None = None,
+    spectral_format: SpectralFormat = "auto",
+    negative_frequencies: NegativeFrequencies = "auto",
+) -> PatchType:
+    """
+    Compute spectral flatness from a Fourier-domain patch.
+
+    Spectral flatness is the ratio between the geometric mean and
+    arithmetic mean of the power spectrum.
+
+    Values near 1 indicate white-noise-like spectra.
+    Values near 0 indicate tonal or peaked spectra. The input patch must
+    already be transformed with [Patch.dft](`dascore.Patch.dft`) or
+    [Patch.stft](`dascore.Patch.stft`).
+
+    Parameters
+    ----------
+    patch
+        Fourier-domain DASCore patch from ``dft`` or ``stft``.
+    dim
+        Frequency dimension over which to compute the descriptor. This can be
+        either the original dimension name or the Fourier dimension name.
+    fmin
+        Optional lower frequency limit.
+    fmax
+        Optional upper frequency limit.
+    spectral_format
+        Representation of the spectral data: ``"auto"``, ``"fft"``,
+        ``"amplitude"``, ``"power"``, or ``"density"``.
+    negative_frequencies
+        How to handle negative frequency bins: ``"auto"``, ``"drop"``,
+        ``"raise"``, or ``"keep"``.
+
+    Returns
+    -------
+    PatchType
+        Patch containing spectral flatness.
+    """
+    _freqs, power, freq_dim = _get_spectral_power(
+        patch, dim, fmin, fmax, spectral_format, negative_frequencies
+    )
+
+    freq_axis = patch.dims.index(freq_dim)
+
+    eps = np.finfo(float).eps
+
+    geo_mean = np.exp(np.mean(np.log(power + eps), axis=freq_axis))
+
+    arith_mean = np.mean(power, axis=freq_axis)
+
+    flatness = np.divide(
+        geo_mean,
+        arith_mean,
+        out=np.full_like(geo_mean, np.nan),
+        where=arith_mean > 0,
+    )
+
+    data_units = None
+    data_type = "Spectral Flatness"
+    return _prepare_output(patch, flatness, freq_dim, data_type, data_units)

--- a/dascore/transform/spectral_descriptors.py
+++ b/dascore/transform/spectral_descriptors.py
@@ -14,6 +14,8 @@ import numpy as np
 import dascore as dc
 from dascore.constants import PatchType
 from dascore.units import Quantity
+from dascore.utils.docs import compose_docstring
+from dascore.utils.misc import broadcast_for_index
 from dascore.utils.patch import patch_function
 
 SpectralFormat = Literal["auto", "fft", "amplitude", "power", "density"]
@@ -39,6 +41,43 @@ _DFT_OUTPUT_TO_FORMAT = {
     "AS": "amplitude",
     "PS": "power",
     "PSD": "density",
+}
+
+
+_SPECTRAL_PARAMETER_DOCS = {
+    "patch": """
+    patch
+        Fourier-domain DASCore patch from ``dft`` or ``stft``.
+    """,
+    "dim": """
+    dim
+        Frequency dimension over which to compute the descriptor. This can be
+        either the original dimension name, such as ``"time"``, or the Fourier
+        dimension name, such as ``"ft_time"``. If omitted, a single Fourier
+        dimension is inferred.
+    """,
+    "fmin": """
+    fmin
+        Optional lower frequency bound.
+    """,
+    "fmax": """
+    fmax
+        Optional upper frequency bound.
+    """,
+    "spectral_format": """
+    spectral_format
+        Representation of the spectral data. ``"auto"`` uses DASCore DFT/STFT
+        metadata when available. Other options are ``"fft"`` for complex Fourier
+        coefficients, ``"amplitude"`` for amplitude spectra, ``"power"`` for
+        power spectra, and ``"density"`` for power spectral densities.
+    """,
+    "negative_frequencies": """
+    negative_frequencies
+        How to handle negative frequency bins. ``"auto"`` drops negative bins
+        only when power is symmetric, ``"drop"`` always uses non-negative
+        frequencies, ``"raise"`` rejects spectra with negative bins, and
+        ``"keep"`` includes them in the calculation.
+    """,
 }
 
 
@@ -263,13 +302,12 @@ def _broadcast_freqs(
     ndim: int,
     freq_axis: int,
 ) -> np.ndarray:
-    """Broadcast frequency vector against an STFT power array."""
-    shape = [1] * ndim
-    shape[freq_axis] = freqs.size
-    return freqs.reshape(shape)
+    """Broadcast a frequency vector against a spectral power array."""
+    return freqs[broadcast_for_index(ndim, freq_axis, slice(None), fill=None)]
 
 
 @patch_function()
+@compose_docstring(**_SPECTRAL_PARAMETER_DOCS)
 def spectral_centroid(
     patch: PatchType,
     dim: str | None = None,
@@ -295,27 +333,12 @@ def spectral_centroid(
 
     Parameters
     ----------
-    patch
-        Fourier-domain DASCore patch from ``dft`` or ``stft``.
-    dim
-        Frequency dimension over which to compute the descriptor. This can be
-        either the original dimension name, such as ``"time"``, or the Fourier
-        dimension name, such as ``"ft_time"``. If omitted, a single Fourier
-        dimension is inferred.
-    fmin
-        Optional lower frequency bound.
-    fmax
-        Optional upper frequency bound.
-    spectral_format
-        Representation of the spectral data. ``"auto"`` uses DASCore DFT/STFT
-        metadata when available. Other options are ``"fft"`` for complex Fourier
-        coefficients, ``"amplitude"`` for amplitude spectra, ``"power"`` for
-        power spectra, and ``"density"`` for power spectral densities.
-    negative_frequencies
-        How to handle negative frequency bins. ``"auto"`` drops negative bins
-        only when power is symmetric, ``"drop"`` always uses non-negative
-        frequencies, ``"raise"`` rejects spectra with negative bins, and
-        ``"keep"`` includes them in the calculation.
+    {patch}
+    {dim}
+    {fmin}
+    {fmax}
+    {spectral_format}
+    {negative_frequencies}
 
     Returns
     -------
@@ -363,6 +386,7 @@ def spectral_centroid(
 
 
 @patch_function()
+@compose_docstring(**_SPECTRAL_PARAMETER_DOCS)
 def median_frequency(
     patch: PatchType,
     dim: str | None = None,
@@ -386,21 +410,12 @@ def median_frequency(
 
     Parameters
     ----------
-    patch
-        Fourier-domain DASCore patch from ``dft`` or ``stft``.
-    dim
-        Frequency dimension over which to compute the descriptor. This can be
-        either the original dimension name or the Fourier dimension name.
-    fmin
-        Optional lower frequency bound.
-    fmax
-        Optional upper frequency bound.
-    spectral_format
-        Representation of the spectral data: ``"auto"``, ``"fft"``,
-        ``"amplitude"``, ``"power"``, or ``"density"``.
-    negative_frequencies
-        How to handle negative frequency bins: ``"auto"``, ``"drop"``,
-        ``"raise"``, or ``"keep"``.
+    {patch}
+    {dim}
+    {fmin}
+    {fmax}
+    {spectral_format}
+    {negative_frequencies}
 
     Returns
     -------
@@ -453,6 +468,7 @@ def median_frequency(
 
 
 @patch_function()
+@compose_docstring(**_SPECTRAL_PARAMETER_DOCS)
 def spectral_peak_frequency(
     patch: PatchType,
     dim: str | None = None,
@@ -473,21 +489,12 @@ def spectral_peak_frequency(
 
     Parameters
     ----------
-    patch
-        Fourier-domain DASCore patch from ``dft`` or ``stft``.
-    dim
-        Frequency dimension over which to compute the descriptor. This can be
-        either the original dimension name or the Fourier dimension name.
-    fmin
-        Optional lower frequency limit.
-    fmax
-        Optional upper frequency limit.
-    spectral_format
-        Representation of the spectral data: ``"auto"``, ``"fft"``,
-        ``"amplitude"``, ``"power"``, or ``"density"``.
-    negative_frequencies
-        How to handle negative frequency bins: ``"auto"``, ``"drop"``,
-        ``"raise"``, or ``"keep"``.
+    {patch}
+    {dim}
+    {fmin}
+    {fmax}
+    {spectral_format}
+    {negative_frequencies}
 
     Returns
     -------
@@ -514,6 +521,7 @@ def spectral_peak_frequency(
 
 
 @patch_function()
+@compose_docstring(**_SPECTRAL_PARAMETER_DOCS)
 def spectral_peak_amplitude(
     patch: PatchType,
     dim: str | None = None,
@@ -533,21 +541,12 @@ def spectral_peak_amplitude(
 
     Parameters
     ----------
-    patch
-        Fourier-domain DASCore patch from ``dft`` or ``stft``.
-    dim
-        Frequency dimension over which to compute the descriptor. This can be
-        either the original dimension name or the Fourier dimension name.
-    fmin
-        Optional lower frequency limit.
-    fmax
-        Optional upper frequency limit.
-    spectral_format
-        Representation of the spectral data: ``"auto"``, ``"fft"``,
-        ``"amplitude"``, ``"power"``, or ``"density"``.
-    negative_frequencies
-        How to handle negative frequency bins: ``"auto"``, ``"drop"``,
-        ``"raise"``, or ``"keep"``.
+    {patch}
+    {dim}
+    {fmin}
+    {fmax}
+    {spectral_format}
+    {negative_frequencies}
 
     Returns
     -------
@@ -571,6 +570,7 @@ def spectral_peak_amplitude(
 
 
 @patch_function()
+@compose_docstring(**_SPECTRAL_PARAMETER_DOCS)
 def spectral_entropy(
     patch: PatchType,
     dim: str | None = None,
@@ -591,23 +591,14 @@ def spectral_entropy(
 
     Parameters
     ----------
-    patch
-        Fourier-domain DASCore patch from ``dft`` or ``stft``.
-    dim
-        Frequency dimension over which to compute the descriptor. This can be
-        either the original dimension name or the Fourier dimension name.
-    fmin
-        Optional lower frequency limit.
-    fmax
-        Optional upper frequency limit.
+    {patch}
+    {dim}
+    {fmin}
+    {fmax}
     normalize
         If True, normalize entropy to [0, 1]. Defaults to True.
-    spectral_format
-        Representation of the spectral data: ``"auto"``, ``"fft"``,
-        ``"amplitude"``, ``"power"``, or ``"density"``.
-    negative_frequencies
-        How to handle negative frequency bins: ``"auto"``, ``"drop"``,
-        ``"raise"``, or ``"keep"``.
+    {spectral_format}
+    {negative_frequencies}
 
     Returns
     -------
@@ -645,6 +636,7 @@ def spectral_entropy(
 
 
 @patch_function()
+@compose_docstring(**_SPECTRAL_PARAMETER_DOCS)
 def spectral_kurtosis(
     patch: PatchType,
     dim: str | None = None,
@@ -666,21 +658,12 @@ def spectral_kurtosis(
 
     Parameters
     ----------
-    patch
-        Fourier-domain DASCore patch from ``dft`` or ``stft``.
-    dim
-        Frequency dimension over which to compute the descriptor. This can be
-        either the original dimension name or the Fourier dimension name.
-    fmin
-        Optional lower frequency limit.
-    fmax
-        Optional upper frequency limit.
-    spectral_format
-        Representation of the spectral data: ``"auto"``, ``"fft"``,
-        ``"amplitude"``, ``"power"``, or ``"density"``.
-    negative_frequencies
-        How to handle negative frequency bins: ``"auto"``, ``"drop"``,
-        ``"raise"``, or ``"keep"``.
+    {patch}
+    {dim}
+    {fmin}
+    {fmax}
+    {spectral_format}
+    {negative_frequencies}
 
     Returns
     -------
@@ -702,10 +685,7 @@ def spectral_kurtosis(
         where=total_power > 0,
     )
 
-    shape = [1] * power.ndim
-    shape[freq_axis] = freqs.size
-
-    f = freqs.reshape(shape)
+    f = _broadcast_freqs(freqs, power.ndim, freq_axis)
 
     mean_f = np.sum(f * p, axis=freq_axis, keepdims=True)
 
@@ -734,6 +714,7 @@ def spectral_kurtosis(
 
 
 @patch_function()
+@compose_docstring(**_SPECTRAL_PARAMETER_DOCS)
 def spectral_flatness(
     patch: PatchType,
     dim: str | None = None,
@@ -755,21 +736,12 @@ def spectral_flatness(
 
     Parameters
     ----------
-    patch
-        Fourier-domain DASCore patch from ``dft`` or ``stft``.
-    dim
-        Frequency dimension over which to compute the descriptor. This can be
-        either the original dimension name or the Fourier dimension name.
-    fmin
-        Optional lower frequency limit.
-    fmax
-        Optional upper frequency limit.
-    spectral_format
-        Representation of the spectral data: ``"auto"``, ``"fft"``,
-        ``"amplitude"``, ``"power"``, or ``"density"``.
-    negative_frequencies
-        How to handle negative frequency bins: ``"auto"``, ``"drop"``,
-        ``"raise"``, or ``"keep"``.
+    {patch}
+    {dim}
+    {fmin}
+    {fmax}
+    {spectral_format}
+    {negative_frequencies}
 
     Returns
     -------

--- a/dascore/transform/spectral_descriptors.py
+++ b/dascore/transform/spectral_descriptors.py
@@ -237,11 +237,11 @@ def _prepare_output(
     data_type: str,
     data_units: str | Quantity | None,
 ) -> PatchType:
-    """Return a patch with the frequency dimension removed."""
-    dims = tuple(dim for dim in patch.dims if dim != freq_dim)
-    coords = {dim: patch.get_array(dim) for dim in dims}
+    """Remove frequency-dependent coordinates and preserve remaining metadata."""
+    # Descriptor data is already reduced, so only drop coordinates here.
+    coords, _ = patch.coords.drop_coords(freq_dim)
     attrs = {"data_type": data_type, "data_units": data_units}
-    return dc.Patch(data=data, dims=dims, coords=coords, attrs=attrs)
+    return dc.Patch(data=data, dims=coords.dims, coords=coords, attrs=attrs)
 
 
 def _broadcast_freqs(
@@ -492,6 +492,7 @@ def spectral_peak_frequency(
     idx = np.argmax(power_f, axis=0)
 
     out = freqs[idx]
+    out = np.where(np.sum(power_f, axis=0) > 0, out, np.nan)
 
     data_units = patch.get_coord(freq_dim).units
     data_type = "Frequency at Maximum"
@@ -548,6 +549,9 @@ def spectral_peak_amplitude(
     out = np.max(amplitude, axis=freq_axis)
 
     data_units = patch.attrs.get("data_units")
+    resolved_format = _normalize_spectral_format(patch, spectral_format)
+    if resolved_format in {"power", "density"} and data_units is not None:
+        data_units = dc.get_quantity(data_units) ** 0.5
     data_type = "Maximum Spectral Amplitude"
     return _prepare_output(patch, out, freq_dim, data_type, data_units)
 
@@ -617,7 +621,9 @@ def spectral_entropy(
     )
 
     if normalize:
-        entropy /= np.log2(freqs.size)
+        entropy = (
+            np.zeros_like(entropy) if freqs.size == 1 else entropy / np.log2(freqs.size)
+        )
 
     data_units = None
     data_type = "Spectral Entropy"

--- a/dascore/transform/spectral_descriptors.py
+++ b/dascore/transform/spectral_descriptors.py
@@ -1,4 +1,9 @@
-"""Spectral descriptor transforms for DASCore patches."""
+"""
+Spectral descriptor transforms for DASCore patches.
+
+Outputs preserve input metadata and processing history, replace data type and
+units, and remove obsolete DFT/STFT attributes and frequency-dependent coordinates.
+"""
 
 from __future__ import annotations
 
@@ -240,7 +245,16 @@ def _prepare_output(
     """Remove frequency-dependent coordinates and preserve remaining metadata."""
     # Descriptor data is already reduced, so only drop coordinates here.
     coords, _ = patch.coords.drop_coords(freq_dim)
-    attrs = {"data_type": data_type, "data_units": data_units}
+    # Reduction no longer represents Fourier coefficients, even when other
+    # Fourier dimensions remain. Preserve unrelated (including private) attrs.
+    obsolete = tuple(
+        key
+        for key in dict(patch.attrs)
+        if key.startswith(("_dft_", "_stft_", "_pre_dft_", "_pre_stft_"))
+    )
+    attrs = patch.attrs.drop(*obsolete, "coords", "dims").update(
+        data_type=data_type, data_units=data_units
+    )
     return dc.Patch(data=data, dims=coords.dims, coords=coords, attrs=attrs)
 
 

--- a/docs/recipes/spectral_descriptors.qmd
+++ b/docs/recipes/spectral_descriptors.qmd
@@ -18,3 +18,5 @@ peak_amplitude = spec.spectral_peak_amplitude(fmin=1, fmax=3)
 `spectral_centroid` is the power-weighted center frequency. `spectral_peak_frequency` returns the frequency bin with the largest spectral power, while `spectral_peak_amplitude` returns the largest linear spectral amplitude. Both peak descriptors select the global maximum within the requested frequency range, rather than finding multiple local peaks.
 
 Other descriptors include `median_frequency`, `spectral_entropy`, `spectral_kurtosis`, and `spectral_flatness`. These methods accept DFT and STFT output and support frequency limits with `fmin` and `fmax`.
+
+Descriptor outputs remove the frequency dimension and coordinates that depend on it, while preserving all remaining coordinates and their units.

--- a/docs/recipes/spectral_descriptors.qmd
+++ b/docs/recipes/spectral_descriptors.qmd
@@ -1,0 +1,20 @@
+---
+title: "Spectral Descriptors"
+---
+
+Spectral descriptors summarize Fourier-domain patches. First transform a patch with `dft` or `stft`, then call descriptor methods directly on the resulting patch.
+
+```{python}
+import dascore as dc
+
+patch = dc.get_example_patch("sin_wav", sample_rate=100, duration=3, frequency=2)
+spec = patch.dft("time", real=True, pad=False)
+
+centroid = spec.spectral_centroid(fmin=1, fmax=3)
+peak_frequency = spec.spectral_peak_frequency(fmin=1, fmax=3)
+peak_amplitude = spec.spectral_peak_amplitude(fmin=1, fmax=3)
+```
+
+`spectral_centroid` is the power-weighted center frequency. `spectral_peak_frequency` returns the frequency bin with the largest spectral power, while `spectral_peak_amplitude` returns the largest linear spectral amplitude. Both peak descriptors select the global maximum within the requested frequency range, rather than finding multiple local peaks.
+
+Other descriptors include `median_frequency`, `spectral_entropy`, `spectral_kurtosis`, and `spectral_flatness`. These methods accept DFT and STFT output and support frequency limits with `fmin` and `fmax`.

--- a/scripts/_templates/_quarto.yml
+++ b/scripts/_templates/_quarto.yml
@@ -144,6 +144,7 @@ website:
             - recipes/real_time_proc.qmd
             - recipes/parallelization.qmd
             - recipes/low_freq_proc.qmd
+            - recipes/spectral_descriptors.qmd
 
         - section: "IO"
           contents:

--- a/tests/test_transform/test_spectral_descriptors.py
+++ b/tests/test_transform/test_spectral_descriptors.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 
 import dascore as dc
+from dascore.transform import spectral_descriptors
 
 
 @pytest.fixture(scope="class")
@@ -174,6 +175,30 @@ class TestSpectralValidation:
         patch = spectrum.update(data=spectrum.data.astype(complex))
         out = patch.spectral_centroid()
         assert np.allclose(out.data, 2.0)
+
+
+class TestSpectralHelpers:
+    """Tests for defensive paths in spectral helpers."""
+
+    def test_unhandled_format(self, sine_patch, monkeypatch):
+        """An unexpected normalized format triggers the internal assertion."""
+        monkeypatch.setattr(
+            spectral_descriptors,
+            "_normalize_spectral_format",
+            lambda patch, spectral_format: "unexpected",
+        )
+        with pytest.raises(
+            AssertionError, match="Unhandled spectral format 'unexpected'"
+        ):
+            spectral_descriptors._get_power(sine_patch, "auto")
+
+    def test_nonnegative_frequencies(self):
+        """Spectra without negative bins need no mirrored-power comparison."""
+        freqs = np.array([0.0, 1.0, 2.0])
+        power = np.array([[1.0, 4.0, 9.0]])
+        assert spectral_descriptors._power_has_symmetric_frequencies(
+            freqs, power, freq_axis=1
+        )
 
 
 class TestSpectralCentroid:

--- a/tests/test_transform/test_spectral_descriptors.py
+++ b/tests/test_transform/test_spectral_descriptors.py
@@ -58,6 +58,123 @@ class TestSpectralPeaks:
         assert np.allclose(out_frequency.data, frequency)
         assert np.allclose(out_amplitude.data, amplitude)
 
+    def test_zero_power_returns_nan_frequency(self):
+        """Zero-power spectra have no defined peak frequency."""
+        patch = dc.Patch(
+            data=np.array([[0.0, 0.0, 0.0], [1.0, 2.0, 1.0]]),
+            coords={"distance": np.array([0.0, 10.0]), "ft_time": np.arange(3.0)},
+            dims=("distance", "ft_time"),
+        )
+
+        out = patch.spectral_peak_frequency(spectral_format="amplitude")
+
+        assert np.isnan(out.data[0])
+        assert out.data[1] == 1.0
+
+
+class TestOutputCoordinates:
+    """Tests for coordinate metadata after spectral reduction."""
+
+    @pytest.mark.parametrize(
+        "name",
+        [
+            "median_frequency",
+            "spectral_centroid",
+            "spectral_peak_frequency",
+            "spectral_peak_amplitude",
+            "spectral_entropy",
+            "spectral_kurtosis",
+            "spectral_flatness",
+        ],
+    )
+    @pytest.mark.parametrize("frequency_first", [False, True])
+    def test_preserves_coordinates(self, name, frequency_first):
+        """Keep unrelated coordinates and units; drop frequency dependents."""
+        patch = dc.Patch(
+            data=np.ones((2, 5)),
+            coords={
+                "distance": np.array([0.0, 10.0]),
+                "ft_time": np.arange(1.0, 6.0),
+                "elevation": ("distance", np.array([100.0, 101.0])),
+                "reference": ((), np.array([42.0])),
+                "frequency_label": ("ft_time", np.arange(5.0)),
+                "calibration": (("distance", "ft_time"), np.ones((2, 5))),
+            },
+            dims=("distance", "ft_time"),
+        ).set_units(distance="m", elevation="m", reference="m", ft_time="Hz")
+        if frequency_first:
+            patch = patch.transpose("ft_time", "distance")
+
+        out = getattr(patch, name)(spectral_format="amplitude")
+
+        assert out.dims == ("distance",)
+        assert out.shape == (2,)
+        assert set(out.coords.coord_map) == {"distance", "elevation", "reference"}
+        for coord in out.coords.coord_map:
+            assert out.get_coord(coord) == patch.get_coord(coord)
+            assert out.coords.dim_map[coord] == patch.coords.dim_map[coord]
+
+
+class TestSpectralValidation:
+    """Tests for invalid input and spectral format inference."""
+
+    @pytest.fixture
+    def spectrum(self):
+        """Return a spectrum without transform metadata."""
+        return dc.Patch(
+            data=np.array([[1.0, 4.0, 1.0]]),
+            coords={"distance": np.array([0.0]), "ft_time": np.arange(1.0, 4.0)},
+            dims=("distance", "ft_time"),
+        )
+
+    @pytest.mark.parametrize(
+        "kwargs, message",
+        [
+            ({"dim": "missing"}, "Fourier dimension.*was not found"),
+            ({"spectral_format": "invalid"}, "Unknown spectral_format"),
+            ({"negative_frequencies": "invalid"}, "negative_frequencies must be"),
+            ({"fmin": 100}, "exclude all Fourier frequency bins"),
+            ({"fmin": 3, "fmax": 1}, "exclude all Fourier frequency bins"),
+        ],
+    )
+    def test_invalid_options(self, sine_dft, kwargs, message):
+        """Invalid dimensions, options, and empty bands raise clear errors."""
+        with pytest.raises(ValueError, match=message):
+            sine_dft.spectral_centroid(**kwargs)
+
+    @pytest.mark.parametrize("spectral_format", ["amplitude", "power", "density"])
+    def test_complex_real_format(self, spectrum, spectral_format):
+        """Real spectral representations reject complex data."""
+        patch = spectrum.update(data=spectrum.data.astype(complex))
+        with pytest.raises(ValueError, match="requires real-valued spectral data"):
+            patch.spectral_centroid(spectral_format=spectral_format)
+
+    @pytest.mark.parametrize("spectral_format", ["amplitude", "power", "density"])
+    def test_negative_values(self, spectrum, spectral_format):
+        """Amplitude, power, and density cannot contain negative values."""
+        patch = spectrum.update(data=-spectrum.data)
+        with pytest.raises(ValueError, match="must be non-negative"):
+            patch.spectral_centroid(spectral_format=spectral_format)
+
+    def test_unknown_real_format(self, spectrum):
+        """Real spectra without identifying metadata require a format."""
+        with pytest.raises(ValueError, match="Could not infer spectral"):
+            spectrum.spectral_centroid()
+
+    @pytest.mark.parametrize(
+        "data_type", ["amplitude spectrum", "power spectrum", "spectral density"]
+    )
+    def test_data_type_inference(self, spectrum, data_type):
+        """Data-type metadata identifies otherwise unmarked spectra."""
+        out = spectrum.update_attrs(data_type=data_type).spectral_centroid()
+        assert np.allclose(out.data, 2.0)
+
+    def test_complex_inference(self, spectrum):
+        """Unmarked complex spectra are interpreted as Fourier coefficients."""
+        patch = spectrum.update(data=spectrum.data.astype(complex))
+        out = patch.spectral_centroid()
+        assert np.allclose(out.data, 2.0)
+
 
 class TestSpectralCentroid:
     """Tests for spectral centroid."""
@@ -175,6 +292,13 @@ class TestOtherDescriptors:
         with pytest.raises(ValueError, match="Decibel-scaled"):
             spec.spectral_centroid()
 
+    def test_entropy_single_frequency(self, sine_dft):
+        """Normalized entropy of one frequency bin is zero."""
+        freq = sine_dft.get_array("ft_time")
+        frequency = freq[freq > 0][0]
+        out = sine_dft.spectral_entropy(fmin=frequency, fmax=frequency)
+        assert np.allclose(out.data, 0.0)
+
     def test_peak_amplitude(self, sine_patch):
         """Peak amplitude agrees across amplitude and power spectra."""
         amplitude = sine_patch.dft("time", real=True, pad=False, output="AS")
@@ -184,3 +308,18 @@ class TestOtherDescriptors:
         out = power.spectral_peak_amplitude(fmin=1, fmax=3)
 
         assert out.equals(expected, close=True)
+
+    @pytest.mark.parametrize("output", ["FFT", "AS", "PS", "PSD"])
+    def test_peak_amplitude_units(self, sine_patch, output):
+        """Peak amplitude units match the returned linear amplitude."""
+        patch = sine_patch.update_attrs(data_units="m/s").dft(
+            "time", real=True, pad=False, output=output
+        )
+
+        out = patch.spectral_peak_amplitude(fmin=1, fmax=3)
+        input_units = dc.get_quantity(patch.attrs.data_units)
+        expected = input_units
+        if output in {"PS", "PSD"}:
+            expected = input_units**0.5
+
+        assert out.attrs.data_units == expected

--- a/tests/test_transform/test_spectral_descriptors.py
+++ b/tests/test_transform/test_spectral_descriptors.py
@@ -116,6 +116,74 @@ class TestOutputCoordinates:
             assert out.coords.dim_map[coord] == patch.coords.dim_map[coord]
 
 
+@pytest.mark.parametrize(
+    "name, data_type, unit_kind",
+    [
+        ("spectral_centroid", "Spectral Centroid", "frequency"),
+        ("median_frequency", "Median Frequency", "frequency"),
+        ("spectral_peak_frequency", "Frequency at Maximum", "frequency"),
+        ("spectral_peak_amplitude", "Maximum Spectral Amplitude", "amplitude"),
+        ("spectral_entropy", "Spectral Entropy", "dimensionless"),
+        ("spectral_kurtosis", "Spectral Kurtosis", "dimensionless"),
+        ("spectral_flatness", "Spectral Flatness", "dimensionless"),
+    ],
+)
+class TestOutputMetadata:
+    """Descriptor reductions preserve provenance without spectral bookkeeping."""
+
+    @pytest.fixture(params=["dft", "stft", "multidimensional_dft"])
+    def spectrum(self, sine_patch, request):
+        """Create actual transform metadata along with ordinary input attrs."""
+        patch = sine_patch.update_attrs(
+            station="TEST",
+            tag="review",
+            history=["previous_processing"],
+            instrument_name="test instrument",
+            _custom_metadata="preserve me",
+            data_units="m/s",
+        )
+        if request.param == "stft":
+            return patch.stft(time=100, overlap=0, samples=True)
+        dims = (
+            ("time", "distance") if request.param == "multidimensional_dft" else "time"
+        )
+        return patch.dft(dims, pad=False)
+
+    def test_preserves_metadata(self, spectrum, name, data_type, unit_kind):
+        """Keep metadata/history and remaining coords without mutating the input."""
+        original_attrs = spectrum.attrs.model_dump()
+        original_data = spectrum.data.copy()
+        original_coords = spectrum.coords
+
+        out = getattr(spectrum, name)(dim="time", fmin=1, fmax=3)
+
+        for key in ("station", "tag", "instrument_name", "_custom_metadata"):
+            assert out.attrs[key] == spectrum.attrs[key]
+        assert out.attrs.history[:-1] == spectrum.attrs.history
+        assert out.attrs.history[0] == "previous_processing"
+        assert out.attrs.history[-1].startswith(f"{name}(")
+        assert out.attrs.data_type == data_type
+        expected_units = {
+            "frequency": spectrum.get_coord("ft_time").units,
+            "amplitude": spectrum.attrs.data_units,
+            "dimensionless": None,
+        }
+        assert out.attrs.data_units == expected_units[unit_kind]
+        assert not any(
+            key.startswith(("_dft_", "_stft_", "_pre_dft_", "_pre_stft_"))
+            for key in dict(out.attrs)
+        )
+        assert out.dims == tuple(dim for dim in spectrum.dims if dim != "ft_time")
+        assert out.attrs.dim_tuple == out.dims
+        assert dict(out.attrs.coords) == out.coords.to_summary_dict()
+        assert "ft_time" not in out.coords.coord_map
+        for coord in out.coords.coord_map:
+            assert out.get_coord(coord) == spectrum.get_coord(coord)
+        assert spectrum.attrs.model_dump() == original_attrs
+        np.testing.assert_array_equal(spectrum.data, original_data)
+        assert spectrum.coords is original_coords
+
+
 class TestSpectralValidation:
     """Tests for invalid input and spectral format inference."""
 

--- a/tests/test_transform/test_spectral_descriptors.py
+++ b/tests/test_transform/test_spectral_descriptors.py
@@ -1,0 +1,186 @@
+"""Tests for spectral descriptor transforms."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import dascore as dc
+
+
+@pytest.fixture(scope="class")
+def sine_patch():
+    """Return a simple sine-wave patch."""
+    return dc.get_example_patch(
+        "sin_wav", sample_rate=100, duration=3, frequency=2
+    ).set_units(time="s")
+
+
+@pytest.fixture(scope="class")
+def sine_dft(sine_patch):
+    """Return a full DFT of the sine patch."""
+    return sine_patch.dft("time", pad=False)
+
+
+class TestSpectralAPI:
+    """Tests for the spectral descriptor public API."""
+
+    @pytest.mark.parametrize(
+        "name", ["spectral_peak_frequency", "spectral_peak_amplitude"]
+    )
+    def test_public_exports(self, sine_dft, name):
+        """Patch methods and transform exports produce the same result."""
+        expected = getattr(dc.transform, name)(sine_dft, fmin=1, fmax=3)
+        out = getattr(sine_dft, name)(fmin=1, fmax=3)
+        assert out.equals(expected)
+
+
+class TestSpectralPeaks:
+    """Tests for peak selection within a frequency band."""
+
+    @pytest.mark.parametrize(
+        "limits, frequency, amplitude",
+        [({}, 2.0, 5.0), ({"fmin": 3, "fmax": 4}, 3.0, 4.0)],
+    )
+    def test_peak_selection(self, limits, frequency, amplitude):
+        """Select the largest peak in the band and the first bin on ties."""
+        patch = dc.Patch(
+            data=np.array([[1.0, 5.0, 4.0, 4.0, 2.0]]),
+            coords={"distance": np.array([0.0]), "ft_time": np.arange(1.0, 6.0)},
+            dims=("distance", "ft_time"),
+        )
+        out_frequency = patch.spectral_peak_frequency(
+            spectral_format="amplitude", **limits
+        )
+        out_amplitude = patch.spectral_peak_amplitude(
+            spectral_format="amplitude", **limits
+        )
+        assert np.allclose(out_frequency.data, frequency)
+        assert np.allclose(out_amplitude.data, amplitude)
+
+
+class TestSpectralCentroid:
+    """Tests for spectral centroid."""
+
+    def test_dft_input(self, sine_dft):
+        """Spectral centroid accepts DFT input."""
+        out = sine_dft.spectral_centroid(fmin=1, fmax=3)
+
+        assert out.dims == ("distance",)
+        assert np.allclose(out.data, 2.0, rtol=0.01)
+
+    def test_stft_input(self, sine_patch):
+        """Spectral centroid accepts STFT input."""
+        spec = sine_patch.stft(time=100, overlap=0, samples=True)
+        out = spec.spectral_centroid(fmin=1, fmax=3)
+
+        assert out.dims == ("distance", "time")
+        assert np.all(np.isfinite(out.data))
+
+    def test_spectral_representations(self, sine_patch):
+        """DFT output representations are handled from metadata."""
+        fft = sine_patch.dft("time", real=True, pad=False, output="FFT")
+        amplitude = sine_patch.dft("time", real=True, pad=False, output="AS")
+        power = sine_patch.dft("time", real=True, pad=False, output="PS")
+        density = sine_patch.dft("time", real=True, pad=False, output="PSD")
+
+        expected = fft.spectral_centroid(fmin=1, fmax=3)
+
+        assert amplitude.spectral_centroid(fmin=1, fmax=3).equals(expected, close=True)
+        assert power.spectral_centroid(fmin=1, fmax=3).equals(expected, close=True)
+        assert density.spectral_centroid(fmin=1, fmax=3).equals(expected, close=True)
+
+    def test_real_spectra_need_known_type(self, sine_dft):
+        """Real-valued spectra without metadata require an explicit format."""
+        unknown = sine_dft.abs().update_attrs(data_type=None)
+
+        with pytest.raises(ValueError, match="requires complex"):
+            unknown.spectral_centroid()
+
+        out = unknown.spectral_centroid(spectral_format="amplitude", fmin=1, fmax=3)
+
+        assert np.allclose(out.data, 2.0, rtol=0.01)
+
+
+class TestFrequencySelection:
+    """Tests for frequency-axis and negative-frequency handling."""
+
+    def test_negative_frequencies_raise(self, sine_dft):
+        """Negative frequency bins can be rejected."""
+        with pytest.raises(ValueError, match="negative frequencies"):
+            sine_dft.spectral_centroid(negative_frequencies="raise")
+
+    def test_negative_frequencies_auto_drops_symmetric(self, sine_dft):
+        """Auto mode drops negative bins for symmetric spectra."""
+        out = sine_dft.spectral_peak_frequency()
+
+        assert np.all(out.data >= 0)
+        assert np.allclose(out.data, 2.0, rtol=0.01)
+
+    def test_negative_frequencies_auto_rejects_nonsymmetric(self, sine_dft):
+        """Auto mode rejects nonsymmetric negative-frequency spectra."""
+        data = sine_dft.data.copy()
+        freq_axis = sine_dft.get_axis("ft_time")
+        neg_index = sine_dft.get_array("ft_time") < 0
+        data[np.compress(neg_index, np.arange(data.shape[freq_axis])), :] *= 2
+        patch = sine_dft.update(data=data)
+
+        with pytest.raises(ValueError, match="non-symmetric power"):
+            patch.spectral_centroid()
+
+        out = patch.spectral_centroid(negative_frequencies="drop", fmin=1, fmax=3)
+
+        assert np.allclose(out.data, 2.0, rtol=0.01)
+
+    def test_multiple_ft_dims_require_dim(self, sine_patch):
+        """Ambiguous Fourier axes require an explicit dimension."""
+        patch = sine_patch.dft(("time", "distance"), pad=False)
+
+        with pytest.raises(ValueError, match="Multiple Fourier dimensions"):
+            patch.spectral_centroid()
+
+        out = patch.spectral_centroid(dim="time", fmin=1, fmax=3)
+
+        assert out.dims == ("ft_distance",)
+
+
+class TestOtherDescriptors:
+    """Smoke tests for remaining spectral descriptors."""
+
+    def test_descriptors_accept_dft_input(self, sine_dft):
+        """All descriptors accept Fourier-domain input."""
+        funcs = (
+            sine_dft.median_frequency,
+            sine_dft.spectral_peak_frequency,
+            sine_dft.spectral_peak_amplitude,
+            sine_dft.spectral_entropy,
+            sine_dft.spectral_kurtosis,
+            sine_dft.spectral_flatness,
+        )
+
+        for func in funcs:
+            out = func(fmin=1, fmax=3)
+            assert out.dims == ("distance",)
+            assert np.all(np.isfinite(out.data) | np.isnan(out.data))
+
+    def test_time_domain_input_raises(self, sine_patch):
+        """Descriptors reject non-Fourier input."""
+        with pytest.raises(ValueError, match="Fourier-domain input"):
+            sine_patch.spectral_centroid()
+
+    def test_db_spectra_raise(self, sine_patch):
+        """Decibel spectra are rejected."""
+        spec = sine_patch.dft("time", real=True, output="PS", db=True)
+
+        with pytest.raises(ValueError, match="Decibel-scaled"):
+            spec.spectral_centroid()
+
+    def test_peak_amplitude(self, sine_patch):
+        """Peak amplitude agrees across amplitude and power spectra."""
+        amplitude = sine_patch.dft("time", real=True, pad=False, output="AS")
+        power = sine_patch.dft("time", real=True, pad=False, output="PS")
+
+        expected = amplitude.spectral_peak_amplitude(fmin=1, fmax=3)
+        out = power.spectral_peak_amplitude(fmin=1, fmax=3)
+
+        assert out.equals(expected, close=True)


### PR DESCRIPTION
The PR adds a few useful signal-processing features based on spectral descriptors. The concepts are originally from speech recognition but also useful in geophysics:

The decriptors are:
- median_frequency,
- spectral_centroid,
- spectral_entropy,
- spectral_flatness,
- spectral_kurtosis,
- spectral_peak_frequency,
- spectral_peak_amplitude,

See the respective doc-strings for more information

## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [X] documented the new feature with docstrings and/or appropriate doc page.
- [X] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [X] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added seven spectral analysis descriptors: centroid, median frequency, peak frequency and amplitude, entropy, kurtosis, and flatness.
  * Descriptors support Fourier and short-time Fourier data, frequency limits, and negative-frequency analysis.
  * Exposed descriptors through patch methods and public transformation utilities.
  * Outputs preserve applicable coordinate metadata and units, with defined handling for zero-power spectra and single-frequency selections.

* **Documentation**
  * Added a recipe demonstrating spectral descriptor workflows and usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->