### PR TITLE
Fix waterfall physical cells after the gap tolerance change

### DIFF
--- a/dascore/viz/waterfall.py
+++ b/dascore/viz/waterfall.py
@@ -186,8 +186,12 @@ def _plot_with_bounds(ax, data, patch, cmap, gap_color, gap_factor):
                 len(patch.get_coord(dim)),
             )
         else:
-            factor = gap_factor if gap_color is not None else None
-            cells[dim] = mesh_cell_edges(*get_gap_edges(patch.get_array(dim), factor))
+            tolerance = (
+                GapTolerance.samples(gap_factor) if gap_color is not None else None
+            )
+            cells[dim] = mesh_cell_edges(
+                *get_gap_edges(patch.get_array(dim), tolerance)
+            )
     y0, y1 = cells[patch.dims[0]]
     x0, x1 = cells[patch.dims[1]]
     vertices = np.empty((*data.shape, 4, 2))

--- a/dascore/viz/waterfall.py
+++ b/dascore/viz/waterfall.py
@@ -190,7 +190,7 @@ def _plot_with_bounds(ax, data, patch, cmap, gap_color, gap_factor):
                 GapTolerance.samples(gap_factor) if gap_color is not None else None
             )
             cells[dim] = mesh_cell_edges(
-                *get_gap_edges(patch.get_array(dim), tolerance)
+                *get_gap_edges(patch.get_coord(dim), tolerance)
             )
     y0, y1 = cells[patch.dims[0]]
     x0, x1 = cells[patch.dims[1]]

--- a/tests/test_viz/test_waterfall.py
+++ b/tests/test_viz/test_waterfall.py
@@ -1335,6 +1335,22 @@ class TestExplicitWaterfallCells:
         assert ax.get_ylim() == (-0.25, 5.75)
         assert len(ax.patches) == (gap_color is not None)
 
+    def test_declared_step_opens_gaps(self):
+        """A declared step, not the median spacing, sizes the cells beside it."""
+        patch = dc.Patch(
+            data=np.zeros((3, 4)),
+            dims=("x", "y"),
+            coords={
+                "x": [0.0, 2.0, 5.0],
+                "y": dc.get_coord(data=np.array([0.0, 3.0, 6.0, 7.0]), step=1.0),
+                "x_start": ("x", [-0.25, 1.75, 4.75]),
+                "x_stop": ("x", [0.75, 2.75, 5.75]),
+            },
+        )
+        ax = patch.viz.waterfall(cbar=False, gap_color="gray")
+        first = ax.collections[0].get_paths()[0].vertices[:, 0]
+        assert (first.min(), first.max()) == (-0.5, 0.5)
+
     def test_overlapping_cells(self, bounded):
         """Overlapping cells retain their full bounds without creating fake gaps."""
         patch = bounded.update_coords(x_stop=("x", [3.0, 6.0, 7.0]))

--- a/tests/test_viz/test_waterfall.py
+++ b/tests/test_viz/test_waterfall.py
@@ -18,7 +18,7 @@ import dascore as dc
 from dascore.examples import inventory_patch_pair
 from dascore.exceptions import ParameterError
 from dascore.units import get_quantity_str, percent
-from dascore.utils.gaps import get_gap_edges
+from dascore.utils.gaps import GapTolerance, get_gap_edges
 from dascore.utils.misc import suppress_warnings
 from dascore.utils.plotting import _get_extents
 from dascore.utils.time import is_datetime64, to_timedelta64
@@ -1289,7 +1289,7 @@ class TestCellExtents:
         values = np.array([0.0, 1.0, 4.0, 5.0])
         if reverse:
             values = values[::-1]
-        edges, gaps = get_gap_edges(values, gap_factor=1.5)
+        edges, gaps = get_gap_edges(values, GapTolerance.samples(1.5))
         assert gaps.tolist() == [False, True, False]
         assert sorted(edges[2:4]) == [1.5, 3.5]
         patch = dc.Patch(


### PR DESCRIPTION
## Description

Dev fails four tests in `tests/test_viz/test_waterfall.py` (`TestCellExtents::test_gap_seam` and `TestExplicitWaterfallCells::test_physical_cells`). #1151 and #1152 each passed on their own, but they crossed when merged: #1151 added a waterfall path that passes a bare `gap_factor` float to `get_gap_edges`, and #1152 changed that argument to a `GapTolerance`. The mesh path already converts with `GapTolerance.samples(gap_factor)`. This PR does the same in the physical-cell path and updates the test's direct call.

## Changelog

- none

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [ ] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved gap detection in waterfall visualizations with irregularly spaced coordinates.
  * Gap sizing now respects the declared coordinate step for more accurate visualization around data gaps.
  * Ensured configured gap coloring continues to be applied consistently when displaying data gaps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->