### PR TITLE
Trim unwritten Terra15 rows regardless of timestamp snapping

### DIFF
--- a/dascore/io/terra15/__init__.py
+++ b/dascore/io/terra15/__init__.py
@@ -16,6 +16,8 @@ from the ``dT`` attribute, so DASCore regularizes them as follows:
 
 3. Convert ``gps_time[0]`` and ``gps_time[-1]`` to ``datetime64`` scan bounds.
 
+Unwritten trailing rows with zero-filled timestamps are excluded whether snapping is enabled or disabled. Passing ``snap=False`` (or ``snap_dims=False`` to `read`) preserves the written samples' raw timestamps.
+
 The scan bounds must exactly match the loaded patch's ``time_min`` and ``time_max``.
 """
 from __future__ import annotations

--- a/dascore/io/terra15/core.py
+++ b/dascore/io/terra15/core.py
@@ -114,20 +114,15 @@ class Terra15FormatterV4(FiberIO):
 
         Besides the requested block, only the time node's ends and the
         header are read (the whole time node for an unfinished file, to
-        count the rows it actually wrote). ``snap`` selects the grid, and
-        unlike other formats it decides how many rows there are: snapped,
-        they stop at the last written sample; raw, every stored row
-        counts, as the raw time coordinate does. ``read`` calls the same
-        option ``snap_dims``, so both spellings are taken, and ``snap``
-        wins when both are given, as it does in `read`.
+        count the rows it actually wrote). Unwritten trailing rows are
+        always excluded. ``snap`` and ``snap_dims`` are accepted for
+        consistency with `read`; timestamp regularization does not affect
+        positional array windows.
         """
         raise_on_extra_kwargs(kwargs, "windows, snap and snap_dims")
-        snap = _resolve_snap(snap, snap_dims)
         _, data_node = _get_version_data_node(resource)
         data = data_node["data"]
-        time_len = data.shape[0]
-        if snap:
-            _, _, time_len, _ = _get_scanned_time_info(data_node)
+        _, _, time_len, _ = _get_scanned_time_info(data_node)
         shape = (time_len, len(_get_distance_coord(resource)))
         return slice_dataset(data, ("time", "distance"), windows, shape)
 

--- a/dascore/io/terra15/utils.py
+++ b/dascore/io/terra15/utils.py
@@ -103,9 +103,9 @@ def _scan_terra15(h5_fi, data_node, extras=None, snap=True) -> list[ScanPayload]
 # --- Reading patch
 
 
-def _get_raw_time_coord(data_node):
-    """Read the time from the data node and return it."""
-    time = _get_time_node(data_node)[:]
+def _get_raw_time_coord(data_node, time_len):
+    """Read timestamps for the written samples without regularizing them."""
+    time = _get_time_node(data_node)[:time_len]
     values = to_datetime64(time)
     return get_exact_coord(values, units="s")
 
@@ -175,11 +175,11 @@ def _get_default_attrs(root_node_attrs):
 
 def _get_time_coord(data_node, snap_dims=True):
     """Get the time coordinate."""
-    t_min, t_max, _time_len, d_time = _get_scanned_time_info(data_node)
+    t_min, t_max, time_len, d_time = _get_scanned_time_info(data_node)
     if snap_dims:
         time_coord = get_coord(start=t_min, stop=t_max + d_time, step=d_time, units="s")
     else:
-        time_coord = _get_raw_time_coord(data_node)
+        time_coord = _get_raw_time_coord(data_node, time_len)
     return time_coord
 
 

--- a/tests/test_io/test_terra15/test_terra15.py
+++ b/tests/test_io/test_terra15/test_terra15.py
@@ -14,6 +14,7 @@ import dascore as dc
 from dascore.io.core import FiberIO
 from dascore.io.terra15.core import Terra15FormatterV4
 from dascore.io.terra15.utils import _get_version_data_node
+from dascore.utils.time import to_datetime64
 
 
 class TestTerra15:
@@ -108,6 +109,26 @@ class TestTerra15Unfinished:
         time = patch_unfinished.coords.get_array("time")
         assert np.all(np.diff(time) >= np.timedelta64(0, "s"))
 
+    @pytest.mark.parametrize("snap", [False, True])
+    def test_read_and_scan_trim_unwritten_rows(self, terra15_das_unfinished_path, snap):
+        """Snapping changes timestamps, never which stored samples are valid."""
+        path = terra15_das_unfinished_path
+        with h5py.File(path) as resource:
+            _, node = _get_version_data_node(resource)
+            times = node["gps_time"][:]
+            count = np.count_nonzero(times > 0)
+            assert 0 < count < len(times)
+            assert np.all(times[count:] == 0)
+            expected_data = node["data"][:count]
+        patch = dc.read(path, snap=snap)[0]
+        np.testing.assert_array_equal(patch.data, expected_data)
+        if not snap:
+            np.testing.assert_array_equal(
+                patch.coords.get_array("time"), to_datetime64(times[:count])
+            )
+        payload = dc.scan_payloads(path, snap=snap)[0]
+        assert payload["coords"] == patch.coords
+
 
 class TestReadArray:
     """Tests for slicing the data node directly."""
@@ -125,35 +146,34 @@ class TestReadArray:
         tail = io.read_array(terra15_das_unfinished_path, {"time": (-3, 10**6)})
         assert np.array_equal(tail, patch.data[-3:])
 
-    def test_raw_grid_counts_every_row(self, terra15_das_unfinished_path):
-        """With snap_dims=False the window lives on the raw grid, as in read."""
+    @pytest.mark.parametrize("snap", [False, True])
+    def test_array_windows_trim_unwritten_rows(self, terra15_das_unfinished_path, snap):
+        """Array windows count from the written tail with either snap setting."""
         io = Terra15FormatterV4()
         path = terra15_das_unfinished_path
-        out = io.read_array(path, {"time": (-5, None)}, snap_dims=False)
-        expected = FiberIO.read_array(io, path, {"time": (-5, None)}, snap_dims=False)
+        out = io.read_array(path, {"time": (-5, None)}, snap_dims=snap)
+        expected = FiberIO.read_array(io, path, {"time": (-5, None)}, snap_dims=snap)
         assert np.array_equal(out, expected)
         assert len(out) == 5
-        raw = io.read_array(path, {}, snap_dims=False)
-        assert len(raw) > len(io.read_array(path, {}))
+        raw = io.read_array(path, {}, snap_dims=snap)
+        np.testing.assert_array_equal(raw, io.read_array(path, {}))
+        np.testing.assert_array_equal(out, raw[-5:])
 
     def test_both_spellings_agree(self, terra15_das_unfinished_path):
-        """`scan` calls it snap and `read` snap_dims; both are taken here.
-
-        The unfinished file is the one where the option changes how many
-        rows there are, so the two grids differ and a mix-up shows.
-        """
+        """Both snap spellings trim unwritten rows; snap wins for coordinates."""
         io = Terra15FormatterV4()
         path = terra15_das_unfinished_path
-        snapped = io.read_array(path, {})
-        raw = io.read_array(path, {}, snap=False)
-        assert len(raw) > len(snapped)
-        # either spelling alone selects the same grid
-        assert len(io.read_array(path, {}, snap_dims=False)) == len(raw)
-        assert len(io.read_array(path, {}, snap=True)) == len(snapped)
-        # given both, snap wins, in read_array and in read alike
-        assert len(io.read_array(path, {}, snap=True, snap_dims=False)) == len(snapped)
+        snapped = io.read(path, snap=True)[0]
+        for options in (
+            {"snap": False},
+            {"snap_dims": False},
+            {"snap": True, "snap_dims": False},
+        ):
+            np.testing.assert_array_equal(
+                io.read_array(path, {}, **options), snapped.data
+            )
         both = io.read(path, snap=True, snap_dims=False)[0]
-        assert len(both.get_coord("time")) == len(snapped)
+        assert both.coords == snapped.coords
 
     def test_reads_only_the_window(self, terra15_v6_path, monkeypatch):
         """The data node is sliced in the file, not read whole then trimmed."""


### PR DESCRIPTION
## Description

Unfinished Terra15 files allocate zero-filled rows beyond the last written sample. Reads with `snap=False` previously returned those rows, while snapped reads trimmed them. Both modes now trim to the same written extent; disabling snapping preserves the valid samples' raw timestamps. `read_array` uses that extent for positional windows, including negative indices.

The regression fixture now returns 3,420 written rows in either mode instead of returning 3,620 rows without snapping. Tests verify data and raw timestamp preservation, scan/read coordinate agreement, end-relative windows, and both snap spellings. The format documentation explains the behavior.

Validation: 14 Terra15 tests passed; the full suite with coverage passed with 12,233 passed, 152 skipped, and 2 xfailed; 227 doctests passed; all pre-commit checks passed. API generation and link validation passed, and both changed API pages rendered successfully. Full-site rendering was stopped; documentation validation is limited to the two changed API pages and the API/link checks.

## Changelog

- fixed: Terra15 readers exclude unwritten trailing rows even when timestamp snapping is disabled.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
