### PR TITLE
Apply OptoDAS dataScale when reading

### DIFF
--- a/dascore/io/optodas/core.py
+++ b/dascore/io/optodas/core.py
@@ -60,7 +60,12 @@ class OptoDASV8(FiberIO):
         distance: tuple[float | None, float | None] | None = None,
         **kwargs,
     ) -> dc.BaseSpool:
-        """Read a OptoDAS spool of patches."""
+        """Read an OptoDAS spool with values in the declared physical units.
+
+        The header's ``dataScale`` is applied to the selected samples for both
+        integer and floating-point storage. If absent, values are unchanged.
+        This decodes storage scaling only; it does not convert phase to strain.
+        """
         patches = _read_opto_das(
             resource, time=time, distance=distance, attr_cls=OptoDASPatchAttrs
         )

--- a/dascore/io/optodas/utils.py
+++ b/dascore/io/optodas/utils.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import numpy as np
+
 import dascore as dc
 import dascore.core
 from dascore.core.coords import get_coord
@@ -86,6 +88,11 @@ def _read_opto_das(fi, distance=None, time=None, attr_cls=dc.PatchAttrs):
     cm, data = coords.select(array=data_node, distance=distance, time=time)
     if not data.size:
         return []
+    if "dataScale" in fi["header"]:
+        scale = float(unpack_scalar_h5_dataset(fi["header/dataScale"]))
+        # Storage scaling applies to floating-point data as well as integers.
+        dtype = np.result_type(data.dtype, np.float32)
+        data = data.astype(dtype, copy=False) * scale
     attrs["coords"] = cm.to_summary_dict()
     attrs["dims"] = cm.dims
     return [dc.Patch(data=data, coords=cm, attrs=attr_cls(**attrs))]

--- a/tests/test_io/test_optodas/test_optodas.py
+++ b/tests/test_io/test_optodas/test_optodas.py
@@ -2,6 +2,12 @@
 Tests for optoDAS files.
 """
 
+import shutil
+
+import h5py
+import numpy as np
+import pytest
+
 import dascore as dc
 from dascore.io.optodas import OptoDASV8
 from dascore.utils.downloader import fetch
@@ -22,3 +28,52 @@ class TestOptoDASIssues:
         patch = spool[0]
         assert isinstance(patch, dc.Patch)
         assert patch.data.shape
+
+
+class TestDataScale:
+    """Storage scaling must produce values matching the declared units."""
+
+    @pytest.fixture
+    def scaled_file(self, tmp_path):
+        """Make a writable copy of the existing OptoDAS fixture."""
+        path = tmp_path / "scaled.hdf5"
+        shutil.copyfile(fetch("decimated_optodas.hdf5"), path)
+        return path
+
+    @pytest.mark.parametrize("version", [8, 9, 10, 11])
+    @pytest.mark.parametrize("dtype", ["int16", "float32", "float64"])
+    @pytest.mark.parametrize("scale", [0.004693713039159775, 1.0, None])
+    def test_scaled_values(self, scaled_file, dtype, scale, version):
+        """Scale all storage dtypes, preserving legacy files without a scale."""
+        with h5py.File(scaled_file, "r+") as fi:
+            shape = fi["data"].shape
+            values = np.resize(np.array([-12, 0, 7, 103], dtype=dtype), shape)
+            del fi["data"]
+            fi["data"] = values
+            del fi["fileVersion"]
+            fi["fileVersion"] = version
+            if "dataScale" in fi["header"]:
+                del fi["header/dataScale"]
+            if scale is not None:
+                fi["header/dataScale"] = scale
+        result = dc.read(scaled_file)[0]
+        expected = values.astype("float64") * (1.0 if scale is None else scale)
+        np.testing.assert_allclose(result.data, expected, rtol=1e-6)
+        expected_dtype = dtype if scale is None else np.result_type(dtype, np.float32)
+        assert result.data.dtype == expected_dtype
+        assert result.attrs.data_units == dc.scan(scaled_file)[0].data_units
+
+    def test_subset(self, scaled_file):
+        """Reading a subset scales exactly once and keeps coordinates aligned."""
+        with h5py.File(scaled_file, "r+") as fi:
+            fi["header/dataScale"][...] = 0.25
+            stored = fi["data"][:]
+        full = dc.read(scaled_file)[0]
+        np.testing.assert_allclose(full.data, stored.astype("float64") * 0.25)
+        bounds = {
+            dim: (full.get_array(dim)[1], full.get_array(dim)[-2]) for dim in full.dims
+        }
+        subset = dc.read(scaled_file, **bounds)[0]
+        expected = full.select(**bounds)
+        np.testing.assert_array_equal(subset.data, expected.data)
+        assert subset.coords == expected.coords


### PR DESCRIPTION
## Description

The OptoDAS reader previously returned stored sample values without applying header[dataScale], so amplitudes could disagree with the declared physical units.

Apply the scale after time/distance selection for both integer and floating-point data. Preserve floating-point precision through dtype promotion, and leave values unchanged when dataScale is absent. This change decodes storage scaling only; phase-to-strain conversion is unchanged.

Validation: 38 OptoDAS tests pass, covering versions 8–11, storage dtypes, missing/unit/non-unit scales, and subset reads. Verified against an Oslofjord recording; all pre-commit hooks pass.


## Checklist

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [X] documented the new feature with docstrings and/or appropriate doc page.
- [X] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [X] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OptoDAS data now correctly applies the header-provided scaling factor to both integer and floating-point samples.
  * Scaling is applied consistently when reading selected subsets of data, while preserving coordinate alignment and units.
  * Data remains unchanged when no scaling factor is provided.

* **Documentation**
  * Clarified that reading performs storage scaling only; phase-to-strain conversion is not included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->