### PR TITLE
Serve DASCore coordinates through a lazy xarray index

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -2,8 +2,9 @@
 Root pytest configuration.
 
 `dascore/xarray/index.py` subclasses xarray classes, so it cannot import
-without xarray; the doctest run (`pytest dascore --doctest-modules`) must
-skip collecting it where that optional dependency is absent.
+without xarray, and `dascore/xarray/patch.py` has examples which convert
+to xarray; the doctest run (`pytest dascore --doctest-modules`) must skip
+collecting both where that optional dependency is absent.
 """
 
 from __future__ import annotations
@@ -12,4 +13,4 @@ from importlib.util import find_spec
 
 collect_ignore: list[str] = []
 if find_spec("xarray") is None:
-    collect_ignore.append("dascore/xarray/index.py")
+    collect_ignore += ["dascore/xarray/index.py", "dascore/xarray/patch.py"]

--- a/dascore/core/coords.py
+++ b/dascore/core/coords.py
@@ -1201,6 +1201,10 @@ class BaseCoord(RichRepr, DascoreBaseModel, abc.ABC):
         """Return the internal data. Same as values attribute."""
         return self.values
 
+    def _get_index_values(self, indices):
+        """The labels at these (possibly negative) sample indices."""
+        return np.asarray(self.values)[np.asarray(indices)]
+
     def _get_compatible_value(self, value, relative=False):
         """
         Return values that are compatible with dtype/units of coord.
@@ -3167,6 +3171,19 @@ class CoordSegmented(BaseCoord):
         """Return the values of the coordinate as an array."""
         out = np.concatenate([x.values for x in self.segments])
         return array(out.astype(self.dtype, copy=False))
+
+    def _get_index_values(self, indices):
+        """Evaluate only the requested samples, each in its own segment."""
+        indices = np.asarray(indices)
+        indices = np.where(indices < 0, indices + len(self), indices)
+        offsets = self._segment_offsets()
+        which = np.searchsorted(offsets, indices, side="right") - 1
+        out = np.empty(indices.shape, dtype=self.dtype)
+        for num in np.unique(which):
+            mask = which == num
+            local = indices[mask] - offsets[num]
+            out[mask] = self.segments[num]._get_index_values(local)
+        return out
 
     def _as_monotonic(self) -> CoordMonotonicArray:
         """

--- a/dascore/utils/indexing.py
+++ b/dascore/utils/indexing.py
@@ -182,8 +182,12 @@ def _label_index(coord, probes, require_unique=False):
     size = len(coord)
     positions = np.unique([0, min(1, size - 1), max(0, size - 2), size - 1])
     anchor = pd.Index(coord._get_index_values(positions))
-    if require_unique and isinstance(coord, CoordRange):
-        _require_unique_range(coord)
+    if require_unique:
+        # pandas needs every label unique, not just those near the probes;
+        # array segments are strictly monotonic, so only ranges can repeat
+        for part in getattr(coord, "segments", (coord,)):
+            if isinstance(part, CoordRange):
+                _require_unique_range(part)
     pieces = [positions]
     values = np.asarray(probes)
     for side in ("left", "right"):

--- a/dascore/utils/indexing.py
+++ b/dascore/utils/indexing.py
@@ -10,7 +10,7 @@ from typing import Any, Literal
 import numpy as np
 import pandas as pd
 
-from dascore.core.coords import BaseCoord, CoordRange
+from dascore.core.coords import BaseCoord, CoordRange, CoordSegmented
 from dascore.utils.time import dtype_time_like, to_timedelta64
 
 
@@ -100,7 +100,7 @@ def _range_searchsorted(coord, bounds, side):
             positions = size - 1 - positions
         return coord._get_index_values(positions)
 
-    if bounds.dtype.kind in "iufmM" and coord.step:
+    if bounds.dtype.kind in "iufmM" and isinstance(coord, CoordRange) and coord.step:
         # Reuse select's arithmetic lookup, but verify its bracket against
         # actual labels: grid rounding may move an estimate by a sample.
         estimate = _range_estimate(coord, bounds)
@@ -122,6 +122,14 @@ def _range_searchsorted(coord, bounds, side):
 def _require_unique_range(coord):
     """Check range uniqueness without an unbounded scan of floating labels."""
     size = len(coord)
+    if coord._exact:
+        # integer labels repeat only on a zero step; construction refuses
+        # a step finer than one tick
+        if size > 1 and not coord.step_numerator:
+            raise pd.errors.InvalidIndexError(
+                "Range labels repeat on a zero step; use positional indexing instead."
+            )
+        return
     if size > 1 and np.dtype(coord.dtype).kind not in "mM":
         endpoints = np.asarray([coord.start, coord.stop - coord.step])
         dtype = np.result_type(endpoints, 0.0)
@@ -139,6 +147,12 @@ def _require_unique_range(coord):
                 )
 
 
+_NOT_FOUND = (
+    "Not all requested labels were found in the coordinate; pass "
+    "method='nearest' to take the nearest samples."
+)
+
+
 def _exact_range_indexer(coord, labels):
     """Resolve exact label arrays using bounded coordinate lookup."""
     # Numeric exact arrays already carry their labels. Resolve positions
@@ -153,21 +167,22 @@ def _exact_range_indexer(coord, labels):
     if np.any(missing):
         found = _range_searchsorted(coord, labels[missing], "left")
         if np.any(found == len(coord)):
-            raise KeyError("Not all requested labels were found in the coordinate.")
+            raise KeyError(_NOT_FOUND)
         positions[missing] = len(coord) - 1 - found if coord.reverse_sorted else found
     if not np.array_equal(coord._get_index_values(positions), labels):
-        raise KeyError("Not all requested labels were found in the coordinate.")
+        raise KeyError(_NOT_FOUND)
     return positions
 
 
 def _label_index(coord, probes, require_unique=False):
     """Use stored labels or query-sized samples; never expand a compact grid."""
-    if not isinstance(coord, CoordRange):
+    # a segmented coordinate is searched like a range, run by run
+    if not isinstance(coord, CoordRange | CoordSegmented):
         return pd.Index(coord.values), None
     size = len(coord)
     positions = np.unique([0, min(1, size - 1), max(0, size - 2), size - 1])
     anchor = pd.Index(coord._get_index_values(positions))
-    if require_unique:
+    if require_unique and isinstance(coord, CoordRange):
         _require_unique_range(coord)
     pieces = [positions]
     values = np.asarray(probes)
@@ -184,13 +199,13 @@ def _label_index(coord, probes, require_unique=False):
                 try:
                     bound = anchor._maybe_cast_slice_bound(probe, side)
                     anchor[0] < bound  # Validate mixed types before batching.
-                except (TypeError, ValueError):
+                except (TypeError, ValueError, OverflowError):
                     continue  # The final pandas lookup reports invalid labels.
                 bounds.append(bound)
             bounds = pd.Index(bounds).to_numpy()
         try:
             found = _range_searchsorted(coord, bounds, side)
-        except (TypeError, ValueError):
+        except (TypeError, ValueError, OverflowError):
             continue
         neighbors = np.concatenate([found - 1, found])
         neighbors = neighbors[(neighbors >= 0) & (neighbors < size)]
@@ -216,9 +231,23 @@ def _restore_indexer(indexer, positions):
     return slice(int(span[0]), None if stop < 0 else stop, step)
 
 
+def _unique_grid(coord) -> bool:
+    """Whether a range is an integer grid of distinct labels."""
+    return coord._exact and bool(coord.step_numerator)
+
+
+def _same_kind(coord, labels) -> bool:
+    """Whether labels are compared with a range's own integer arithmetic."""
+    if dtype_time_like(coord.dtype):
+        # another unit would be converted to nanoseconds, which can wrap
+        return labels.dtype == np.dtype(coord.dtype)
+    return labels.dtype.kind in "iu"
+
+
 def _exact_slice(coord, start, stop, step) -> slice | None:
     """A label slice on an ascending integer grid, or None to ask pandas."""
-    if not (isinstance(coord, CoordRange) and coord._exact and coord.sorted):
+    ascending = isinstance(coord, CoordRange) and coord._exact
+    if not (ascending and coord.step_numerator > 0):
         return None
     # np.timedelta64 subclasses np.integer, so a duration step is refused here
     step_ok = step is None or (
@@ -226,9 +255,8 @@ def _exact_slice(coord, start, stop, step) -> slice | None:
         and not isinstance(step, np.timedelta64)
         and step > 0
     )
-    kinds = np.dtype(coord.dtype).kind if dtype_time_like(coord.dtype) else "iu"
     bounds = [np.asarray(x) for x in (start, stop) if x is not None]
-    if not step_ok or any(x.dtype.kind not in kinds or pd.isnull(x) for x in bounds):
+    if not step_ok or any(not _same_kind(coord, x) or pd.isnull(x) for x in bounds):
         return None
     if start is not None and stop is not None and start > stop:
         return slice(0, 0, step)  # select would swap them; pandas selects nothing
@@ -263,6 +291,8 @@ def label_indexer(
             raise NotImplementedError(
                 "method and tolerance are not supported with slices."
             )
+        if value.step == 0:
+            raise ValueError("slice step cannot be zero")
         start, stop = compatible(value.start), compatible(value.stop)
         if (fast := _exact_slice(coord, start, stop, value.step)) is not None:
             return fast
@@ -288,13 +318,13 @@ def label_indexer(
             tolerance = compatible(tolerance)
     if (
         isinstance(coord, CoordRange)
-        # a scalar on an integer grid, whose labels cannot repeat
-        and (labels.ndim == 1 or (labels.ndim == 0 and coord._exact))
+        # a scalar only on an integer grid whose labels cannot repeat
+        and (labels.ndim == 1 or (labels.ndim == 0 and _unique_grid(coord)))
         and method is None
         and tolerance is None
         and labels.dtype.kind in "iufmM"
         and (
-            labels.dtype.kind == np.dtype(coord.dtype).kind
+            labels.dtype == np.dtype(coord.dtype)
             if np.dtype(coord.dtype).kind in "mM"
             else labels.dtype.kind in "iuf"
         )

--- a/dascore/utils/indexing.py
+++ b/dascore/utils/indexing.py
@@ -11,7 +11,7 @@ import numpy as np
 import pandas as pd
 
 from dascore.core.coords import BaseCoord, CoordRange
-from dascore.utils.time import to_timedelta64
+from dascore.utils.time import dtype_time_like, to_timedelta64
 
 
 def get_indexers(
@@ -216,6 +216,27 @@ def _restore_indexer(indexer, positions):
     return slice(int(span[0]), None if stop < 0 else stop, step)
 
 
+def _exact_slice(coord, start, stop, step) -> slice | None:
+    """A label slice on an ascending integer grid, or None to ask pandas."""
+    if not (isinstance(coord, CoordRange) and coord._exact and coord.sorted):
+        return None
+    # np.timedelta64 subclasses np.integer, so a duration step is refused here
+    step_ok = step is None or (
+        isinstance(step, int | np.integer)
+        and not isinstance(step, np.timedelta64)
+        and step > 0
+    )
+    kinds = np.dtype(coord.dtype).kind if dtype_time_like(coord.dtype) else "iu"
+    bounds = [np.asarray(x) for x in (start, stop) if x is not None]
+    if not step_ok or any(x.dtype.kind not in kinds or pd.isnull(x) for x in bounds):
+        return None
+    if start is not None and stop is not None and start > stop:
+        return slice(0, 0, step)  # select would swap them; pandas selects nothing
+    # select keeps every sample within the inclusive bounds, as pandas does
+    _, indexer = coord.select((start, stop))
+    return slice(indexer.start, indexer.stop, step)
+
+
 def label_indexer(
     coord: BaseCoord,
     value: Any,
@@ -243,6 +264,8 @@ def label_indexer(
                 "method and tolerance are not supported with slices."
             )
         start, stop = compatible(value.start), compatible(value.stop)
+        if (fast := _exact_slice(coord, start, stop, value.step)) is not None:
+            return fast
         index, positions = _label_index(coord, (start, stop))
         result = index.slice_indexer(start, stop, value.step)
         if not isinstance(result, slice):
@@ -265,7 +288,8 @@ def label_indexer(
             tolerance = compatible(tolerance)
     if (
         isinstance(coord, CoordRange)
-        and labels.ndim == 1
+        # a scalar on an integer grid, whose labels cannot repeat
+        and (labels.ndim == 1 or (labels.ndim == 0 and coord._exact))
         and method is None
         and tolerance is None
         and labels.dtype.kind in "iufmM"
@@ -275,7 +299,8 @@ def label_indexer(
             else labels.dtype.kind in "iuf"
         )
     ):
-        return _exact_range_indexer(coord, labels)
+        positions = _exact_range_indexer(coord, np.atleast_1d(labels))
+        return int(positions[0]) if labels.ndim == 0 else positions
     index, positions = _label_index(
         coord,
         np.atleast_1d(labels),

--- a/dascore/xarray/accessor.py
+++ b/dascore/xarray/accessor.py
@@ -78,6 +78,9 @@ def _stated_coords(*values) -> set[str]:
     away from the rest, whichever of the two is called on.
     """
     xr = optional_import("xarray")
+    # function-level: importing the index imports xarray
+    from dascore.xarray.index import CoordIndex  # noqa: PLC0415
+
     stated, spelled_out = set(), set()
     for value in values:
         if not isinstance(value, xr.DataArray):
@@ -85,7 +88,7 @@ def _stated_coords(*values) -> set[str]:
         names = {
             name
             for name, index in value.xindexes.items()
-            if hasattr(getattr(index, "transform", None), "start_ns")
+            if isinstance(index, CoordIndex)
         }
         stated.update(names)
         spelled_out.update(set(value.xindexes) - names)

--- a/dascore/xarray/accessor.py
+++ b/dascore/xarray/accessor.py
@@ -108,8 +108,9 @@ def _as_xarray(value, lazy: set[str]):
     Whether a coordinate is spelled out belongs to the object, not to
     the conversion: a coordinate which arrived stated goes back stated,
     and every other keeps the eager index xarray aligns arithmetic on --
-    including a temporal one beside it, which is why the coordinates are
-    named rather than the array being called lazy as a whole. The
+    even one `CoordIndex` could serve, beside it, which is why the
+    coordinates are named rather than the array being called lazy as a
+    whole. The
     conversion is told which names, so one a tree never spelled out is
     not spelled out on the way back either.
 

--- a/dascore/xarray/index.py
+++ b/dascore/xarray/index.py
@@ -34,10 +34,12 @@ from dascore.core.coords import (
     CoordRange,
     CoordSegmented,
     concat_coords,
+    get_coord,
 )
 from dascore.exceptions import CoordError
 from dascore.utils.indexing import label_indexer, positional_indexer
 from dascore.utils.misc import is_strictly_monotonic
+from dascore.utils.time import dtype_time_like
 
 
 def is_servable(coord) -> bool:
@@ -161,6 +163,33 @@ class CoordIndex(CoordinateTransformIndex):
     """
 
     transform: CoordTransform
+
+    @classmethod
+    def from_variables(cls, variables, *, options) -> CoordIndex:
+        """
+        Build from a coordinate variable, as ``set_xindex`` asks.
+
+        Lets an array whose index holds its labels take this index type,
+        so it aligns with a lazy array without reading that array's labels:
+        ``other.drop_indexes("time").set_xindex("time", CoordIndex)``.
+        Evenly sampled labels become a range; others are held as they are.
+        """
+        if len(variables) != 1:
+            msg = f"CoordIndex serves one coordinate, got {list(variables)}."
+            raise ValueError(msg)
+        ((name, variable),) = variables.items()
+        if variable.ndim != 1:
+            msg = f"CoordIndex serves a one-dimensional coordinate, not {name!r}."
+            raise ValueError(msg)
+        values = np.asarray(variable.values)
+        units = variable.attrs.get("units")
+        coord = get_coord(data=values)
+        # a range is kept only where it reproduces the labels exactly
+        if not np.array_equal(coord._get_index_values(np.arange(len(coord))), values):
+            coord = _array_coord(values, None)
+        if units is not None and not dtype_time_like(coord.dtype):
+            coord = coord.set_units(units)
+        return cls(CoordTransform(name, coord, variable.dims[0]))
 
     @classmethod
     def from_coord(cls, name: str, coord: BaseCoord) -> CoordIndex:

--- a/dascore/xarray/index.py
+++ b/dascore/xarray/index.py
@@ -7,10 +7,11 @@ sample before any data loads — a year of millisecond sampling is a
 quarter terabyte of labels. `CoordIndex` holds the DASCore coordinate
 itself instead: an evenly sampled range (an exact integer grid for
 nanosecond time and integers, a scalar step for floats) or a segmented
-coordinate of such runs. Labels are the coordinate's own, computed for
-the positions asked about; selection follows the rules `Patch.sel`
-follows, which are pandas'; and a slice or an abutting concatenation is
-again a coordinate, so laziness survives selection chains.
+coordinate, whose segments may be ranges or monotonic arrays. Labels are
+the coordinate's own, computed for the positions asked about; selection
+follows the rules `Patch.sel` follows, which are pandas'; and a slice or
+an abutting concatenation of an integer grid is again a coordinate, so
+laziness survives selection chains.
 
 Everything here is imported only behind the optional xarray dependency.
 """
@@ -26,9 +27,17 @@ from xarray import DataArray, Variable
 from xarray.core.indexes import IndexSelResult
 from xarray.indexes import CoordinateTransform, CoordinateTransformIndex, PandasIndex
 
-from dascore.core.coords import BaseCoord, CoordRange, CoordSegmented, concat_coords
+from dascore.core.coords import (
+    BaseCoord,
+    CoordArray,
+    CoordMonotonicArray,
+    CoordRange,
+    CoordSegmented,
+    concat_coords,
+)
 from dascore.exceptions import CoordError
-from dascore.utils.indexing import label_indexer
+from dascore.utils.indexing import label_indexer, positional_indexer
+from dascore.utils.misc import is_strictly_monotonic
 
 
 def is_servable(coord) -> bool:
@@ -37,6 +46,22 @@ def is_servable(coord) -> bool:
         return True
     # a zero step repeats one label, which no index can look up
     return isinstance(coord, CoordRange) and bool(coord.step)
+
+
+def _relabels_exactly(coord) -> bool:
+    """Whether slices of a coordinate keep exactly the labels they select."""
+    # a float range recomputes a slice's labels from its new start, which
+    # can move them in the last bits, and then they no longer align
+    if isinstance(coord, CoordSegmented):
+        return all(_relabels_exactly(x) for x in coord.segments)
+    return not isinstance(coord, CoordRange) or coord._exact
+
+
+def _array_coord(labels, units) -> BaseCoord:
+    """Labels held as they are, never re-inferred as a range."""
+    monotonic = len(labels) > 1 and is_strictly_monotonic(labels)
+    cls = CoordMonotonicArray if monotonic else CoordArray
+    return cls(values=labels, units=units)
 
 
 def _as_pandas(index) -> PandasIndex:
@@ -68,7 +93,7 @@ def _chained(coords: list[BaseCoord]) -> BaseCoord | None:
     # concat_coords orders its inputs; xarray's order is the data's
     starts = [x.min() if out.sorted else x.max() for x in coords]
     ordered = all((a < b) if out.sorted else (a > b) for a, b in pairwise(starts))
-    return out if ordered and is_servable(out) else None
+    return out if ordered and is_servable(out) and _relabels_exactly(out) else None
 
 
 class CoordTransform(CoordinateTransform):
@@ -80,8 +105,9 @@ class CoordTransform(CoordinateTransform):
     contract asks. `CoordIndex` selects through `label_indexer` instead.
     """
 
-    def __init__(self, name: str, coord: BaseCoord):
-        super().__init__((name,), {name: len(coord)}, dtype=np.dtype(coord.dtype))
+    def __init__(self, name, coord: BaseCoord, dim: str | None = None):
+        dim = name if dim is None else dim
+        super().__init__((name,), {dim: len(coord)}, dtype=np.dtype(coord.dtype))
         self.coord = coord
 
     @property
@@ -104,7 +130,7 @@ class CoordTransform(CoordinateTransform):
         return {self.dim: np.asarray(positions, dtype=np.float64)}
 
     def equals(self, other, exclude=None, **kwargs) -> bool:
-        """Two transforms are equal when they label every sample alike."""
+        """Two transforms are equal when they label every sample alike, units aside."""
         return (
             isinstance(other, CoordTransform)
             and self.dims == other.dims
@@ -118,22 +144,20 @@ class CoordIndex(CoordinateTransformIndex):
 
     Selection answers as `Patch.sel` answers, which is as a materialized
     pandas index answers: partial datetime strings name their periods,
-    slices keep their endpoints, and ``method`` and ``tolerance`` work as
-    pandas has them. A slice ``isel`` or a concatenation whose parts
-    chain returns a new lazy index; fancy indexing, or a concatenation
-    which reorders or overlaps, falls back to a materialized pandas index
-    over just the labels concerned. Aligning with a different index
-    materializes both, as aligning materialized indexes costs.
+    slices include both endpoints, and ``method`` and ``tolerance`` work
+    as pandas has them. A slice ``isel`` or a concatenation whose parts
+    chain returns a new lazy index; fancy indexing, an empty slice, a
+    slice whose labels a coordinate would recompute (a float range, or a
+    stride over segments), or a concatenation which reorders or overlaps
+    holds just the labels concerned, still as a `CoordIndex`, so arrays
+    derived from one another align. Aligning with a `CoordIndex` whose
+    labels differ materializes both, costing what aligning materialized
+    indexes costs.
 
-    An index matches only indexes of its own type: combining a lazy array
-    with one whose index is materialized raises xarray's AlignmentError
-    even where the labels agree. Convert with ``lazy_coords=False`` to
-    combine with such arrays.
-
-    A segmented coordinate's labels are evaluated in full for each label
-    selection on it, and not kept. A slice of a float range is labeled as
-    DASCore labels it, which can differ from the parent's labels in the
-    last bits.
+    xarray matches an index only with indexes of its own type: combining
+    a lazy array with one whose index is materialized, or reindexing it
+    to new labels, raises xarray's AlignmentError even where the labels
+    agree. Convert with ``lazy_coords=False`` for those.
     """
 
     transform: CoordTransform
@@ -154,59 +178,76 @@ class CoordIndex(CoordinateTransformIndex):
         """The dimension the index labels."""
         return self.transform.dim
 
-    def _positions(self, positions) -> PandasIndex:
-        """A materialized index over the labels at these positions."""
-        labels = self.transform.forward({self.dim: np.asarray(positions)})
-        return PandasIndex(pd.Index(labels[self.transform.coord_names[0]]), self.dim)
+    @property
+    def index(self) -> pd.Index:
+        """The materialized pandas form, as a `PandasIndex` offers it."""
+        # xarray's own indexes read these when a materialized part comes
+        # first in a concatenation
+        return self.to_pandas_index()
+
+    @property
+    def coord_dtype(self) -> np.dtype:
+        """The label dtype, as a `PandasIndex` offers it."""
+        return self.transform.dtype
+
+    def _with(self, coord: BaseCoord) -> CoordIndex:
+        """An index serving another coordinate under these names."""
+        name = self.transform.coord_names[0]
+        return type(self)(CoordTransform(name, coord, self.dim))
+
+    def _labels(self, positions) -> np.ndarray:
+        """The labels at these positions."""
+        name = self.transform.coord_names[0]
+        return self.transform.forward({self.dim: np.asarray(positions)})[name]
+
+    def _picked(self, positions) -> CoordIndex:
+        """An index holding the labels at these positions."""
+        # still a CoordIndex, which xarray aligns with this one
+        return self._with(_array_coord(self._labels(positions), self.coordinate.units))
 
     def to_pandas_index(self) -> pd.Index:
         """The materialized pandas form, computed on demand."""
-        return self._positions(np.arange(len(self.coordinate))).index
+        labels = self._labels(np.arange(len(self.coordinate)))
+        return pd.Index(labels, name=self.transform.coord_names[0])
 
     def isel(self, indexers) -> Any:
-        """A sliced view keeps a lazy index; fancy indexing materializes."""
+        """A slice keeps a lazy index where its labels stay exact; else materialize."""
         idx = indexers.get(self.dim)
         coord = self.coordinate
         if isinstance(idx, slice):
             start, stop, stride = idx.indices(len(coord))
             positions = range(start, stop, stride)
             # a strided segmented coordinate is an array of its labels
-            if len(positions) and (isinstance(coord, CoordRange) or stride == 1):
-                name = self.transform.coord_names[0]
-                return type(self)(CoordTransform(name, coord[idx]))
-            return self._positions(np.asarray(positions, dtype=np.int64))
+            lazy = isinstance(coord, CoordRange) or stride == 1
+            if len(positions) and lazy and _relabels_exactly(coord):
+                return self._with(coord[idx])
+            return self._picked(np.asarray(positions, dtype=np.int64))
         if getattr(idx, "dims", (self.dim,)) != (self.dim,):
             # vectorized onto another dimension: the labels no longer
             # index this one, so xarray drops the index
             return None
-        positions = np.asarray(getattr(idx, "values", idx))
-        if isinstance(idx, list | tuple) and not len(idx):
-            positions = positions.astype(np.int64)  # an empty list picks nothing
-        if positions.ndim != 1:
+        raw = idx.values if isinstance(idx, Variable | DataArray) else idx
+        if np.ndim(raw) != 1:
             return None
-        if positions.dtype == bool:
-            positions = np.flatnonzero(positions)
-        if positions.dtype.kind not in "iu":
-            # as numpy refuses them for the data; forward would round them
-            msg = "arrays used as indices must be of integer (or boolean) type"
-            raise IndexError(msg)
-        return self._positions(positions)
+        return self._picked(positional_indexer(raw, len(coord)))
 
     def sel(self, labels, method=None, tolerance=None) -> IndexSelResult:
         """Resolve label selection as `Patch.sel` does."""
-        label = labels[self.dim]
+        label = labels[self.transform.coord_names[0]]
         coord = self.coordinate
-        if isinstance(coord, CoordSegmented):
-            # evaluated for this lookup only; the coordinate keeps no values
-            coord = coord.new(values=coord._get_index_values(np.arange(len(coord))))
+        if isinstance(label, Variable | DataArray) and label.ndim == 0:
+            label = label.values[()]  # a scalar, strings naming their periods
         if not isinstance(label, Variable | DataArray):
             return IndexSelResult(
                 {self.dim: label_indexer(coord, label, method, tolerance)}
             )
-        # vectorized selection: look up the values, keep the label's dims
+        # vectorized selection: look up the values, keep the label's dims;
+        # a mask selects as it stands
         values = np.asarray(label.values)
-        found = label_indexer(coord, values.ravel(), method, tolerance)
-        pos = np.asarray(found).reshape(values.shape)
+        pos = values
+        if values.dtype != bool:
+            found = label_indexer(coord, values.ravel(), method, tolerance)
+            pos = np.asarray(found).reshape(values.shape)
         if isinstance(label, DataArray):
             return IndexSelResult({self.dim: label.copy(data=pos)})
         return IndexSelResult({self.dim: Variable(label.dims, pos)})
@@ -219,15 +260,22 @@ class CoordIndex(CoordinateTransformIndex):
         Parts in ascending (or descending) order with no overlap chain
         into one range when they continue each other's grid and into a
         segmented coordinate otherwise; anything else — a reordering, an
-        overlap, a materialized part — comes back as a pandas index over
-        the concatenated labels.
+        overlap, a materialized part, float ranges whose fused labels
+        would be recomputed — comes back as a pandas index over the
+        concatenated labels.
         """
-        if positions is None and all(isinstance(x, CoordIndex) for x in indexes):
-            coords = [x.coordinate for x in indexes]
-            if (out := _chained(coords)) is not None:
-                name = indexes[0].transform.coord_names[0]
-                return cls(CoordTransform(name, out))
-        return PandasIndex.concat([_as_pandas(x) for x in indexes], dim, positions)
+        if not all(isinstance(x, CoordIndex) for x in indexes):
+            return PandasIndex.concat([_as_pandas(x) for x in indexes], dim, positions)
+        first = indexes[0]
+        coords = [x.coordinate for x in indexes]
+        if positions is None and (out := _chained(coords)) is not None:
+            return first._with(out)
+        labels = np.concatenate(
+            [x._labels(np.arange(len(x.coordinate))) for x in indexes]
+        )
+        if positions is not None:
+            labels = labels[np.argsort(np.concatenate([list(x) for x in positions]))]
+        return first._with(_array_coord(labels, first.coordinate.units))
 
     def join(self, other, how="inner") -> PandasIndex:
         """Join as materialized indexes join."""

--- a/dascore/xarray/index.py
+++ b/dascore/xarray/index.py
@@ -1,18 +1,16 @@
 """
-A lazy, evenly sampled datetime/timedelta index for xarray.
+A lazy xarray index over a DASCore coordinate.
 
 xarray materializes every dimension coordinate into a numpy array and a
 pandas index, which for a long merged time coordinate costs 8 bytes a
 sample before any data loads — a year of millisecond sampling is a
-quarter terabyte of labels. pandas has no computed-on-demand datetime
-index (``freq`` is metadata on a fully allocated array), so xarray grew
-the ``CoordinateTransform`` machinery instead; its own ``RangeIndex``
-serves lazy float labels on top of it. This module supplies the
-temporal counterpart: labels are ``start + i * step`` computed from the
-position on demand, and selection inverts that arithmetic exactly in
-python integers — int64 subtraction of a far-away label wraps around,
-and float inversion loses sample precision once offsets pass 2**53 ns,
-about 104 days.
+quarter terabyte of labels. `CoordIndex` holds the DASCore coordinate
+itself instead: an evenly sampled range (an exact integer grid for
+nanosecond time and integers, a scalar step for floats) or a segmented
+coordinate of such runs. Labels are the coordinate's own, computed for
+the positions asked about; selection follows the rules `Patch.sel`
+follows, which are pandas'; and a slice or an abutting concatenation is
+again a coordinate, so laziness survives selection chains.
 
 Everything here is imported only behind the optional xarray dependency.
 """
@@ -26,401 +24,224 @@ import numpy as np
 import pandas as pd
 from xarray import DataArray, Variable
 from xarray.core.indexes import IndexSelResult
-from xarray.indexes import CoordinateTransform, CoordinateTransformIndex
+from xarray.indexes import CoordinateTransform, CoordinateTransformIndex, PandasIndex
 
-_NAT_I8 = np.iinfo("int64").min
-
-# pandas' Resolution ranks, finest first; a partial datetime string
-# names a span only when its resolution is coarser than the index's
-_PERIOD_RESO = {
-    "ns": 0,
-    "us": 1,
-    "ms": 2,
-    "s": 3,
-    "min": 4,
-    "h": 5,
-    "D": 6,
-    "M": 7,
-    "Q": 8,
-    "Y": 9,
-}
-_UNIT_NS = (1_000, 10**6, 10**9, 60 * 10**9, 3_600 * 10**9, 86_400 * 10**9)
+from dascore.core.coords import BaseCoord, CoordRange, CoordSegmented, concat_coords
+from dascore.exceptions import CoordError
+from dascore.utils.indexing import label_indexer
 
 
-def _ns_resolution(value: int) -> int:
-    """The finest unit with a nonzero component in ``value`` (day at most)."""
-    for rank, divisor in enumerate(_UNIT_NS):
-        if value % divisor:
-            return rank
-    return _PERIOD_RESO["D"]
+def is_servable(coord) -> bool:
+    """Whether `CoordIndex` can serve a coordinate's labels."""
+    if isinstance(coord, CoordSegmented):
+        return True
+    # a zero step repeats one label, which no index can look up
+    return isinstance(coord, CoordRange) and bool(coord.step)
 
 
-def _label_ints(labels: np.ndarray, dtype) -> np.ndarray:
-    """Labels as exact python-int nanoseconds, refusing NaT."""
-    arr = np.atleast_1d(np.asarray(labels))
-    if arr.dtype.kind in "biufc":
-        # pandas never reads a number as a stamp; a materialized twin
-        # raises here, so the lazy index must not select the epoch
-        msg = f"Numeric label(s) {labels!r} do not name {np.dtype(dtype)} samples."
-        raise KeyError(msg)
-    if arr.dtype == np.dtype(dtype):
-        ints = arr.view("int64")
-    else:
-        # pandas raises for values the ns range cannot represent, where a
-        # raw astype would silently wrap a year-2500 label into 1915; the
-        # explicit ns astype matters too, since pandas keeps a coarser
-        # input unit and its int64 form would then be in that unit
-        kind = np.dtype(dtype).kind
-        converter = pd.to_timedelta if kind == "m" else pd.to_datetime
-        try:
-            converted = converter(arr.ravel())
-        except ValueError as err:
-            msg = f"Label(s) {labels!r} do not name {np.dtype(dtype)} samples."
-            raise KeyError(msg) from err
-        converted = converted.astype(np.dtype(dtype))
-        ints = np.asarray(converted.astype("int64")).reshape(arr.shape)
-    if np.any(ints == _NAT_I8):
-        msg = "Cannot select with NaT labels on an evenly sampled coordinate."
-        raise ValueError(msg)
-    # python ints: label arithmetic must not wrap for far-away labels
-    return ints.astype(object)
+def _as_pandas(index) -> PandasIndex:
+    """The materialized form of any one-dimensional index."""
+    if isinstance(index, PandasIndex):
+        return index
+    return PandasIndex(index.to_pandas_index(), index.dim)
 
 
-class TemporalRangeTransform(CoordinateTransform):
+def _same_labels(first: BaseCoord, second: BaseCoord) -> bool:
+    """Whether two coordinates label their samples alike, units aside."""
+    if first is second:
+        return True
+    if len(first) != len(second) or first.dtype != second.dtype:
+        return False
+    if first.units != second.units:
+        # xarray states units as an attribute beside the labels, so an
+        # index compares labels only, as a materialized index does
+        first, second = first.set_units(None), second.set_units(None)
+    return first.fingerprint() == second.fingerprint()
+
+
+def _chained(coords: list[BaseCoord]) -> BaseCoord | None:
+    """The coordinates end to end, or None if they do not chain in this order."""
+    try:
+        out = concat_coords(*coords)
+    except CoordError:
+        return None
+    # concat_coords orders its inputs; xarray's order is the data's
+    starts = [x.min() if out.sorted else x.max() for x in coords]
+    ordered = all((a < b) if out.sorted else (a > b) for a, b in pairwise(starts))
+    return out if ordered and is_servable(out) else None
+
+
+class CoordTransform(CoordinateTransform):
     """
-    Positions to evenly sampled datetime64/timedelta64 labels and back.
+    Positions to the labels of a DASCore coordinate, and back.
 
-    ``forward`` is exact int64 (positions are valid, so no overflow);
-    ``reverse`` computes through python integers, so a label centuries
-    away yields its true out-of-range position instead of wrapping — but
-    returns float positions, as xarray's transform contract asks, so its
-    callers accept float rounding; the index's own selection paths use
-    `_exact_positions` instead.
+    ``forward`` evaluates only the positions asked for; ``reverse``
+    returns the nearest sample as a float position, as xarray's transform
+    contract asks. `CoordIndex` selects through `label_indexer` instead.
     """
 
-    def __init__(self, name: str, size: int, start_ns: int, step_ns: int, dtype):
-        super().__init__((name,), {name: int(size)}, dtype=np.dtype(dtype))
-        self.name = name
-        self.start_ns = int(start_ns)
-        self.step_ns = int(step_ns)
+    def __init__(self, name: str, coord: BaseCoord):
+        super().__init__((name,), {name: len(coord)}, dtype=np.dtype(coord.dtype))
+        self.coord = coord
+
+    @property
+    def dim(self) -> str:
+        """The dimension the coordinate labels."""
+        return self.dims[0]
 
     def forward(self, dim_positions) -> dict:
         """Return the labels for the given positions."""
-        pos = np.asarray(dim_positions[self.name])
+        pos = np.asarray(dim_positions[self.dim])
         if pos.dtype.kind == "f":
-            # rounding through float would corrupt exact positions past
-            # 2**53, so only genuinely fractional input goes through it
             pos = np.rint(pos)
-        ints = self.start_ns + pos.astype("int64") * self.step_ns
-        return {self.name: ints.astype("int64").view(self.dtype)}
+        labels = self.coord._get_index_values(pos.astype(np.int64))
+        return {self.coord_names[0]: labels}
 
     def reverse(self, coord_labels) -> dict:
-        """Return the (float) positions for the given labels."""
-        ints = _label_ints(coord_labels[self.name], self.dtype)
-        positions = (ints - self.start_ns) / self.step_ns
-        return {self.name: positions.astype("float64")}
+        """Return the (float) positions of the samples nearest the labels."""
+        labels = np.atleast_1d(np.asarray(coord_labels[self.coord_names[0]]))
+        positions = label_indexer(self.coord, labels, method="nearest")
+        return {self.dim: np.asarray(positions, dtype=np.float64)}
 
-    def equals(self, other, **kwargs) -> bool:
+    def equals(self, other, exclude=None, **kwargs) -> bool:
         """Two transforms are equal when they label every sample alike."""
         return (
-            isinstance(other, TemporalRangeTransform)
-            and self.start_ns == other.start_ns
-            and self.step_ns == other.step_ns
-            and self.dim_size == other.dim_size
-            and self.dtype == other.dtype
+            isinstance(other, CoordTransform)
+            and self.dims == other.dims
+            and _same_labels(self.coord, other.coord)
         )
 
 
-class TemporalRangeIndex(CoordinateTransformIndex):
+class CoordIndex(CoordinateTransformIndex):
     """
-    An xarray index over a `TemporalRangeTransform`.
+    An xarray index serving a DASCore coordinate's labels.
 
-    Selection answers exactly as the materialized segments of the same
-    tree answer: a scalar label must land on a sample — nearer than half
-    a step past either end counts — or ``method="nearest"`` takes the
-    nearest sample within the span; a slice keeps every sample within
-    its (inclusive) endpoints; and a partial datetime string names its
-    whole period, as pandas reads it. A contiguous or strided ``isel``
-    returns a new lazy index, so laziness survives selection chains;
-    anything fancier falls back to a materialized pandas index over just
-    the selected labels. Asking for the pandas form (``.indexes``,
-    ``.to_pandas()``) materializes the labels, as reading ``.values``
-    does, and concatenating abutting segments stays lazy.
+    Selection answers as `Patch.sel` answers, which is as a materialized
+    pandas index answers: partial datetime strings name their periods,
+    slices keep their endpoints, and ``method`` and ``tolerance`` work as
+    pandas has them. A slice ``isel`` or a concatenation whose parts
+    chain returns a new lazy index; fancy indexing, or a concatenation
+    which reorders or overlaps, falls back to a materialized pandas index
+    over just the labels concerned. Aligning with a different index
+    materializes both, as aligning materialized indexes costs.
 
-    Not yet supported: aligning with a differently indexed coordinate
-    (xarray raises), and ``sel`` with ``tolerance``, with a ``method``
-    other than nearest, or with ``method`` on a slice.
+    An index matches only indexes of its own type: combining a lazy array
+    with one whose index is materialized raises xarray's AlignmentError
+    even where the labels agree. Convert with ``lazy_coords=False`` to
+    combine with such arrays.
+
+    A segmented coordinate's labels are evaluated in full for each label
+    selection on it, and not kept. A slice of a float range is labeled as
+    DASCore labels it, which can differ from the parent's labels in the
+    last bits.
     """
 
-    transform: TemporalRangeTransform
-
-    def __init__(self, transform: TemporalRangeTransform):
-        super().__init__(transform)
-        self.dim = transform.name
+    transform: CoordTransform
 
     @classmethod
-    def from_coord(cls, name: str, coord) -> TemporalRangeIndex:
-        """Build from an evenly sampled temporal dascore coordinate."""
-        start = np.asarray(coord.min())
-        kind = (
-            "datetime64[ns]"
-            if np.issubdtype(start.dtype, np.datetime64)
-            else ("timedelta64[ns]")
-        )
-        # explicit ns: a coarser-unit start or step would silently
-        # relabel every sample 1000x too fine read as raw integers
-        start_ns = start.astype(kind).view("int64")
-        step_ns = np.asarray(coord.step).astype("timedelta64[ns]").view("int64")
-        transform = TemporalRangeTransform(
-            name, len(coord), int(start_ns), int(step_ns), kind
-        )
-        return cls(transform)
+    def from_coord(cls, name: str, coord: BaseCoord) -> CoordIndex:
+        """Serve a range or segmented DASCore coordinate as ``name``."""
+        assert is_servable(coord), f"{type(coord).__name__} is not servable"
+        return cls(CoordTransform(name, coord))
 
     @property
-    def size(self) -> int:
-        """The number of samples the index labels."""
-        return self.transform.dim_size[self.dim]
+    def coordinate(self) -> BaseCoord:
+        """The DASCore coordinate this index serves."""
+        return self.transform.coord
 
-    def _exact_positions(self, values) -> tuple[np.ndarray, np.ndarray]:
-        """Exact (quotient, remainder) sample positions for labels."""
-        t = self.transform
-        # object (python-int) arrays lack a divmod ufunc; // and % map
-        # to the exact python operators
-        offset = _label_ints(values, t.dtype) - t.start_ns
-        quotient = offset // t.step_ns
-        return quotient, offset - quotient * t.step_ns
+    @property
+    def dim(self) -> str:
+        """The dimension the index labels."""
+        return self.transform.dim
 
-    def rename(self, name_dict, dims_dict) -> TemporalRangeIndex:
-        """A renamed coordinate keeps its lazy index under the new name."""
-        t = self.transform
-        new = dims_dict.get(self.dim, name_dict.get(self.dim, self.dim))
-        if new == self.dim:
-            return self
-        return type(self)(
-            TemporalRangeTransform(new, self.size, t.start_ns, t.step_ns, t.dtype)
-        )
+    def _positions(self, positions) -> PandasIndex:
+        """A materialized index over the labels at these positions."""
+        labels = self.transform.forward({self.dim: np.asarray(positions)})
+        return PandasIndex(pd.Index(labels[self.transform.coord_names[0]]), self.dim)
 
     def to_pandas_index(self) -> pd.Index:
         """The materialized pandas form, computed on demand."""
-        labels = self.transform.forward({self.dim: np.arange(self.size)})[self.dim]
-        return pd.Index(labels)
-
-    @classmethod
-    def concat(cls, indexes, dim, positions=None) -> TemporalRangeIndex | Any:
-        """
-        Concatenate segment indexes, staying lazy when the grids chain.
-
-        Segments whose ranges abut exactly (same step, each starting one
-        step past the previous end) merge into one lazy index; anything
-        else — a gap, a step change, an explicit reordering — comes back
-        as an ordinary materialized pandas index over the concatenated
-        labels.
-        """
-        transforms = [index.transform for index in indexes]
-        first = transforms[0]
-        chained = positions is None and all(
-            t.step_ns == first.step_ns
-            and t.dtype == first.dtype
-            and t.start_ns == prev.start_ns + prev.dim_size[prev.name] * prev.step_ns
-            for prev, t in pairwise(transforms)
-        )
-        if chained:
-            size = sum(t.dim_size[t.name] for t in transforms)
-            return cls(
-                TemporalRangeTransform(
-                    first.name, size, first.start_ns, first.step_ns, first.dtype
-                )
-            )
-        from xarray.core import nputils  # noqa: PLC0415
-        from xarray.indexes import PandasIndex  # noqa: PLC0415
-
-        values = np.concatenate([index.to_pandas_index().values for index in indexes])
-        if positions is not None:
-            indices = nputils.inverse_permutation(np.concatenate(positions))
-            values = values[indices]
-        return PandasIndex(pd.Index(values), dim)
+        return self._positions(np.arange(len(self.coordinate))).index
 
     def isel(self, indexers) -> Any:
-        """A sliced view keeps a lazy index; fancy indexing materializes.
-
-        Falling back to a pandas index over just the selected labels
-        (rather than returning None, which would drop the index) keeps
-        label selection working on the result.
-        """
+        """A sliced view keeps a lazy index; fancy indexing materializes."""
         idx = indexers.get(self.dim)
+        coord = self.coordinate
         if isinstance(idx, slice):
-            start, stop, stride = idx.indices(self.size)
-            if stride > 0:
-                size = max((stop - start + stride - 1) // stride, 0)
-                t = self.transform
-                new = TemporalRangeTransform(
-                    self.dim,
-                    size,
-                    t.start_ns + start * t.step_ns,
-                    t.step_ns * stride,
-                    t.dtype,
-                )
-                return type(self)(new)
-            positions = np.arange(start, stop, stride)
-        else:
-            if getattr(idx, "dims", (self.dim,)) != (self.dim,):
-                # vectorized onto another dimension: the labels no
-                # longer index this one, so xarray drops the index
-                return None
-            positions = np.asarray(getattr(idx, "values", idx))
-            if positions.ndim != 1:
-                # multi-dimensional (vectorized) indexing has no 1-d
-                # labels to index; let xarray drop the index
-                return None
-            if positions.dtype == bool:
-                positions = np.flatnonzero(positions)
-            # the data reads a negative position from the end; so must
-            # its label
-            positions = np.where(positions < 0, positions + self.size, positions)
-        from xarray.indexes import PandasIndex  # noqa: PLC0415
-
-        labels = self.transform.forward({self.dim: positions})[self.dim]
-        return PandasIndex(pd.Index(labels), self.dim)
-
-    def _positions_for(self, values, method):
-        """Validated integer positions for on-grid/nearest label values."""
-        step = self.transform.step_ns
-        quot, rem = self._exact_positions(values)
-        if method == "nearest":
-            pos = quot + (2 * rem >= step)
-        else:
-            if np.any(rem != 0):
-                msg = (
-                    f"Label(s) {values} do not fall on the coordinate's "
-                    "sample grid; pass method='nearest' to take the "
-                    "nearest sample."
-                )
-                raise KeyError(msg)
-            pos = quot
-        if np.any((pos < 0) | (pos >= self.size)):
-            msg = (
-                f"Label(s) {values} fall outside the coordinate's sampled "
-                "span; nothing to select."
-            )
-            raise KeyError(msg)
-        return pos.astype("int64")
-
-    def _period_bounds(self, label: str):
-        """The inclusive span a partial datetime string names, or None.
-
-        pandas answers ``sel(time="2020-01-01")`` on an hourly index with
-        the whole day; the lazy index must answer identically, so a
-        string label resolves through its period's start and end.
-        """
-        if np.dtype(self.transform.dtype).kind != "M":
+            start, stop, stride = idx.indices(len(coord))
+            positions = range(start, stop, stride)
+            # a strided segmented coordinate is an array of its labels
+            if len(positions) and (isinstance(coord, CoordRange) or stride == 1):
+                name = self.transform.coord_names[0]
+                return type(self)(CoordTransform(name, coord[idx]))
+            return self._positions(np.asarray(positions, dtype=np.int64))
+        if getattr(idx, "dims", (self.dim,)) != (self.dim,):
+            # vectorized onto another dimension: the labels no longer
+            # index this one, so xarray drops the index
             return None
-        try:
-            period = pd.Period(label)
-        except Exception:
+        positions = np.asarray(getattr(idx, "values", idx))
+        if isinstance(idx, list | tuple) and not len(idx):
+            positions = positions.astype(np.int64)  # an empty list picks nothing
+        if positions.ndim != 1:
             return None
-        if not isinstance(period, pd.Period):  # NaT parses without erroring
-            return None
-        reso = _PERIOD_RESO.get(period.freqstr.split("-")[0])
-        assert reso is not None, f"unexpected period frequency {period.freqstr!r}"
-        return (
-            period.start_time.to_datetime64(),
-            period.end_time.to_datetime64(),
-            reso,
-        )
-
-    @property
-    def _resolution(self) -> int:
-        """The finest unit any label carries, as pandas infers it.
-
-        pandas infers a DatetimeIndex's resolution from its values; the
-        samples here are ``start + k * step``, so the start's finest unit
-        and (past one sample) the step's finest unit decide it.
-        """
-        t = self.transform
-        reso = _ns_resolution(t.start_ns)
-        if self.size > 1:
-            reso = min(reso, _ns_resolution(t.step_ns))
-        return reso
+        if positions.dtype == bool:
+            positions = np.flatnonzero(positions)
+        if positions.dtype.kind not in "iu":
+            # as numpy refuses them for the data; forward would round them
+            msg = "arrays used as indices must be of integer (or boolean) type"
+            raise IndexError(msg)
+        return self._positions(positions)
 
     def sel(self, labels, method=None, tolerance=None) -> IndexSelResult:
-        """Resolve label selection arithmetically."""
-        if method not in (None, "nearest"):
-            msg = (
-                "TemporalRangeIndex resolves labels to their nearest "
-                f"sample; method={method!r} is not supported."
-            )
-            raise ValueError(msg)
-        if tolerance is not None:
-            msg = "TemporalRangeIndex does not support tolerance in sel."
-            raise ValueError(msg)
+        """Resolve label selection as `Patch.sel` does."""
         label = labels[self.dim]
-        if isinstance(label, slice):
-            if method is not None:
-                msg = "cannot use ``method`` argument with a slice, as pandas."
-                raise ValueError(msg)
-            return IndexSelResult({self.dim: self._sel_slice(label)})
-        if isinstance(label, Variable | DataArray):
-            # same validation as plain arrays, keeping the label's dims
-            # so vectorized selection stays vectorized
-            pos = self._positions_for(np.asarray(label.values), method)
-            if isinstance(label, DataArray):
-                return IndexSelResult({self.dim: label.copy(data=pos)})
-            return IndexSelResult({self.dim: Variable(label.dims, pos)})
-        if isinstance(label, str) and (bounds := self._period_bounds(label)):
-            # a datetime string coarser than the index names a span and
-            # keeps the dimension, even over one sample; one at least as
-            # fine names a single stamp, exactly as pandas resolves it
-            lo, hi, reso = bounds
-            if reso <= self._resolution:
-                pos = self._positions_for(lo, method)
-                return IndexSelResult({self.dim: int(pos[0])})
-            indexer = self._sel_slice(slice(lo, hi))
-            if indexer.stop == indexer.start:
-                msg = f"No samples fall within the period named by {label!r}."
-                raise KeyError(msg)
-            return IndexSelResult({self.dim: indexer})
-        # scalar and plain-array labels: exact by default, exactly as the
-        # materialized segments of the same tree answer; nearest opts in.
-        pos = self._positions_for(label, method)
-        if np.ndim(label) == 0:
-            return IndexSelResult({self.dim: int(pos[0])})
-        return IndexSelResult({self.dim: pos})
-
-    def _sel_slice(self, label: slice) -> slice:
-        """Resolve a label slice to a positional slice, endpoints inclusive."""
-        # np.timedelta64 subclasses np.integer, so exclude it by name
-        step_ok = isinstance(label.step, int | np.integer) and not isinstance(
-            label.step, np.timedelta64
-        )
-        if label.step is not None and (not step_ok or label.step <= 0):
-            msg = (
-                "A label slice step must be a positive integer stride "
-                f"of samples, got {label.step!r}."
+        coord = self.coordinate
+        if isinstance(coord, CoordSegmented):
+            # evaluated for this lookup only; the coordinate keeps no values
+            coord = coord.new(values=coord._get_index_values(np.arange(len(coord))))
+        if not isinstance(label, Variable | DataArray):
+            return IndexSelResult(
+                {self.dim: label_indexer(coord, label, method, tolerance)}
             )
-            raise ValueError(msg)
+        # vectorized selection: look up the values, keep the label's dims
+        values = np.asarray(label.values)
+        found = label_indexer(coord, values.ravel(), method, tolerance)
+        pos = np.asarray(found).reshape(values.shape)
+        if isinstance(label, DataArray):
+            return IndexSelResult({self.dim: label.copy(data=pos)})
+        return IndexSelResult({self.dim: Variable(label.dims, pos)})
 
-        def endpoint(value, edge):
-            """A slice endpoint, with partial strings naming their period."""
-            if value is None:
-                return None
-            if isinstance(value, str) and (bounds := self._period_bounds(value)):
-                return bounds[edge]
-            return value
+    @classmethod
+    def concat(cls, indexes, dim, positions=None) -> Any:
+        """
+        Concatenate indexes, staying lazy when their coordinates chain.
 
-        start = endpoint(label.start, 0)
-        stop = endpoint(label.stop, 1)
-        # inclusive endpoints, like pandas label slicing: every sample
-        # with start <= label <= stop stays.
-        if start is None:
-            first = 0
-        else:
-            quot, rem = self._exact_positions(start)
-            first = int(quot[0]) + int(rem[0] > 0)  # ceil
-        if stop is None:
-            last = self.size - 1
-        else:
-            quot, _ = self._exact_positions(stop)
-            last = int(quot[0])  # floor
-        first = max(first, 0)
-        last = min(last, self.size - 1)
-        return slice(first, max(last + 1, first), label.step)
+        Parts in ascending (or descending) order with no overlap chain
+        into one range when they continue each other's grid and into a
+        segmented coordinate otherwise; anything else — a reordering, an
+        overlap, a materialized part — comes back as a pandas index over
+        the concatenated labels.
+        """
+        if positions is None and all(isinstance(x, CoordIndex) for x in indexes):
+            coords = [x.coordinate for x in indexes]
+            if (out := _chained(coords)) is not None:
+                name = indexes[0].transform.coord_names[0]
+                return cls(CoordTransform(name, out))
+        return PandasIndex.concat([_as_pandas(x) for x in indexes], dim, positions)
+
+    def join(self, other, how="inner") -> PandasIndex:
+        """Join as materialized indexes join."""
+        # xarray folds several indexes through this, so self may already
+        # be the materialized result of an earlier join
+        return _as_pandas(self).join(_as_pandas(other), how=how)
+
+    def reindex_like(self, other, method=None, tolerance=None) -> dict:
+        """Reindex as a materialized index reindexes."""
+        return _as_pandas(self).reindex_like(_as_pandas(other), method, tolerance)
+
+    def _repr_inline_(self, max_width) -> str:
+        coord = self.coordinate
+        return f"{type(self).__name__} ({type(coord).__name__}, size={len(coord)})"
+
+    def __repr__(self) -> str:
+        return self._repr_inline_(None)

--- a/dascore/xarray/index.py
+++ b/dascore/xarray/index.py
@@ -61,6 +61,8 @@ def _relabels_exactly(coord) -> bool:
 
 def _array_coord(labels, units) -> BaseCoord:
     """Labels held as they are, never re-inferred as a range."""
+    if np.asarray(labels).dtype.kind in "USO":
+        return get_coord(data=labels, units=units)  # text keeps its own class
     monotonic = len(labels) > 1 and is_strictly_monotonic(labels)
     cls = CoordMonotonicArray if monotonic else CoordArray
     return cls(values=labels, units=units)
@@ -79,6 +81,11 @@ def _same_labels(first: BaseCoord, second: BaseCoord) -> bool:
         return True
     if len(first) != len(second) or first.dtype != second.dtype:
         return False
+    if not (is_servable(first) and is_servable(second)):
+        # a side which holds its labels costs nothing more to compare
+        positions = np.arange(len(first))
+        labels = (x._get_index_values(positions) for x in (first, second))
+        return bool(np.array_equal(next(labels), next(labels)))
     if first.units != second.units:
         # xarray states units as an attribute beside the labels, so an
         # index compares labels only, as a materialized index does

--- a/dascore/xarray/patch.py
+++ b/dascore/xarray/patch.py
@@ -22,12 +22,23 @@ def _register_accessor() -> None:
     from dascore.xarray import accessor  # noqa: F401, PLC0415
 
 
-def _lazy_index(name, coord):
-    """A lazy xarray index for a range or segmented coordinate, else None."""
-    # function-level: xarray is an optional dependency
-    from dascore.xarray.index import CoordIndex, is_servable  # noqa: PLC0415
+def _lazy_index(name, coord, held: bool = False):
+    """
+    A lazy xarray index for a range or segmented coordinate, else None.
 
-    return CoordIndex.from_coord(name, coord) if is_servable(coord) else None
+    With ``held``, any coordinate is served, holding its labels, so an
+    index built over labels by hand comes back as the index it was.
+    """
+    # function-level: xarray is an optional dependency
+    from dascore.xarray.index import (  # noqa: PLC0415
+        CoordIndex,
+        CoordTransform,
+        is_servable,
+    )
+
+    if held or is_servable(coord):
+        return CoordIndex(CoordTransform(name, coord))
+    return None
 
 
 def patch_to_xarray(patch: PatchType, lazy_coords: bool | Collection[str] = False):
@@ -39,11 +50,12 @@ def patch_to_xarray(patch: PatchType, lazy_coords: bool | Collection[str] = Fals
     patch
         The patch to convert.
     lazy_coords
-        Which dimension coordinates to serve lazily through
+        Which dimension coordinates to serve through
         `dascore.xarray.index.CoordIndex`, which computes labels on demand from
         the coordinate instead of storing them: True for every evenly sampled or
-        segmented one, False (the default) for none, or their names. Other
-        coordinates are materialized.
+        segmented one, False (the default) for none, or their names, served
+        whatever their kind (one holding its labels keeps them in the index).
+        Other coordinates are materialized.
 
     Notes
     -----
@@ -73,7 +85,8 @@ def patch_to_xarray(patch: PatchType, lazy_coords: bool | Collection[str] = Fals
         key: value for key, value in dict(patch.attrs).items() if value is not None
     }
     patch_dims = patch.dims
-    if isinstance(lazy_coords, bool):
+    named = not isinstance(lazy_coords, bool)
+    if not named:
         lazy_coords = patch_dims if lazy_coords else ()
     coords, units, lazy = {}, {}, []
     for name, coord in patch.coords.coord_map.items():
@@ -90,7 +103,7 @@ def patch_to_xarray(patch: PatchType, lazy_coords: bool | Collection[str] = Fals
         # one can be served by it; a coordinate merely riding a dimension
         # states its values as any other does.
         if name in lazy_coords and dims == (name,):
-            if (index := _lazy_index(name, coord)) is not None:
+            if (index := _lazy_index(name, coord, held=named)) is not None:
                 lazy.append(index)
                 continue
         coords[name] = (dims, coord.values)

--- a/dascore/xarray/patch.py
+++ b/dascore/xarray/patch.py
@@ -5,11 +5,10 @@ from __future__ import annotations
 from collections.abc import Collection
 
 import numpy as np
-import pandas as pd
 
 import dascore as dc
 from dascore.constants import PatchType
-from dascore.core.coords import get_coord
+from dascore.core.coords import BaseCoord, get_coord
 from dascore.utils.misc import optional_import
 
 
@@ -23,37 +22,15 @@ def _register_accessor() -> None:
     from dascore.xarray import accessor  # noqa: F401, PLC0415
 
 
-def _lazy_temporal_index(name, coord):
-    """
-    Return a lazy xarray index for an evenly sampled temporal coordinate.
-
-    None when the coordinate cannot be served lazily — an irregular
-    (segmented or array) coordinate, a descending one, or a numeric one,
-    whose materialized values are short in practice.
-    """
-    from dascore.core.coords import CoordRange  # noqa: PLC0415
-
-    step = getattr(coord, "step", None)
-    if not isinstance(coord, CoordRange) or step is None or pd.isnull(step):
-        return None
-    if not (
-        np.issubdtype(coord.dtype, np.datetime64)
-        or np.issubdtype(coord.dtype, np.timedelta64)
-    ):
-        return None
-    if np.asarray(step).astype("int64") <= 0:
-        return None
-    # The index holds one whole-tick step; a fractional grid would be
-    # relabelled by it, so its values travel instead.
-    if getattr(coord, "step_denominator", None) not in (None, 1):
-        return None
+def _lazy_index(name, coord):
+    """A lazy xarray index for a range or segmented coordinate, else None."""
     # function-level: xarray is an optional dependency
-    from dascore.xarray.index import TemporalRangeIndex  # noqa: PLC0415
+    from dascore.xarray.index import CoordIndex, is_servable  # noqa: PLC0415
 
-    return TemporalRangeIndex.from_coord(name, coord)
+    return CoordIndex.from_coord(name, coord) if is_servable(coord) else None
 
 
-def patch_to_xarray(patch: PatchType, lazy_coords: Collection[str] = ()):
+def patch_to_xarray(patch: PatchType, lazy_coords: bool | Collection[str] = True):
     """
     Convert a patch to an xarray DataArray.
 
@@ -62,15 +39,30 @@ def patch_to_xarray(patch: PatchType, lazy_coords: Collection[str] = ()):
     patch
         The patch to convert.
     lazy_coords
-        Coordinates to represent as ranges instead of materialized labels. Names
-        that are not evenly sampled temporal dimension coordinates are ignored;
-        unnamed coordinates remain materialized for xarray alignment. See
-        `dascore.xarray.index.TemporalRangeIndex` for current limitations.
+        Which dimension coordinates to serve lazily through
+        `dascore.xarray.index.CoordIndex`, which computes labels on demand from
+        the coordinate instead of storing them: True for every evenly sampled or
+        segmented one, False for none, or their names. Other coordinates are
+        materialized.
 
     Notes
     -----
-    A one-sample materialized coordinate cannot retain its step; a lazy coordinate
-    can.
+    A lazy coordinate is the patch's own coordinate, so it converts back exactly,
+    exact sampling grid included; a one-sample materialized coordinate cannot
+    retain its step. xarray aligns a lazy index only with lazy indexes: combining
+    the result with an array whose index is materialized raises an AlignmentError,
+    so convert with ``lazy_coords=False`` for that.
+
+    Examples
+    --------
+    >>> import dascore as dc
+    >>> from dascore.xarray import patch_to_xarray
+    >>> patch = dc.get_example_patch()
+    >>> # Lazy labels by default; the patch's own coordinates come back.
+    >>> array = patch_to_xarray(patch)
+    >>> assert array.xindexes["time"].coordinate == patch.get_coord("time")
+    >>> # Materialized labels, as a plain xarray index holds them.
+    >>> eager = patch_to_xarray(patch, lazy_coords=False)
     """
     xr = optional_import("xarray")
     _register_accessor()
@@ -80,24 +72,26 @@ def patch_to_xarray(patch: PatchType, lazy_coords: Collection[str] = ()):
         key: value for key, value in dict(patch.attrs).items() if value is not None
     }
     patch_dims = patch.dims
+    if isinstance(lazy_coords, bool):
+        lazy_coords = patch_dims if lazy_coords else ()
     coords, units, lazy = {}, {}, []
     for name, coord in patch.coords.coord_map.items():
         if coord._partial:
             continue
         dims = patch.coords.dim_map[name]
-        # An index labels a dimension, so only a coordinate which defines
-        # one can be served by it; a coordinate merely riding a dimension
-        # states its values as any other does.
-        if name in lazy_coords and dims == (name,):
-            if (index := _lazy_temporal_index(name, coord)) is not None:
-                lazy.append(index)
-                continue
         if coord.units is not None and not _is_temporal(coord.dtype):
             # a coordinate's units are its own; xarray states them the
             # way the CF conventions do, as an attribute beside it.
             # A datetime says its units in its dtype, and xarray spends
             # that same attribute on saying how to serialize it.
             units[name] = str(coord.units)
+        # An index labels a dimension, so only a coordinate which defines
+        # one can be served by it; a coordinate merely riding a dimension
+        # states its values as any other does.
+        if name in lazy_coords and dims == (name,):
+            if (index := _lazy_index(name, coord)) is not None:
+                lazy.append(index)
+                continue
         coords[name] = (dims, coord.values)
     # Need to exclude non-coords
     out = xr.DataArray(patch.data, attrs=attrs, dims=patch_dims, coords=coords)
@@ -130,28 +124,16 @@ def _coord_from(data_array, name, coord):
     """
     The dims and values a patch coordinate is built from.
 
-    A lazily indexed coordinate states its samples rather than storing
-    them, and reading its values would spell out every one -- which for
-    a tree spanning a long acquisition is what the lazy index exists to
-    avoid. The range it describes rebuilds the same coordinate from
-    three numbers.
+    A lazily indexed coordinate is served by the DASCore coordinate it
+    was built from, which comes back as it is: reading its values would
+    spell out every sample, which is what the lazy index exists to avoid.
     """
     index = data_array.xindexes.get(name)
-    transform = getattr(index, "transform", None)
     units = coord.attrs.get("units")
-    size = None if transform is None else transform.dim_size.get(name)
-    # A range needs somewhere to go: a selection which kept no samples
-    # has no start, step and stop to be rebuilt from, and its values are
-    # the empty array they say they are.
-    if transform is not None and hasattr(transform, "start_ns") and size:
-        # scalars, not zero-dimensional arrays: a coordinate's step is
-        # divided into and compared against, which an array shape breaks
-        start = np.asarray(transform.start_ns).astype(transform.dtype)[()]
-        step = np.timedelta64(int(transform.step_ns), "ns")
-        values = get_coord(
-            start=start, step=step, stop=start + step * size, units=units
-        )
-        return coord.dims, values
+    if isinstance(served := getattr(index, "coordinate", None), BaseCoord):
+        if units is not None and not _is_temporal(served.dtype):
+            served = served.set_units(units)
+        return coord.dims, served
     values = coord.values
     if units is not None and not _is_temporal(values.dtype):
         return coord.dims, get_coord(values=values, units=units)

--- a/dascore/xarray/patch.py
+++ b/dascore/xarray/patch.py
@@ -30,7 +30,7 @@ def _lazy_index(name, coord):
     return CoordIndex.from_coord(name, coord) if is_servable(coord) else None
 
 
-def patch_to_xarray(patch: PatchType, lazy_coords: bool | Collection[str] = True):
+def patch_to_xarray(patch: PatchType, lazy_coords: bool | Collection[str] = False):
     """
     Convert a patch to an xarray DataArray.
 
@@ -42,27 +42,28 @@ def patch_to_xarray(patch: PatchType, lazy_coords: bool | Collection[str] = True
         Which dimension coordinates to serve lazily through
         `dascore.xarray.index.CoordIndex`, which computes labels on demand from
         the coordinate instead of storing them: True for every evenly sampled or
-        segmented one, False for none, or their names. Other coordinates are
-        materialized.
+        segmented one, False (the default) for none, or their names. Other
+        coordinates are materialized.
 
     Notes
     -----
     A lazy coordinate is the patch's own coordinate, so it converts back exactly,
     exact sampling grid included; a one-sample materialized coordinate cannot
     retain its step. xarray aligns a lazy index only with lazy indexes: combining
-    the result with an array whose index is materialized raises an AlignmentError,
-    so convert with ``lazy_coords=False`` for that.
+    a lazy result with an array whose index is materialized, or reindexing it to
+    new labels, raises an AlignmentError. Materialized labels, the default, cost
+    8 bytes a sample along each dimension, which beside a patch's data is little.
 
     Examples
     --------
     >>> import dascore as dc
     >>> from dascore.xarray import patch_to_xarray
     >>> patch = dc.get_example_patch()
-    >>> # Lazy labels by default; the patch's own coordinates come back.
-    >>> array = patch_to_xarray(patch)
-    >>> assert array.xindexes["time"].coordinate == patch.get_coord("time")
     >>> # Materialized labels, as a plain xarray index holds them.
-    >>> eager = patch_to_xarray(patch, lazy_coords=False)
+    >>> array = patch_to_xarray(patch)
+    >>> # Lazy labels; the patch's own coordinates come back exactly.
+    >>> lazy = patch_to_xarray(patch, lazy_coords=True)
+    >>> assert lazy.xindexes["time"].coordinate == patch.get_coord("time")
     """
     xr = optional_import("xarray")
     _register_accessor()

--- a/dascore/xarray/spool.py
+++ b/dascore/xarray/spool.py
@@ -3,8 +3,8 @@ Convert a spool to a lazy, dask-backed xarray DataTree.
 
 The tree is partitioned exactly as `chunk` partitions patches; blocks
 load through the same resolver path a chunked spool loads through, and
-range and segmented dimension coordinates are served by the lazy index
-in `dascore.xarray.index`.
+the merged dimension's coordinate is served by the lazy index in
+`dascore.xarray.index`.
 """
 
 from __future__ import annotations
@@ -469,14 +469,19 @@ def spool_to_xarray(
     numeric values are floats — an integer-valued dimension coordinate
     comes back as floats.
 
-    A dimension coordinate which is a range or segmented is served
-    lazily by `dascore.xarray.index.CoordIndex`: its labels are computed
-    on demand from the merged coordinate rather than stored, so an
+    The merged dimension's coordinate, when it is a range or segmented,
+    is served lazily by `dascore.xarray.index.CoordIndex`: its labels are
+    computed on demand from the merged coordinate rather than stored, so an
     arbitrarily long merged time coordinate costs nothing to build, even
     when sub-tolerance gaps or slightly different sampling steps leave it
     segmented rather than one range. Label selection on it answers
     as `Patch.sel` does, and reading ``.values`` or asking for the
-    pandas index materializes labels on demand.
+    pandas index materializes labels on demand. Other dimensions keep
+    materialized labels, which per-channel arrays (gains, offsets) align
+    with. xarray aligns a lazy index only with lazy ones: to combine a
+    segment with arrays indexed along the merged dimension, or reindex
+    it, give it an ordinary index first, which reads its labels, e.g.
+    ``data.drop_indexes("time").set_xindex("time")``.
 
     A spool with pending value-range selections cannot be converted: the
     catalog states such bounds as candidacy rather than sample positions,
@@ -651,11 +656,11 @@ def spool_to_xarray(
                 else:
                     coord = _envelope_coord(out, d, get_coord)
                 sizes[d] = len(coord)
-                # A range or segmented coordinate stays lazy: its labels
-                # cost 8 bytes a sample materialized, which for a long
-                # merged time coordinate dwarfs everything else the tree
-                # holds.
-                if (index := _lazy_index(d, coord)) is not None:
+                # The merged coordinate stays lazy: its labels cost 8 bytes
+                # a sample materialized, which for a long merge dwarfs
+                # everything else the tree holds. The others are short, and
+                # a materialized index is what per-channel arrays align on.
+                if d == dim and (index := _lazy_index(d, coord)) is not None:
                     lazy_indexes[d] = index
                 else:
                     coords[d] = coord.values

--- a/dascore/xarray/spool.py
+++ b/dascore/xarray/spool.py
@@ -480,7 +480,8 @@ def spool_to_xarray(
     materialized labels, which per-channel arrays (gains, offsets) align
     with. xarray aligns a lazy index only with lazy ones: to combine a
     segment with arrays indexed along the merged dimension, or reindex
-    it, give it an ordinary index first, which reads its labels, e.g.
+    it, give it an ordinary index first, which reads all its labels into
+    memory (so select first where possible), e.g.
     ``data.drop_indexes("time").set_xindex("time")``.
 
     A spool with pending value-range selections cannot be converted: the

--- a/dascore/xarray/spool.py
+++ b/dascore/xarray/spool.py
@@ -472,8 +472,9 @@ def spool_to_xarray(
     A dimension coordinate which is a range or segmented is served
     lazily by `dascore.xarray.index.CoordIndex`: its labels are computed
     on demand from the merged coordinate rather than stored, so an
-    arbitrarily long merged time coordinate costs nothing to build, and
-    gaps a tolerance keeps stay lazy too. Label selection on it answers
+    arbitrarily long merged time coordinate costs nothing to build, even
+    when sub-tolerance gaps or slightly different sampling steps leave it
+    segmented rather than one range. Label selection on it answers
     as `Patch.sel` does, and reading ``.values`` or asking for the
     pandas index materializes labels on demand.
 

--- a/dascore/xarray/spool.py
+++ b/dascore/xarray/spool.py
@@ -3,8 +3,8 @@ Convert a spool to a lazy, dask-backed xarray DataTree.
 
 The tree is partitioned exactly as `chunk` partitions patches; blocks
 load through the same resolver path a chunked spool loads through, and
-evenly sampled time coordinates are served by the lazy index in
-`dascore.xarray.index`.
+range and segmented dimension coordinates are served by the lazy index
+in `dascore.xarray.index`.
 """
 
 from __future__ import annotations
@@ -22,7 +22,7 @@ from dascore.constants import SpoolType
 from dascore.exceptions import PatchConversionError
 from dascore.utils.misc import optional_import
 from dascore.utils.time import to_float
-from dascore.xarray.patch import _lazy_temporal_index
+from dascore.xarray.patch import _lazy_index
 
 
 def _np_scalar(value):
@@ -469,16 +469,13 @@ def spool_to_xarray(
     numeric values are floats — an integer-valued dimension coordinate
     comes back as floats.
 
-    An evenly sampled datetime/timedelta dimension coordinate is served
-    lazily: its labels are computed from start and step on demand
-    rather than stored, so an arbitrarily long merged time coordinate
-    costs nothing to build. Label selection on it resolves
-    arithmetically — a scalar must land on a sample (or pass
-    ``method="nearest"``), a slice keeps every sample within its
-    inclusive endpoints — and reading ``.values`` or asking for the
-    pandas index materializes labels on demand. A merged coordinate
-    which is not one even range (a sub-tolerance seam between
-    differently sampled members) spells its values out, as it must.
+    A dimension coordinate which is a range or segmented is served
+    lazily by `dascore.xarray.index.CoordIndex`: its labels are computed
+    on demand from the merged coordinate rather than stored, so an
+    arbitrarily long merged time coordinate costs nothing to build, and
+    gaps a tolerance keeps stay lazy too. Label selection on it answers
+    as `Patch.sel` does, and reading ``.values`` or asking for the
+    pandas index materializes labels on demand.
 
     A spool with pending value-range selections cannot be converted: the
     catalog states such bounds as candidacy rather than sample positions,
@@ -653,12 +650,11 @@ def spool_to_xarray(
                 else:
                     coord = _envelope_coord(out, d, get_coord)
                 sizes[d] = len(coord)
-                # An evenly sampled temporal coordinate stays lazy: its
-                # labels cost 8 bytes a sample materialized, which for a
-                # long merged time coordinate dwarfs everything else the
-                # tree holds. Irregular (segmented) coordinates are the
-                # exception that must spell out its values.
-                if (index := _lazy_temporal_index(d, coord)) is not None:
+                # A range or segmented coordinate stays lazy: its labels
+                # cost 8 bytes a sample materialized, which for a long
+                # merged time coordinate dwarfs everything else the tree
+                # holds.
+                if (index := _lazy_index(d, coord)) is not None:
                     lazy_indexes[d] = index
                 else:
                     coords[d] = coord.values

--- a/dascore/xarray/spool.py
+++ b/dascore/xarray/spool.py
@@ -482,7 +482,9 @@ def spool_to_xarray(
     segment with arrays indexed along the merged dimension, or reindex
     it, give it an ordinary index first, which reads all its labels into
     memory (so select first where possible), e.g.
-    ``data.drop_indexes("time").set_xindex("time")``.
+    ``data.drop_indexes("time").set_xindex("time")``, or give the other
+    array this index type, ``other.drop_indexes("time").set_xindex("time",
+    CoordIndex)``, which reads no lazy labels where the two agree.
 
     A spool with pending value-range selections cannot be converted: the
     catalog states such bounds as candidacy rather than sample positions,

--- a/docs/recipes/external_conversion.qmd
+++ b/docs/recipes/external_conversion.qmd
@@ -39,13 +39,13 @@ patch = dc.get_example_patch()
 lazy = patch.io.to_xarray(lazy_coords=True)
 ```
 
-xarray aligns a lazy index only with others of its kind, so combining a lazy array with an array whose index holds its labels (built from numpy, loaded from netCDF, or converted with the default), or reindexing it to new labels, raises an `AlignmentError`. To combine them, give the lazy array ordinary indexes; the data stays as it is:
+xarray aligns a lazy index only with others of its kind, so combining a lazy array with an array whose index holds its labels (built from numpy, loaded from netCDF, or converted with the default), or reindexing it to new labels, raises an `AlignmentError`. To combine them, give the lazy array ordinary indexes: `drop_indexes` removes the lazy index but keeps the coordinate's labels, and `set_xindex` builds an ordinary index from them, reading every label (8 bytes a sample). The data stays as it is:
 
 ```python
 eager = lazy.drop_indexes(["time", "distance"]).set_xindex("time").set_xindex("distance")
 ```
 
-A whole spool converts to a lazy, [dask](https://docs.dask.org/)-backed [DataTree](https://docs.xarray.dev/en/stable/user-guide/hierarchical-data.html) with one node per group of related patches (partitioned exactly as [`chunk`](`dascore.Spool.chunk`) partitions them) and one child node per merged output segment. Building the tree reads no data, and its dimension coordinates are lazy (as with `lazy_coords=True` above), so a segment spanning years of samples costs nothing to label. Computing a selection loads only the source patches it touches.
+A whole spool converts to a lazy, [dask](https://docs.dask.org/)-backed [DataTree](https://docs.xarray.dev/en/stable/user-guide/hierarchical-data.html) with one node per group of related patches (partitioned exactly as [`chunk`](`dascore.Spool.chunk`) partitions them) and one child node per merged output segment. Building the tree reads no data, and the coordinate of the dimension segments are merged along is lazy (as with `lazy_coords=True` above), so a segment spanning years of samples costs nothing to label. Other dimensions keep ordinary indexes, so per-channel arrays such as gains combine with a segment directly; along the merged dimension, use the `drop_indexes`/`set_xindex` swap above. Computing a selection loads only the source patches it touches.
 
 ```python
 import dascore as dc

--- a/docs/recipes/external_conversion.qmd
+++ b/docs/recipes/external_conversion.qmd
@@ -29,17 +29,23 @@ dar = patch.io.to_xarray()
 patch_from_dar = dc.io.xarray_to_patch(dar)
 ```
 
-Dimension coordinates are lazy: the DataArray's index holds the patch's own coordinate and computes labels only for the samples a selection or `.values` asks about, so a coordinate spanning billions of samples costs nothing to convert. Selection answers as it does on a materialized index (partial datetime strings, `method="nearest"`, `tolerance`), and converting back returns the coordinate exactly, fractional sampling rates and gaps included. xarray aligns such an index only with others of its kind, so an array built by hand, whose index holds its labels, cannot be combined with a lazy one; convert with `lazy_coords=False` to get materialized labels instead.
+Coordinate labels are materialized, as in any xarray index. With `lazy_coords=True` (or a collection of names) the DataArray's index instead holds the patch's own coordinate and computes labels only for the samples a selection or `.values` asks about. Selection answers as it does on a materialized index (partial datetime strings, `method="nearest"`, `tolerance`), and converting back returns the coordinate exactly, fractional sampling rates and gaps included.
 
 ```python
 import dascore as dc
 
 patch = dc.get_example_patch()
 
-eager = patch.io.to_xarray(lazy_coords=False)
+lazy = patch.io.to_xarray(lazy_coords=True)
 ```
 
-A whole spool converts to a lazy, [dask](https://docs.dask.org/)-backed [DataTree](https://docs.xarray.dev/en/stable/user-guide/hierarchical-data.html) with one node per group of related patches (partitioned exactly as [`chunk`](`dascore.Spool.chunk`) partitions them) and one child node per merged output segment. Building the tree reads no data, and its coordinates are lazy as in the single-patch conversion above, so a segment spanning years of samples costs nothing to label. Computing a selection loads only the source patches it touches.
+xarray aligns a lazy index only with others of its kind, so combining a lazy array with an array whose index holds its labels (built from numpy, loaded from netCDF, or converted with the default), or reindexing it to new labels, raises an `AlignmentError`. To combine them, give the lazy array ordinary indexes; the data stays as it is:
+
+```python
+eager = lazy.drop_indexes(["time", "distance"]).set_xindex("time").set_xindex("distance")
+```
+
+A whole spool converts to a lazy, [dask](https://docs.dask.org/)-backed [DataTree](https://docs.xarray.dev/en/stable/user-guide/hierarchical-data.html) with one node per group of related patches (partitioned exactly as [`chunk`](`dascore.Spool.chunk`) partitions them) and one child node per merged output segment. Building the tree reads no data, and its dimension coordinates are lazy (as with `lazy_coords=True` above), so a segment spanning years of samples costs nothing to label. Computing a selection loads only the source patches it touches.
 
 ```python
 import dascore as dc

--- a/docs/recipes/external_conversion.qmd
+++ b/docs/recipes/external_conversion.qmd
@@ -45,6 +45,14 @@ xarray aligns a lazy index only with others of its kind, so combining a lazy arr
 eager = lazy.drop_indexes(["time", "distance"]).set_xindex("time").set_xindex("distance")
 ```
 
+The other way round often costs less: give the ordinary array the lazy index type instead. Its labels are already in memory, and where they equal the lazy array's the two align without reading the lazy labels at all (labels that differ are joined as ordinary indexes would be, which reads both).
+
+```python
+from dascore.xarray.index import CoordIndex
+
+aligned = eager.drop_indexes("time").set_xindex("time", CoordIndex)
+```
+
 A whole spool converts to a lazy, [dask](https://docs.dask.org/)-backed [DataTree](https://docs.xarray.dev/en/stable/user-guide/hierarchical-data.html) with one node per group of related patches (partitioned exactly as [`chunk`](`dascore.Spool.chunk`) partitions them) and one child node per merged output segment. Building the tree reads no data, and the coordinate of the dimension segments are merged along is lazy (as with `lazy_coords=True` above), so a segment spanning years of samples costs nothing to label. Other dimensions keep ordinary indexes, so per-channel arrays such as gains combine with a segment directly; along the merged dimension, use the `drop_indexes`/`set_xindex` swap above. Computing a selection loads only the source patches it touches.
 
 ```python

--- a/docs/recipes/external_conversion.qmd
+++ b/docs/recipes/external_conversion.qmd
@@ -29,7 +29,17 @@ dar = patch.io.to_xarray()
 patch_from_dar = dc.io.xarray_to_patch(dar)
 ```
 
-A whole spool converts to a lazy, [dask](https://docs.dask.org/)-backed [DataTree](https://docs.xarray.dev/en/stable/user-guide/hierarchical-data.html) with one node per group of related patches (partitioned exactly as [`chunk`](`dascore.Spool.chunk`) partitions them) and one child node per merged output segment. Building the tree reads no data — even the tree's time coordinates are lazy (unlike the single-patch conversion above, which materializes its labels): an evenly sampled one is served from start and step on demand, so a segment spanning years of samples costs nothing to label. Computing a selection loads only the source patches it touches.
+Dimension coordinates are lazy: the DataArray's index holds the patch's own coordinate and computes labels only for the samples a selection or `.values` asks about, so a coordinate spanning billions of samples costs nothing to convert. Selection answers as it does on a materialized index (partial datetime strings, `method="nearest"`, `tolerance`), and converting back returns the coordinate exactly, fractional sampling rates and gaps included. xarray aligns such an index only with others of its kind, so an array built by hand, whose index holds its labels, cannot be combined with a lazy one; convert with `lazy_coords=False` to get materialized labels instead.
+
+```python
+import dascore as dc
+
+patch = dc.get_example_patch()
+
+eager = patch.io.to_xarray(lazy_coords=False)
+```
+
+A whole spool converts to a lazy, [dask](https://docs.dask.org/)-backed [DataTree](https://docs.xarray.dev/en/stable/user-guide/hierarchical-data.html) with one node per group of related patches (partitioned exactly as [`chunk`](`dascore.Spool.chunk`) partitions them) and one child node per merged output segment. Building the tree reads no data, and its coordinates are lazy as in the single-patch conversion above, so a segment spanning years of samples costs nothing to label. Computing a selection loads only the source patches it touches.
 
 ```python
 import dascore as dc
@@ -64,7 +74,7 @@ A DataArray from somewhere else needs `import dascore.xarray.accessor` first, si
 
 A dask-backed DataArray is passed through as it stands, so a method which works on the array's own backend leaves it lazy. One which cannot converts, as it does on a patch. Where such a method announces that conversion, and the array is larger than free memory, the accessor raises rather than attempting it; a method which converts silently is not caught, and fails on memory as it would anywhere else.
 
-A coordinate a tree states rather than stores -- an evenly sampled time coordinate, whose labels are computed from its range on demand -- is stated again in what a method hands back, so labelling a long acquisition costs no more after a call than before it. Every DataArray in the call says how its own coordinates arrived, an argument as much as the one called on. A coordinate which arrived spelled out anywhere is spelled out in the result, since a spelled-out index is what xarray aligns on. Laziness follows the name, so a method which renames such a coordinate spells its labels out under the new name.
+A coordinate a DataArray states rather than stores (a lazy one, whose labels are computed on demand) is stated again in what a method hands back, so labelling a long acquisition costs no more after a call than before it. Every DataArray in the call says how its own coordinates arrived, an argument as much as the one called on. A coordinate which arrived spelled out anywhere is spelled out in the result, since a spelled-out index is what xarray aligns on. Laziness follows the name, so a method which renames such a coordinate spells its labels out under the new name.
 
 ## [ObsPy](https://docs.obspy.org/)
 

--- a/docs/recipes/external_conversion.qmd
+++ b/docs/recipes/external_conversion.qmd
@@ -39,7 +39,7 @@ patch = dc.get_example_patch()
 lazy = patch.io.to_xarray(lazy_coords=True)
 ```
 
-xarray aligns a lazy index only with others of its kind, so combining a lazy array with an array whose index holds its labels (built from numpy, loaded from netCDF, or converted with the default), or reindexing it to new labels, raises an `AlignmentError`. To combine them, give the lazy array ordinary indexes: `drop_indexes` removes the lazy index but keeps the coordinate's labels, and `set_xindex` builds an ordinary index from them, reading every label (8 bytes a sample). The data stays as it is:
+xarray aligns a lazy index only with others of its kind, so combining a lazy array with an array whose index holds its labels (built from numpy, loaded from netCDF, or converted with the default), or reindexing it to new labels, raises an `AlignmentError`. To combine them, give the lazy array ordinary indexes: `drop_indexes` removes the lazy index but keeps the coordinate's labels, and `set_xindex` builds an ordinary index from them, reading every label into memory (8 bytes a sample; a day at 1 kHz is about 0.7 GB). The data stays as it is. Select first where you can, so only the selection's labels are read:
 
 ```python
 eager = lazy.drop_indexes(["time", "distance"]).set_xindex("time").set_xindex("distance")

--- a/tests/test_core/test_coord_range_int.py
+++ b/tests/test_core/test_coord_range_int.py
@@ -796,7 +796,7 @@ class TestPersistenceGuards:
         )
 
         patch = dc.get_example_patch().update_coords(time=hz_1024[:2000])
-        array = patch_to_xarray(patch)
+        array = patch_to_xarray(patch, lazy_coords=True)
         assert array.xindexes["time"].coordinate == patch.get_coord("time")
         assert np.array_equal(array["time"].values, patch.get_coord("time").values)
         assert xarray_to_patch(array).get_coord("time") == patch.get_coord("time")

--- a/tests/test_core/test_coord_range_int.py
+++ b/tests/test_core/test_coord_range_int.py
@@ -787,15 +787,19 @@ class TestPersistenceGuards:
         patch.io.write(path, "dasdae", file_version="1")
         assert dc.spool(path)[0].get_coord("time") == patch.get_coord("time")
 
-    def test_xarray_lazy_index_skipped(self, hz_1024):
-        """A fractional grid travels to xarray as values, not a rounded index."""
+    def test_xarray_keeps_the_grid(self, hz_1024):
+        """A fractional grid travels to xarray and back exactly, not rounded."""
         pytest.importorskip("xarray")
-        from dascore.xarray.patch import patch_to_xarray  # noqa: PLC0415
+        from dascore.xarray.patch import (  # noqa: PLC0415
+            patch_to_xarray,
+            xarray_to_patch,
+        )
 
         patch = dc.get_example_patch().update_coords(time=hz_1024[:2000])
-        array = patch_to_xarray(patch, lazy_coords={"time"})
-        assert type(array.xindexes["time"]).__name__ != "TemporalRangeIndex"
+        array = patch_to_xarray(patch)
+        assert array.xindexes["time"].coordinate == patch.get_coord("time")
         assert np.array_equal(array["time"].values, patch.get_coord("time").values)
+        assert xarray_to_patch(array).get_coord("time") == patch.get_coord("time")
 
 
 class TestValidationErrors:

--- a/tests/test_core/test_coord_segmented.py
+++ b/tests/test_core/test_coord_segmented.py
@@ -341,6 +341,15 @@ class TestEquivalenceWithMonotonic:
                 np.atleast_1d(seg[slc].values), np.atleast_1d(mono[slc].values)
             )
 
+    def test_index_values_parity(self, coord_pair):
+        """Evaluating chosen samples agrees with the materialized coord."""
+        seg, mono = coord_pair
+        indices = np.array([0, 5, len(seg) - 1, -1, 3, 3])
+        out = seg._get_index_values(indices)
+        assert out.dtype == seg.dtype
+        assert np.array_equal(out, mono.values[indices])
+        assert not len(seg._get_index_values(np.array([], dtype=np.int64)))
+
     def test_get_next_index_parity(self, coord_pair):
         """get_next_index matches the materialized coordinate."""
         seg, mono = coord_pair

--- a/tests/test_proc/test_indexing.py
+++ b/tests/test_proc/test_indexing.py
@@ -591,6 +591,20 @@ class TestCompactRangeIndexing:
         assert_matches(patch, "isel", {"x": 0})
         assert_matches(patch, "sel", {"x": coord.start})
 
+    @pytest.mark.parametrize("start", [3, np.datetime64("2020-01-01", "ns")])
+    def test_zero_step_range(self, start):
+        """Every sample of a zero-step range shares its label, as pandas finds."""
+        step = 0 if isinstance(start, int) else np.timedelta64(0, "ns")
+        coord = get_coord(start=start, step=step, shape=(10,))
+        patch = dc.Patch(data=np.arange(10), coords={"x": coord}, dims=("x",))
+        assert_matches(patch, "sel", {"x": coord.start})
+        assert_matches(patch, "sel", {"x": slice(coord.start, coord.start)})
+        # an array of labels cannot say which of the repeats it means
+        with pytest.raises(pd.errors.InvalidIndexError):
+            patch.io.to_xarray().sel(x=[coord.start])
+        with pytest.raises(pd.errors.InvalidIndexError, match="zero step"):
+            patch.sel(x=[coord.start])
+
     @pytest.mark.parametrize("reverse", [False, True])
     @pytest.mark.parametrize(
         "step", [0.1, 0.3, np.float32(0.1), 2, np.timedelta64(1, "ms")]

--- a/tests/test_xarray/test_xr_accessor.py
+++ b/tests/test_xarray/test_xr_accessor.py
@@ -381,6 +381,17 @@ class TestLazyCoordinates:
         assert type(out.xindexes["time"]).__name__ == "CoordIndex"
         assert (out - unindexed).shape == tree_leaf.shape
 
+    def test_an_index_over_held_labels_survives(self):
+        """An index given to irregular labels by hand comes back as it was."""
+        from dascore.xarray.index import CoordIndex  # noqa: PLC0415
+
+        xr = pytest.importorskip("xarray")
+        array = xr.DataArray(np.arange(3.0), dims="x", coords={"x": [0.0, 1.0, 5.0]})
+        held = array.drop_indexes("x").set_xindex("x", CoordIndex)
+        out = held.dc.abs()
+        assert isinstance(out.xindexes["x"], CoordIndex)
+        assert (out + held).sizes == held.sizes
+
     def test_a_duration_is_served_like_a_time(self):
         """A lag says its units in its dtype as a stamp does."""
         from dascore.core.coords import get_coord  # noqa: PLC0415

--- a/tests/test_xarray/test_xr_accessor.py
+++ b/tests/test_xarray/test_xr_accessor.py
@@ -25,8 +25,8 @@ def patch():
 
 @pytest.fixture(scope="module")
 def data_array(patch):
-    """That patch as a DataArray, which registers the accessor."""
-    return patch.io.to_xarray()
+    """That patch as a DataArray with materialized labels."""
+    return patch.io.to_xarray(lazy_coords=False)
 
 
 @pytest.fixture()
@@ -154,9 +154,9 @@ class TestLaziness:
         pytest.importorskip("dask")
         tree = random_spool.io.to_xarray()
         leaf = next(x for x in tree.subtree if "data" in x.dataset)["data"]
-        assert type(leaf.xindexes["time"]).__name__ == "TemporalRangeIndex"
+        assert type(leaf.xindexes["time"]).__name__ == "CoordIndex"
         out = leaf.dc.abs()
-        assert type(out.xindexes["time"]).__name__ == "TemporalRangeIndex"
+        assert type(out.xindexes["time"]).__name__ == "CoordIndex"
 
     def test_an_ordinary_array_keeps_its_eager_index(self, data_array):
         """Whether a coordinate is spelled out belongs to the object.
@@ -176,12 +176,12 @@ class TestLaziness:
         """A method which trims it is served lazily at its new bounds."""
         values = np.asarray(tree_leaf["time"].values)
         out = tree_leaf.dc.select(time=(None, values[100]))
-        assert type(out.xindexes["time"]).__name__ == "TemporalRangeIndex"
+        assert type(out.xindexes["time"]).__name__ == "CoordIndex"
         assert np.array_equal(np.asarray(out["time"].values), values[:101])
 
     def test_a_property_keeps_it_lazy_too(self, tree_leaf):
         """A property's value is converted like a method's result."""
-        assert type(tree_leaf.dc.T.xindexes["time"]).__name__ == "TemporalRangeIndex"
+        assert type(tree_leaf.dc.T.xindexes["time"]).__name__ == "CoordIndex"
 
     def test_a_coordinate_riding_a_dimension_is_left_alone(self, tree_leaf):
         """Only a coordinate which defines its dimension can index it.
@@ -194,7 +194,7 @@ class TestLaziness:
         with_aux = tree_leaf.assign_coords(aux_time=("time", values))
         out = with_aux.dc.abs()
         assert out.coords["aux_time"].dims == ("time",)
-        assert type(out.xindexes["time"]).__name__ == "TemporalRangeIndex"
+        assert type(out.xindexes["time"]).__name__ == "CoordIndex"
 
     def test_the_values_are_the_same_either_way(self, patch, lazy_data_array):
         """Laziness is about when the work happens, not what it produces."""
@@ -214,22 +214,22 @@ class TestLazyCoordinates:
 
     def test_the_index_is_lazy_to_begin_with(self, tree_leaf):
         """Otherwise the test below would prove nothing."""
-        assert type(tree_leaf.xindexes["time"]).__name__ == "TemporalRangeIndex"
+        assert type(tree_leaf.xindexes["time"]).__name__ == "CoordIndex"
 
     def test_converting_does_not_spell_out_the_labels(self, tree_leaf, monkeypatch):
-        """A range rebuilds from three numbers, not from every sample.
+        """The index hands back its coordinate, not every sample.
 
         The transform computes labels, so a conversion that never calls it keeps them
         lazy. The returned coordinate alone cannot prove this because evenly spaced
         materialized values also infer a range.
         """
         from dascore.core.coords import CoordRange  # noqa: PLC0415
-        from dascore.xarray.index import TemporalRangeTransform  # noqa: PLC0415
+        from dascore.xarray.index import CoordTransform  # noqa: PLC0415
 
         def _refuse(self, dim_positions):
             raise AssertionError("the labels were materialized")
 
-        monkeypatch.setattr(TemporalRangeTransform, "forward", _refuse)
+        monkeypatch.setattr(CoordTransform, "forward", _refuse)
         coord = tree_leaf.dc.to_patch().get_coord("time")
         assert isinstance(coord, CoordRange)
 
@@ -246,7 +246,7 @@ class TestLazyCoordinates:
         both paths; numeric coordinates remain unaffected.
         """
         from dascore.core.coords import CoordRange  # noqa: PLC0415
-        from dascore.xarray.index import TemporalRangeTransform  # noqa: PLC0415
+        from dascore.xarray.index import CoordTransform  # noqa: PLC0415
 
         def _refuse_forward(self, dim_positions):
             raise AssertionError("the labels were computed by the transform")
@@ -261,7 +261,7 @@ class TestLazyCoordinates:
                 raise AssertionError("the range spelled out its labels")
             return original.__get__(self, CoordRange)
 
-        monkeypatch.setattr(TemporalRangeTransform, "forward", _refuse_forward)
+        monkeypatch.setattr(CoordTransform, "forward", _refuse_forward)
         monkeypatch.setattr(CoordRange, "values", _refuse_values)
 
     def test_a_forwarded_call_never_spells_out_the_labels(self, tree_leaf, monkeypatch):
@@ -272,14 +272,14 @@ class TestLazyCoordinates:
         """
         self._refuse_to_materialize(monkeypatch)
         out = tree_leaf.dc.abs()
-        assert type(out.xindexes["time"]).__name__ == "TemporalRangeIndex"
+        assert type(out.xindexes["time"]).__name__ == "CoordIndex"
 
     def test_a_forwarded_property_never_spells_them_out_either(
         self, tree_leaf, monkeypatch
     ):
         """A property states a patch by the same conversion a call does."""
         self._refuse_to_materialize(monkeypatch)
-        assert type(tree_leaf.dc.T.xindexes["time"]).__name__ == "TemporalRangeIndex"
+        assert type(tree_leaf.dc.T.xindexes["time"]).__name__ == "CoordIndex"
 
     def test_a_renamed_coordinate_is_spelled_out(self, tree_leaf):
         """Laziness follows the name, and a rename is a new name.
@@ -319,7 +319,7 @@ class TestLazyCoordinates:
         array = patch_to_xarray(patch, lazy_coords={"time"})
         assert type(array.xindexes["lag"]).__name__ == "PandasIndex"
         out = array.dc.abs()
-        assert type(out.xindexes["time"]).__name__ == "TemporalRangeIndex"
+        assert type(out.xindexes["time"]).__name__ == "CoordIndex"
         assert type(out.xindexes["lag"]).__name__ == "PandasIndex"
         # which is what a lazy index on `lag` would refuse to align
         assert (out - array).shape == array.shape
@@ -349,13 +349,13 @@ class TestLazyCoordinates:
         offsets = self._offsets(tree_leaf)
         self._refuse_to_materialize(monkeypatch)
         out = offsets.dc.add(other=tree_leaf) if keyword else offsets.dc.add(tree_leaf)
-        assert type(out.xindexes["time"]).__name__ == "TemporalRangeIndex"
+        assert type(out.xindexes["time"]).__name__ == "CoordIndex"
 
     def test_either_order_states_it_the_same_way(self, tree_leaf):
         """The same sum, so the same coordinate, however it is written."""
         offsets = self._offsets(tree_leaf)
         first, second = tree_leaf.dc.add(offsets), offsets.dc.add(tree_leaf)
-        assert type(first.xindexes["time"]).__name__ == "TemporalRangeIndex"
+        assert type(first.xindexes["time"]).__name__ == "CoordIndex"
         assert type(first.xindexes["time"]) is type(second.xindexes["time"])
         assert np.allclose(first.transpose(*second.dims).values, second.values)
 
@@ -366,7 +366,7 @@ class TestLazyCoordinates:
         out; the result keeps what the stricter of them can align on,
         the same way round either way.
         """
-        spelled_out = tree_leaf.dc.to_patch().io.to_xarray()
+        spelled_out = tree_leaf.dc.to_patch().io.to_xarray(lazy_coords=False)
         assert type(spelled_out.xindexes["time"]).__name__ == "PandasIndex"
         for out in (spelled_out.dc.add(tree_leaf), tree_leaf.dc.add(spelled_out)):
             assert type(out.xindexes["time"]).__name__ == "PandasIndex"
@@ -374,10 +374,11 @@ class TestLazyCoordinates:
     @pytest.mark.parametrize("reverse", [False, True])
     def test_an_unindexed_coordinate_does_not_force_eager(self, tree_leaf, reverse):
         """Only an eager index requires the result to preserve eager alignment."""
-        unindexed = tree_leaf.dc.to_patch().io.to_xarray().drop_indexes("time")
+        patch = tree_leaf.dc.to_patch()
+        unindexed = patch.io.to_xarray(lazy_coords=False).drop_indexes("time")
         first, second = (unindexed, tree_leaf) if reverse else (tree_leaf, unindexed)
         out = first.dc.add(second)
-        assert type(out.xindexes["time"]).__name__ == "TemporalRangeIndex"
+        assert type(out.xindexes["time"]).__name__ == "CoordIndex"
         assert (out - unindexed).shape == tree_leaf.shape
 
     def test_a_duration_is_served_like_a_time(self):
@@ -390,7 +391,7 @@ class TestLazyCoordinates:
         )
         patch = dc.Patch(data=np.arange(4.0), dims=("lag",), coords={"lag": lag})
         array = patch_to_xarray(patch, lazy_coords={"lag"})
-        assert type(array.xindexes["lag"]).__name__ == "TemporalRangeIndex"
+        assert type(array.xindexes["lag"]).__name__ == "CoordIndex"
         assert np.array_equal(np.asarray(array["lag"].values), lag.values)
 
     def test_a_coordinate_which_no_longer_names_a_dimension(self, tree_leaf):

--- a/tests/test_xarray/test_xr_index.py
+++ b/tests/test_xarray/test_xr_index.py
@@ -523,6 +523,52 @@ class TestAlignment:
             lazy + eager
 
 
+class TestFromVariables:
+    """An ordinary array takes this index type through set_xindex."""
+
+    @pytest.mark.parametrize("name", ["ms", "descending", "float", "segmented"])
+    def test_labels_kept_exactly(self, name):
+        """The labels an array holds come back unchanged, as a range when even."""
+        _, eager = _pair(COORDS[name])
+        out = eager.drop_indexes("x").set_xindex("x", CoordIndex)
+        assert isinstance(out.xindexes["x"], CoordIndex)
+        np.testing.assert_array_equal(out["x"].values, eager["x"].values)
+        _assert_same(
+            lambda: out.sel(x=eager["x"].values[3]),
+            lambda: eager.sel(x=eager["x"].values[3]),
+        )
+
+    def test_aligns_with_a_lazy_array_without_reading_it(self, monkeypatch):
+        """Equal labels align without evaluating the lazy side's labels."""
+        lazy, eager = _pair(MS)
+        converted = eager.drop_indexes("x").set_xindex("x", CoordIndex)
+        original = CoordRange._get_index_values
+
+        def _bounded(self, indices):
+            assert np.size(indices) < 10, "the lazy labels were read"
+            return original(self, indices)
+
+        monkeypatch.setattr(CoordRange, "_get_index_values", _bounded)
+        out = lazy + converted
+        assert isinstance(out.xindexes["x"], CoordIndex)
+
+    def test_units_and_refusals(self):
+        """Units come from the variable; several or 2-d variables are refused."""
+        distance = xr.DataArray(
+            np.arange(5.0),
+            dims="d",
+            coords={"d": ("d", np.arange(5.0), {"units": "m"})},
+        )
+        out = distance.drop_indexes("d").set_xindex("d", CoordIndex)
+        assert out.xindexes["d"].coordinate.units == dc.get_quantity("m")
+        pair = xr.Dataset(coords={"a": ("x", [1, 2]), "b": ("x", [3, 4])})
+        with pytest.raises(ValueError, match="one coordinate"):
+            pair.set_xindex(["a", "b"], CoordIndex)
+        grid = xr.Dataset(coords={"g": (("x", "y"), [[1, 2], [3, 4]])})
+        with pytest.raises(ValueError, match="one-dimensional"):
+            grid.set_xindex("g", CoordIndex)
+
+
 class TestScale:
     """The reason this index exists: metadata-cost construction."""
 

--- a/tests/test_xarray/test_xr_index.py
+++ b/tests/test_xarray/test_xr_index.py
@@ -150,6 +150,17 @@ class TestSelParity:
         for label in (2**53 + 5, [2**53 + 5, 2**53 + 7]):
             _assert_same(lambda q=label: lazy.sel(x=q), lambda q=label: eager.sel(x=q))
 
+    def test_repeats_anywhere_refuse_arrays(self):
+        """A repeating segment far from the query still refuses array lookups."""
+        coord = concat_coords(
+            get_coord(start=0, step=1, shape=(5,)),
+            get_coord(start=10, step=0, shape=(3,)),
+            get_coord(start=20, step=1, shape=(5,)),
+        )
+        lazy, eager = _pair(coord)
+        for query in (dict(x=[1, 21]), dict(x=21, method="nearest")):
+            _assert_same(lambda q=query: lazy.sel(**q), lambda q=query: eager.sel(**q))
+
     def test_one_sample_period_keeps_dimension(self):
         """A coarse string over one sample keeps the dimension."""
         coord = get_coord(start=T0 - HOUR, step=HOUR, shape=(30,))
@@ -482,6 +493,21 @@ class TestConcat:
 class TestAlignment:
     """Arithmetic between lazy arrays aligns as between eager ones."""
 
+    def test_exact_join_across_representations(self):
+        """A slice and the same samples picked by position are the same labels."""
+        lazy, eager = _pair(MS)
+        _assert_same(
+            lambda: xr.align(
+                lazy.isel(x=slice(0, 3)), lazy.isel(x=[0, 1, 2]), join="exact"
+            )[0],
+            lambda: xr.align(
+                eager.isel(x=slice(0, 3)), eager.isel(x=[0, 1, 2]), join="exact"
+            )[0],
+        )
+        other = lazy.isel(x=[0, 1, 3])
+        with pytest.raises(xr.AlignmentError):
+            xr.align(lazy.isel(x=slice(0, 3)), other, join="exact")
+
     def test_equal_labels_need_no_join(self):
         """Arrays whose coordinates label alike stay lazy."""
         distance = get_coord(start=0.0, step=0.5, shape=(20,), units="m")
@@ -551,6 +577,15 @@ class TestFromVariables:
         monkeypatch.setattr(CoordRange, "_get_index_values", _bounded)
         out = lazy + converted
         assert isinstance(out.xindexes["x"], CoordIndex)
+
+    def test_text_labels_stay_text(self):
+        """Picked text labels keep their own coordinate class."""
+        text = xr.DataArray(np.arange(3), dims="x", coords={"x": ["a", "b", "c"]})
+        out = text.drop_indexes("x").set_xindex("x", CoordIndex)
+        picked = out.isel(x=[0, 1])
+        assert type(picked.xindexes["x"].coordinate).__name__ == "CoordString"
+        joined = xr.concat([picked, out.isel(x=[2])], "x")
+        np.testing.assert_array_equal(joined["x"].values, ["a", "b", "c"])
 
     def test_units_and_refusals(self):
         """Units come from the variable; several or 2-d variables are refused."""
@@ -682,6 +717,15 @@ class TestPatchRoundTrip:
         kinds = {type(x).__name__ for x in array.xindexes.values()}
         assert kinds == {"PandasIndex"}
         assert xarray_to_patch(array) == patch
+
+    def test_all_serves_ranges_only(self):
+        """lazy_coords=True leaves a coordinate holding its labels materialized."""
+        coord = get_coord(data=np.array([0.0, 1.0, 5.0]))
+        patch = dc.Patch(data=np.arange(3), dims=("x",), coords={"x": coord})
+        array = patch_to_xarray(patch, lazy_coords=True)
+        assert type(array.xindexes["x"]).__name__ == "PandasIndex"
+        named = patch_to_xarray(patch, lazy_coords={"x"})
+        assert isinstance(named.xindexes["x"], CoordIndex)
 
     def test_named_coordinates_only(self):
         """Names choose which dimensions are served lazily."""

--- a/tests/test_xarray/test_xr_index.py
+++ b/tests/test_xarray/test_xr_index.py
@@ -9,7 +9,13 @@ import pandas as pd
 import pytest
 
 import dascore as dc
-from dascore.core.coords import CoordRange, CoordSegmented, concat_coords, get_coord
+from dascore.core.coords import (
+    CoordArray,
+    CoordRange,
+    CoordSegmented,
+    concat_coords,
+    get_coord,
+)
 
 xr = pytest.importorskip("xarray")
 da = pytest.importorskip("dask.array")
@@ -59,13 +65,7 @@ def _assert_same(lazy_call, eager_call):
     assert out.sizes == expected.sizes
     np.testing.assert_array_equal(np.asarray(out.values), expected.values)
     for name in expected.coords:
-        got, want = out[name].values, expected[name].values
-        if want.dtype.kind == "f":
-            # a slice of a float range is labeled as DASCore labels it,
-            # which can differ from the parent's labels in the last bits
-            np.testing.assert_allclose(got, want, rtol=1e-12, atol=1e-12)
-        else:
-            np.testing.assert_array_equal(got, want)
+        np.testing.assert_array_equal(out[name].values, expected[name].values)
 
 
 def _between(values, i):
@@ -97,6 +97,8 @@ def _queries(values):
         dict(x=slice(values[3], values[21], 3)),
         dict(x=slice(far, values[4])),
         dict(x=slice(values[9], values[3])),
+        dict(x=slice(values[21], values[3], -3)),
+        dict(x=slice(values[3], values[9], 0)),
     ]
 
 
@@ -113,6 +115,12 @@ class TestSelParity:
     @pytest.mark.parametrize(
         "label",
         [
+            slice(np.datetime64("NaT", "ns"), T0 + 5 * HOUR),
+            slice(np.datetime64("2500-01-01"), None),
+            slice(None, np.datetime64("1500-01-01")),
+            np.datetime64("2500-01-01"),
+            np.datetime64("2020-01-01T05", "h"),
+            xr.DataArray("2020-01-01"),
             "2020-01-01",
             "2020-01-01T05",
             "2019-06",
@@ -129,6 +137,19 @@ class TestSelParity:
         lazy, eager = _pair(COORDS["hourly"])
         _assert_same(lambda: lazy.sel(x=label), lambda: eager.sel(x=label))
 
+    @pytest.mark.parametrize("label", [0, [0, 1], 5.0])
+    def test_numbers_do_not_name_stamps(self, label):
+        """A number is no timestamp, even on a grid starting at the epoch."""
+        epoch = get_coord(start=np.datetime64(0, "ns"), step=ONE_MS, shape=(10,))
+        lazy, eager = _pair(epoch)
+        _assert_same(lambda: lazy.sel(x=label), lambda: eager.sel(x=label))
+
+    def test_integers_past_float_precision(self):
+        """An integer grid beyond 2**53 answers exactly."""
+        lazy, eager = _pair(get_coord(start=2**53, step=1, shape=(100,)))
+        for label in (2**53 + 5, [2**53 + 5, 2**53 + 7]):
+            _assert_same(lambda q=label: lazy.sel(x=q), lambda q=label: eager.sel(x=q))
+
     def test_one_sample_period_keeps_dimension(self):
         """A coarse string over one sample keeps the dimension."""
         coord = get_coord(start=T0 - HOUR, step=HOUR, shape=(30,))
@@ -144,6 +165,7 @@ class TestSelParity:
             xr.DataArray(values[[2, 8]], dims="z"),
             xr.Variable("z", values[[4, 9]]),
             xr.DataArray(values[[[1, 2], [3, 4]]], dims=("a", "b")),
+            xr.DataArray(np.arange(len(MS)) % 3 == 0, dims="x"),
         ):
             _assert_same(lambda q=label: lazy.sel(x=q), lambda q=label: eager.sel(x=q))
         out = lazy.sel(x=xr.DataArray(values[[2, 8]], dims="z"))
@@ -167,6 +189,24 @@ class TestSelParity:
         assert lazy.sel(x=slice(values[3], values[9])).sizes["x"] == 7
         assert lazy.sel(x=values[5]).values == 5
         assert lazy.isel(x=slice(2, 50, 3)).sel(x=values[5]).values == 5
+
+    @pytest.mark.parametrize("name", ["ms", "fraction", "int", "descending"])
+    def test_integer_grids_skip_pandas(self, name, monkeypatch):
+        """Scalars and ascending slices on integer grids resolve arithmetically."""
+        from dascore.utils import indexing  # noqa: PLC0415
+
+        coord = COORDS[name]
+        lazy, _ = _pair(coord)
+
+        def _refuse(*args, **kwargs):
+            raise AssertionError("resolved through pandas")
+
+        values = coord.values
+        monkeypatch.setattr(indexing, "_label_index", _refuse)
+        assert lazy.sel(x=values[5]).values == 5
+        if coord.sorted:
+            out = lazy.sel(x=slice(values[3], values[9], 2))
+            np.testing.assert_array_equal(out.values, [3, 5, 7, 9])
 
     def test_segmented_sel_keeps_no_labels(self, monkeypatch):
         """A segmented coordinate evaluates labels for a lookup, never keeps them."""
@@ -196,6 +236,8 @@ class TestIsel:
             [-1, 0],
             np.arange(10) % 3 == 0,
             3,
+            [1.5],
+            [1000],
         ],
     )
     def test_labels_match(self, name, indexer):
@@ -203,9 +245,15 @@ class TestIsel:
         lazy, eager = _pair(COORDS[name])
         if isinstance(indexer, np.ndarray):
             indexer = np.resize(indexer, len(COORDS[name]))
-        out, expected = lazy.isel(x=indexer), eager.isel(x=indexer)
+        try:
+            expected = eager.isel(x=indexer)
+        except Exception as err:
+            with pytest.raises(type(err)):
+                lazy.isel(x=indexer)
+            return
+        out = lazy.isel(x=indexer)
         _assert_same(lambda: out, lambda: expected)
-        if np.ndim(indexer):
+        if np.ndim(indexer) and len(expected["x"]):
             # a label lookup still works on the result
             label = expected["x"].values[0]
             _assert_same(lambda: out.sel(x=label), lambda: expected.sel(x=label))
@@ -220,16 +268,31 @@ class TestIsel:
         assert isinstance(index, CoordIndex)
         assert index.coordinate == MS[indexer]
 
+    def test_float_slices_keep_their_labels(self):
+        """A float range's slice is materialized, keeping the labels it selects."""
+        coord = COORDS["float"]
+        lazy, _ = _pair(coord)
+        sub = lazy.isel(x=slice(3, 20))
+        assert sub.sel(x=coord.values[5]).values == 5
+        assert (lazy + sub).sizes["x"] == 17
+
     def test_segmented_slice_stays_lazy(self):
         """A contiguous slice of a segmented coordinate is served lazily too."""
         lazy, _ = _pair(COORDS["segmented"])
         assert isinstance(lazy.isel(x=slice(10, 60)).xindexes["x"], CoordIndex)
-        assert not isinstance(lazy.isel(x=slice(10, 60, 2)).xindexes["x"], CoordIndex)
+        strided = lazy.isel(x=slice(10, 60, 2)).xindexes["x"]
+        assert isinstance(strided.coordinate, CoordArray)
 
-    def test_fancy_indexing_materializes(self):
-        """Fancy indexing keeps a materialized index over the picks."""
-        lazy, _ = _pair(MS)
-        assert type(lazy.isel(x=[1, 5]).xindexes["x"]).__name__ == "PandasIndex"
+    def test_fancy_indexing_holds_its_picks(self):
+        """Fancy indexing holds the picked labels, and still aligns with a slice."""
+        lazy, eager = _pair(MS)
+        index = lazy.isel(x=[1, 5]).xindexes["x"]
+        assert isinstance(index, CoordIndex)
+        assert isinstance(index.coordinate, CoordArray)
+        _assert_same(
+            lambda: lazy.isel(x=[0, 1, 2]) + lazy.isel(x=slice(0, 3)),
+            lambda: eager.isel(x=[0, 1, 2]) + eager.isel(x=slice(0, 3)),
+        )
 
     def test_vectorized_isel_onto_another_dimension(self):
         """An indexer on a new dimension moves the labels there."""
@@ -241,6 +304,30 @@ class TestIsel:
         np.testing.assert_array_equal(out["x"].values, expected["x"].values)
         grid = xr.DataArray([[1, 5]], dims=("a", "b"))
         assert "x" not in lazy.isel(x=grid).xindexes
+
+
+class TestRenames:
+    """Renaming a dimension or its coordinate keeps them apart."""
+
+    @pytest.mark.parametrize("name", ["ms", "segmented"])
+    def test_rename_dims_and_vars(self, name):
+        """Selection and slicing follow each new name, as eager arrays do."""
+        lazy, eager = (x.to_dataset(name="v") for x in _pair(COORDS[name]))
+        label = COORDS[name].values[3]
+        for rename, key in ((dict(x="y"), "dims"), (dict(x="z"), "vars")):
+            got = getattr(lazy, f"rename_{key}")(**rename)
+            want = getattr(eager, f"rename_{key}")(**rename)
+            coord_name, dim = ("x", "y") if key == "dims" else ("z", "x")
+            _assert_same(
+                lambda g=got, n=coord_name: g.sel({n: label})["v"],
+                lambda w=want, n=coord_name: w.sel({n: label})["v"],
+            )
+            sliced = got.isel({dim: slice(2, 9)})
+            assert sliced[coord_name].dims == (dim,)
+            np.testing.assert_array_equal(
+                sliced[coord_name].values,
+                want.isel({dim: slice(2, 9)})[coord_name].values,
+            )
 
 
 class TestTransform:
@@ -284,11 +371,6 @@ class TestTransform:
 
 class TestEligibility:
     """Which coordinates are served lazily."""
-
-    @pytest.mark.parametrize("name", list(COORDS))
-    def test_ranges_and_segments_are_served(self, name):
-        """Every range and segmented coordinate, any dtype or direction."""
-        assert is_servable(COORDS[name])
 
     def test_others_are_not(self):
         """Arrays and a zero step, whose labels repeat, are not."""
@@ -346,10 +428,10 @@ class TestConcat:
         ],
     )
     def test_unchained_concat_materializes(self, pieces):
-        """Parts which do not chain in order keep their labels, materialized."""
+        """Parts which do not chain in order keep their labels, held as they are."""
         parts = self._parts(*pieces)
         out = xr.concat(parts, dim="x")
-        assert type(out.xindexes["x"]).__name__ == "PandasIndex"
+        assert isinstance(out.xindexes["x"].coordinate, CoordArray)
         expected = np.concatenate([x["x"].values for x in parts])
         np.testing.assert_array_equal(out["x"].values, expected)
 
@@ -360,6 +442,32 @@ class TestConcat:
         out = xr.concat([lazy, later], dim="x")
         np.testing.assert_array_equal(out["x"].values, MS.values)
         assert type(out.xindexes["x"]).__name__ == "PandasIndex"
+
+    def test_concat_after_a_materialized_part(self):
+        """A materialized first part concatenates with lazy ones."""
+        lazy, eager = _pair(MS[:10])
+        _assert_same(
+            lambda: xr.concat([lazy.isel(x=[0, 1]), lazy.isel(x=slice(2, None))], "x"),
+            lambda: xr.concat(
+                [eager.isel(x=[0, 1]), eager.isel(x=slice(2, None))], "x"
+            ),
+        )
+
+    def test_concat_after_a_pandas_index(self):
+        """A plain pandas index first reads the lazy parts' materialized form."""
+        eager = _pair(MS[:50])[1]
+        lazy = _pair(MS[50:])[0]
+        out = xr.concat([eager, lazy], dim="x")
+        assert type(out.xindexes["x"]).__name__ == "PandasIndex"
+        np.testing.assert_array_equal(out["x"].values, MS.values)
+
+    def test_float_parts_keep_their_labels(self):
+        """Float parts never fuse into a range that would relabel them."""
+        coord = COORDS["float"]
+        parts = [_pair(coord[s])[0] for s in (slice(0, 20), slice(20, 50))]
+        out = xr.concat(parts, dim="x")
+        expected = np.concatenate([x["x"].values for x in parts])
+        np.testing.assert_array_equal(out["x"].values, expected)
 
     def test_concat_with_positions_reorders(self):
         """An explicit permutation materializes in that order."""
@@ -396,6 +504,18 @@ class TestAlignment:
         for got, want in zip(out, expected):
             _assert_same(lambda g=got: g, lambda w=want: w)
 
+    @pytest.mark.parametrize("method", [None, "nearest"])
+    def test_reindex_like_takes_method(self, method):
+        """Reindexing to another lazy array honours method, as eager does."""
+        lazy, eager = _pair(MS, data=np.arange(len(MS)) * 1.0)
+        # a coarser grid off this one's samples, so only nearest finds them
+        coarse = get_coord(start=T0 + ONE_MS // 3, step=10 * ONE_MS, shape=(10,))
+        lazy_to, eager_to = _pair(coarse)
+        _assert_same(
+            lambda: lazy.reindex_like(lazy_to, method=method),
+            lambda: eager.reindex_like(eager_to, method=method),
+        )
+
     def test_materialized_index_refuses_to_align(self):
         """Xarray matches indexes by type; lazy_coords=False is the way out."""
         lazy, eager = _pair(MS)
@@ -423,6 +543,30 @@ class TestScale:
         assert sub.sizes["time"] == 2000
         assert sub["time"].values[0] == np.datetime64("2020-01-05", "ns")
         assert isinstance(sub.xindexes["time"], CoordIndex)
+
+    def test_segmented_selection_reads_few_labels(self, monkeypatch):
+        """Selecting on a long segmented coordinate evaluates a handful of labels."""
+        n = 1_000_000_000
+        first = get_coord(start=T0, step=ONE_MS, shape=(n,))
+        second = get_coord(start=first.max() + 10 * ONE_MS, step=ONE_MS, shape=(n,))
+        coord = concat_coords(first, second)
+        index = CoordIndex.from_coord("x", coord)
+        lazy = xr.DataArray(
+            da.zeros((2 * n,), chunks=100_000_000),
+            dims=("x",),
+            coords=xr.Coordinates.from_xindex(index),
+        )
+        original = CoordRange._get_index_values
+
+        def _bounded(self, indices):
+            assert np.size(indices) < 1000, "the selection evaluated every label"
+            return original(self, indices)
+
+        monkeypatch.setattr(CoordRange, "_get_index_values", _bounded)
+        label = second.min() + 5 * ONE_MS
+        assert int(lazy.sel(x=label)["x"].values == label)
+        sub = lazy.sel(x=slice(first.max() - ONE_MS, label))
+        assert sub.sizes["x"] == 8
 
     def test_billion_sample_segments_are_free(self):
         """A gapped merge of long runs builds without materializing labels."""
@@ -470,7 +614,7 @@ class TestPatchRoundTrip:
         """The coordinate comes back equal, exact grid and segments included."""
         coord = COORDS[name]
         patch = dc.Patch(data=np.arange(len(coord)), dims=("x",), coords={"x": coord})
-        array = patch_to_xarray(patch)
+        array = patch_to_xarray(patch, lazy_coords=True)
         assert isinstance(array.xindexes["x"], CoordIndex)
         assert xarray_to_patch(array).get_coord("x") == coord
 
@@ -478,17 +622,17 @@ class TestPatchRoundTrip:
         """Units stated beside a lazy coordinate are the coordinate's units."""
         coord = get_coord(start=0.0, step=0.5, shape=(20,), units="m")
         patch = dc.Patch(data=np.arange(20), dims=("x",), coords={"x": coord})
-        array = patch_to_xarray(patch)
+        array = patch_to_xarray(patch, lazy_coords=True)
         assert array["x"].attrs["units"] == "1 m"
         array["x"].attrs["units"] = "ft"
         back = xarray_to_patch(array).get_coord("x")
         assert back == coord.set_units("ft")
 
-    @pytest.mark.parametrize("lazy", [False, ()])
-    def test_opt_out(self, lazy):
-        """lazy_coords=False (or no names) materializes every coordinate."""
+    @pytest.mark.parametrize("lazy", [{}, {"lazy_coords": False}, {"lazy_coords": ()}])
+    def test_materialized_by_default(self, lazy):
+        """By default (or with no names) every coordinate is materialized."""
         patch = dc.get_example_patch()
-        array = patch_to_xarray(patch, lazy_coords=lazy)
+        array = patch_to_xarray(patch, **lazy)
         kinds = {type(x).__name__ for x in array.xindexes.values()}
         assert kinds == {"PandasIndex"}
         assert xarray_to_patch(array) == patch

--- a/tests/test_xarray/test_xr_index.py
+++ b/tests/test_xarray/test_xr_index.py
@@ -1,694 +1,500 @@
-"""Tests for the lazy evenly sampled temporal xarray index."""
+"""Tests for the lazy xarray index over DASCore coordinates."""
 
 from __future__ import annotations
 
 import pickle
 
 import numpy as np
+import pandas as pd
 import pytest
 
-from dascore.core.coords import get_coord
+import dascore as dc
+from dascore.core.coords import CoordRange, CoordSegmented, concat_coords, get_coord
 
-pytest.importorskip("xarray")
-pytest.importorskip("dask")
+xr = pytest.importorskip("xarray")
+da = pytest.importorskip("dask.array")
 
+from dascore.xarray.index import CoordIndex, CoordTransform, is_servable  # noqa: E402
+from dascore.xarray.patch import patch_to_xarray, xarray_to_patch  # noqa: E402
 
+T0 = np.datetime64("2020-01-01", "ns")
 ONE_MS = np.timedelta64(1_000_000, "ns")
+HOUR = np.timedelta64(3_600_000_000_000, "ns")
+
+MS = get_coord(start=T0, step=ONE_MS, shape=(100,))
+COORDS = {
+    "ms": MS,
+    "hourly": get_coord(start=T0, step=HOUR, shape=(48,)),
+    "descending": MS[::-1],
+    "fraction": get_coord(start=T0, step=(1, 1024), shape=(3000,)),
+    "duration": get_coord(start=np.timedelta64(0, "s"), step=ONE_MS, shape=(50,)),
+    "float": get_coord(start=-3.3, step=1.0209, shape=(50,)),
+    "int": get_coord(start=10, step=3, shape=(40,)),
+    "segmented": concat_coords(MS[:30], MS[50:]),
+    "float_segmented": concat_coords(
+        get_coord(start=0.0, step=0.5, shape=(20,)),
+        get_coord(start=20.0, step=0.5, shape=(20,)),
+    ),
+}
 
 
-@pytest.fixture(scope="module")
-def small_index():
-    """An index over 100 samples of millisecond data."""
-    from dascore.xarray.index import TemporalRangeIndex  # noqa: PLC0415
+def _pair(coord, name="x", data=None):
+    """The same array labeled lazily and eagerly by one coordinate."""
+    data = np.arange(len(coord)) if data is None else data
+    index = CoordIndex.from_coord(name, coord)
+    lazy = xr.DataArray(data, dims=(name,), coords=xr.Coordinates.from_xindex(index))
+    eager = xr.DataArray(data, dims=(name,), coords={name: coord.values})
+    return lazy, eager
 
-    coord = get_coord(
-        min=np.datetime64("2020-01-01", "ns"),
-        max=np.datetime64("2020-01-01", "ns") + 100 * ONE_MS,
-        step=ONE_MS,
+
+def _assert_same(lazy_call, eager_call):
+    """The lazy array answers as the eager one does, raising alike."""
+    try:
+        expected = eager_call()
+    except Exception as err:
+        with pytest.raises(type(err)):
+            lazy_call()
+        return
+    out = lazy_call()
+    assert out.sizes == expected.sizes
+    np.testing.assert_array_equal(np.asarray(out.values), expected.values)
+    for name in expected.coords:
+        got, want = out[name].values, expected[name].values
+        if want.dtype.kind == "f":
+            # a slice of a float range is labeled as DASCore labels it,
+            # which can differ from the parent's labels in the last bits
+            np.testing.assert_allclose(got, want, rtol=1e-12, atol=1e-12)
+        else:
+            np.testing.assert_array_equal(got, want)
+
+
+def _between(values, i):
+    """A label a third of the way from sample i to sample i + 1."""
+    gap = values[i + 1] - values[i]
+    return values[i] + (gap // 3 if values.dtype.kind in "iumM" else gap / 3)
+
+
+def _queries(values):
+    """Label selections to ask of both arrays, as sel keyword dicts."""
+    off = _between(values, 7)
+    step = values[1] - values[0]
+    far = values[0] - 5 * step
+    tiny = step // 10 if values.dtype.kind in "iumM" else step / 10
+    tiny = tiny or 1
+    return [
+        dict(x=values[7]),
+        dict(x=values[[2, 8]]),
+        dict(x=off),
+        dict(x=off, method="nearest"),
+        dict(x=values[[2, 8]] + (off - values[7]), method="nearest"),
+        dict(x=far, method="nearest"),
+        dict(x=off, method="nearest", tolerance=abs(tiny)),
+        dict(x=off, method="nearest", tolerance=abs(step)),
+        dict(x=slice(values[3], values[9])),
+        dict(x=slice(off, values[20])),
+        dict(x=slice(None, values[5])),
+        dict(x=slice(values[5], None)),
+        dict(x=slice(values[3], values[21], 3)),
+        dict(x=slice(far, values[4])),
+        dict(x=slice(values[9], values[3])),
+    ]
+
+
+class TestSelParity:
+    """Label selection answers as a materialized pandas index answers."""
+
+    @pytest.mark.parametrize("name", list(COORDS))
+    def test_queries(self, name):
+        """Scalars, arrays, nearest, tolerance, and slices, on every kind."""
+        lazy, eager = _pair(COORDS[name])
+        for query in _queries(COORDS[name].values):
+            _assert_same(lambda q=query: lazy.sel(**q), lambda q=query: eager.sel(**q))
+
+    @pytest.mark.parametrize(
+        "label",
+        [
+            "2020-01-01",
+            "2020-01-01T05",
+            "2019-06",
+            "not-a-date",
+            ["not-a-date"],
+            0,
+            [0, 1],
+            slice("2020-01-01", "2020-01-02"),
+            slice("2020-01-01T10", None),
+        ],
     )
-    return TemporalRangeIndex.from_coord("time", coord)
+    def test_datetime_strings(self, label):
+        """Partial strings name their periods, as pandas reads them."""
+        lazy, eager = _pair(COORDS["hourly"])
+        _assert_same(lambda: lazy.sel(x=label), lambda: eager.sel(x=label))
 
+    def test_one_sample_period_keeps_dimension(self):
+        """A coarse string over one sample keeps the dimension."""
+        coord = get_coord(start=T0 - HOUR, step=HOUR, shape=(30,))
+        lazy, eager = _pair(coord)
+        for label in ("2019-12-31", "2019-12-31T23"):
+            _assert_same(lambda q=label: lazy.sel(x=q), lambda q=label: eager.sel(x=q))
 
-@pytest.fixture(scope="module")
-def small_array(small_index):
-    """A dask-backed DataArray labeled by the small index."""
-    import dask.array as da  # noqa: PLC0415
-    import xarray as xr  # noqa: PLC0415
-
-    coords = xr.Coordinates.from_xindex(small_index)
-    data = da.arange(100, chunks=25)
-    return xr.DataArray(data, dims=("time",), coords=coords)
-
-
-class TestTemporalRangeTransform:
-    """Unit tests for the position/label arithmetic."""
-
-    def test_forward_matches_coord_values(self, small_index):
-        """Lazily served labels equal the materialized coordinate's."""
-        coord = get_coord(
-            min=np.datetime64("2020-01-01", "ns"),
-            max=np.datetime64("2020-01-01", "ns") + 100 * ONE_MS,
-            step=ONE_MS,
-        )
-        served = small_index.transform.forward({"time": np.arange(100)})["time"]
-        np.testing.assert_array_equal(served, coord.values)
-
-    def test_reverse_exact_at_large_offsets(self):
-        """A label a year of nanoseconds out lands on its exact sample.
-
-        Float inversion loses sample precision past 2**53 ns (~104
-        days); the integer divmod must not.
-        """
-        from dascore.xarray.index import (  # noqa: PLC0415
-            TemporalRangeIndex,
-            TemporalRangeTransform,
-        )
-
-        step_ns = 1  # nanosecond sampling: the worst case
-        size = 2**53 + 10
-        start = np.datetime64("2020-01-01", "ns").astype("int64")
-        t = TemporalRangeTransform("time", size, int(start), step_ns, "datetime64[ns]")
-        # 2**53 + 1 has no float64 representation, so a float inversion
-        # cannot return it; the exact integer path must.
-        pos = 2**53 + 1
-        label = t.forward({"time": np.array([pos])})["time"]
-        quot, rem = TemporalRangeIndex(t)._exact_positions(label)
-        assert int(quot[0]) == pos and int(rem[0]) == 0
-
-    def test_timedelta_dtype(self):
-        """A timedelta64 coordinate round-trips through the transform."""
-        from dascore.xarray.index import TemporalRangeIndex  # noqa: PLC0415
-
-        coord = get_coord(min=np.timedelta64(0, "ns"), max=10 * ONE_MS, step=ONE_MS)
-        index = TemporalRangeIndex.from_coord("offset", coord)
-        served = index.transform.forward({"offset": np.arange(len(coord))})["offset"]
-        np.testing.assert_array_equal(served, coord.values)
-
-    def test_equals(self, small_index):
-        """Equality keys on start, step, size, and dtype."""
-        from dascore.xarray.index import (  # noqa: PLC0415
-            TemporalRangeIndex,
-            TemporalRangeTransform,
-        )
-
-        t = small_index.transform
-        same = TemporalRangeIndex(
-            TemporalRangeTransform("time", 100, t.start_ns, t.step_ns, t.dtype)
-        )
-        assert t.equals(same.transform)
-        changed = [
-            TemporalRangeTransform("time", 100, t.start_ns + 1, t.step_ns, t.dtype),
-            TemporalRangeTransform("time", 100, t.start_ns, t.step_ns + 1, t.dtype),
-            TemporalRangeTransform("time", 99, t.start_ns, t.step_ns, t.dtype),
-            TemporalRangeTransform(
-                "time", 100, t.start_ns, t.step_ns, "timedelta64[ns]"
-            ),
-        ]
-        for wrong in changed:
-            assert not t.equals(wrong)
-
-    def test_pickle_roundtrip(self, small_index):
-        """The index ships in a dask graph, so it must pickle."""
-        loaded = pickle.loads(pickle.dumps(small_index))
-        assert loaded.transform.equals(small_index.transform)
-
-
-class TestSel:
-    """Label selection resolves arithmetically."""
-
-    def test_slice_inclusive_endpoints(self, small_array):
-        """Both on-grid endpoints stay, as pandas label slicing keeps."""
-        t = small_array["time"].values
-        out = small_array.sel(time=slice(t[10], t[20]))
-        assert out.sizes["time"] == 11
-        np.testing.assert_array_equal(out.compute().values, np.arange(10, 21))
-
-    def test_slice_off_grid_endpoints(self, small_array):
-        """Off-grid endpoints keep only samples inside the interval."""
-        t = small_array["time"].values
-        half = ONE_MS // 2
-        out = small_array.sel(time=slice(t[10] + half, t[20] + half))
-        np.testing.assert_array_equal(out.compute().values, np.arange(11, 21))
-
-    def test_slice_beyond_span_clamps(self, small_array):
-        """Overhanging endpoints clamp to the edges; disjoint ones empty."""
-        t = small_array["time"].values
-        wide = small_array.sel(time=slice(t[0] - 5 * ONE_MS, t[-1] + 5 * ONE_MS))
-        assert wide.sizes["time"] == 100
-        before = small_array.sel(time=slice(t[0] - 9 * ONE_MS, t[0] - ONE_MS))
-        assert before.sizes["time"] == 0
-        after = small_array.sel(time=slice(t[-1] + ONE_MS, t[-1] + 9 * ONE_MS))
-        assert after.sizes["time"] == 0
-        # far enough out that naive int64 subtraction could overflow
-        century = small_array.sel(time=slice("1800-01-01", t[10]))
-        assert century.sizes["time"] == 11
-
-    def test_slice_step_strides_samples(self, small_array):
-        """An integer slice step strides the selected samples."""
-        t = small_array["time"].values
-        out = small_array.sel(time=slice(t[10], t[20], 3))
-        np.testing.assert_array_equal(out.compute().values, np.arange(10, 21, 3))
-
-    def test_slice_step_validated(self, small_array):
-        """A non-integer or negative slice step is refused with a reason."""
-        t = small_array["time"].values
-        with pytest.raises(ValueError, match="stride"):
-            small_array.sel(time=slice(t[0], t[20], ONE_MS))
-        with pytest.raises(ValueError, match="stride"):
-            small_array.sel(time=slice(t[20], t[0], -1))
-
-    def test_slice_open_ends(self, small_array):
-        """Open-ended slices span to the array's edges."""
-        t = small_array["time"].values
-        assert small_array.sel(time=slice(None, t[5])).sizes["time"] == 6
-        assert small_array.sel(time=slice(t[95], None)).sizes["time"] == 5
-        assert small_array.sel(time=slice(None, None)).sizes["time"] == 100
-
-    def test_slice_with_string_labels(self, small_array):
-        """Strings parse like any other datetime spelling."""
-        out = small_array.sel(
-            time=slice("2020-01-01T00:00:00.010", "2020-01-01T00:00:00.020")
-        )
-        assert out.sizes["time"] == 11
-
-    def test_scalar_exact_by_default(self, small_array):
-        """An on-grid scalar selects; an off-grid one raises, as pandas."""
-        t = small_array["time"].values
-        assert small_array.sel(time=t[7]).compute().values == 7
-        with pytest.raises(KeyError, match="sample grid"):
-            small_array.sel(time=t[7] + ONE_MS // 4)
-
-    def test_scalar_nearest_rounds_both_ways(self, small_array):
-        """method="nearest" picks the closer sample on either side."""
-        t = small_array["time"].values
-        low = small_array.sel(time=t[7] + ONE_MS // 4, method="nearest")
-        high = small_array.sel(time=t[7] + (6 * ONE_MS) // 10, method="nearest")
-        assert low.compute().values == 7
-        assert high.compute().values == 8
-
-    def test_scalar_out_of_span_raises(self, small_array):
-        """A label outside the sampled span never clips to an edge."""
-        t = small_array["time"].values
-        with pytest.raises(KeyError, match="outside"):
-            small_array.sel(time=t[0] - ONE_MS, method="nearest")
-        with pytest.raises(KeyError, match="outside"):
-            small_array.sel(time=t[-1] + ONE_MS, method="nearest")
-        # centuries away (but ns-representable) must not wrap into a sample
-        with pytest.raises(KeyError):
-            small_array.sel(time=np.datetime64("1800-01-01", "ns"), method="nearest")
-
-    def test_nat_labels_raise(self, small_array):
-        """NaT never resolves to a sample, scalar or slice endpoint."""
-        with pytest.raises(ValueError, match="NaT"):
-            small_array.sel(time=np.datetime64("NaT", "ns"), method="nearest")
-        with pytest.raises(ValueError, match="NaT"):
-            small_array.sel(time=slice(np.datetime64("NaT", "ns"), None))
-
-    def test_unsupported_method_raises(self, small_array):
-        """pad/ffill would silently answer differently; refuse them."""
-        t = small_array["time"].values
-        with pytest.raises(ValueError, match="method"):
-            small_array.sel(time=t[7], method="pad")
-
-    def test_dataarray_label_keeps_dims(self, small_array):
-        """A DataArray label routes through vectorized nearest lookup."""
-        import xarray as xr  # noqa: PLC0415
-
-        t = small_array["time"].values
-        label = xr.DataArray(t[[2, 8]], dims="z")
-        out = small_array.sel(time=label)
+    def test_dataarray_labels_keep_their_dims(self):
+        """Vectorized labels select along their own dimension."""
+        lazy, eager = _pair(MS)
+        values = MS.values
+        for label in (
+            xr.DataArray(values[[2, 8]], dims="z"),
+            xr.Variable("z", values[[4, 9]]),
+            xr.DataArray(values[[[1, 2], [3, 4]]], dims=("a", "b")),
+        ):
+            _assert_same(lambda q=label: lazy.sel(x=q), lambda q=label: eager.sel(x=q))
+        out = lazy.sel(x=xr.DataArray(values[[2, 8]], dims="z"))
         assert out.dims == ("z",)
-        np.testing.assert_array_equal(out.compute().values, [2, 8])
 
-    def test_array_labels(self, small_array):
-        """An array of on-grid labels resolves per label."""
-        t = small_array["time"].values
-        out = small_array.sel(time=t[[3, 40, 99]])
-        np.testing.assert_array_equal(out.compute().values, [3, 40, 99])
-        with pytest.raises(KeyError, match="sample grid"):
-            small_array.sel(time=t[[3, 40]] + ONE_MS // 3)
+    def test_method_with_slice_raises(self):
+        """Neither index takes a method with a slice."""
+        lazy, _ = _pair(MS)
+        with pytest.raises(NotImplementedError):
+            lazy.sel(x=slice(MS.values[1], None), method="nearest")
 
-    def test_tolerance_refused(self, small_array):
-        """Tolerance is not implemented; say so rather than ignore it."""
-        t = small_array["time"].values
-        with pytest.raises(ValueError, match="tolerance"):
-            small_array.sel(time=t[0], tolerance=ONE_MS)
+    def test_sel_reads_no_labels(self, monkeypatch):
+        """Selecting on a range looks up the queried labels only."""
+        lazy, _ = _pair(MS)
+
+        def _refuse(self):
+            raise AssertionError("the coordinate spelled out its labels")
+
+        monkeypatch.setattr(CoordRange, "values", property(_refuse))
+        values = MS._get_index_values(np.arange(len(MS)))
+        assert lazy.sel(x=slice(values[3], values[9])).sizes["x"] == 7
+        assert lazy.sel(x=values[5]).values == 5
+        assert lazy.isel(x=slice(2, 50, 3)).sel(x=values[5]).values == 5
+
+    def test_segmented_sel_keeps_no_labels(self, monkeypatch):
+        """A segmented coordinate evaluates labels for a lookup, never keeps them."""
+        lazy, _ = _pair(concat_coords(MS[:30], MS[50:]))
+
+        def _refuse(self):
+            raise AssertionError("the coordinate spelled out and cached its labels")
+
+        monkeypatch.setattr(CoordSegmented, "values", property(_refuse))
+        out = lazy.sel(x=slice(MS.values[20], MS.values[60]))
+        np.testing.assert_array_equal(out.values, np.r_[20:30, 30:41])
 
 
 class TestIsel:
-    """Positional selection keeps the index lazy where it can."""
+    """Positional selection keeps a lazy index where it can."""
 
-    def test_contiguous_slice_keeps_lazy_index(self, small_array):
-        """A plain slice yields a new lazy index with a shifted start."""
-        from dascore.xarray.index import TemporalRangeIndex  # noqa: PLC0415
+    @pytest.mark.parametrize("name", list(COORDS))
+    @pytest.mark.parametrize(
+        "indexer",
+        [
+            slice(3, 20),
+            slice(2, 50, 3),
+            slice(None, None, -1),
+            slice(30, 5, -2),
+            slice(5, 5),
+            [1, 5, 9],
+            [-1, 0],
+            np.arange(10) % 3 == 0,
+            3,
+        ],
+    )
+    def test_labels_match(self, name, indexer):
+        """Every indexer labels the samples it selects, as the eager array does."""
+        lazy, eager = _pair(COORDS[name])
+        if isinstance(indexer, np.ndarray):
+            indexer = np.resize(indexer, len(COORDS[name]))
+        out, expected = lazy.isel(x=indexer), eager.isel(x=indexer)
+        _assert_same(lambda: out, lambda: expected)
+        if np.ndim(indexer):
+            # a label lookup still works on the result
+            label = expected["x"].values[0]
+            _assert_same(lambda: out.sel(x=label), lambda: expected.sel(x=label))
 
-        out = small_array.isel(time=slice(10, 20))
-        index = out.xindexes["time"]
-        assert isinstance(index, TemporalRangeIndex)
-        assert index.transform.start_ns == small_array["time"].values[10].astype(
-            "int64"
-        )
+    @pytest.mark.parametrize(
+        "indexer", [slice(3, 20), slice(2, 50, 3), slice(None, None, -1)]
+    )
+    def test_slices_stay_lazy(self, indexer):
+        """A slice of a range is a range: the index stays lazy."""
+        lazy, _ = _pair(MS)
+        index = lazy.isel(x=indexer).xindexes["x"]
+        assert isinstance(index, CoordIndex)
+        assert index.coordinate == MS[indexer]
+
+    def test_segmented_slice_stays_lazy(self):
+        """A contiguous slice of a segmented coordinate is served lazily too."""
+        lazy, _ = _pair(COORDS["segmented"])
+        assert isinstance(lazy.isel(x=slice(10, 60)).xindexes["x"], CoordIndex)
+        assert not isinstance(lazy.isel(x=slice(10, 60, 2)).xindexes["x"], CoordIndex)
+
+    def test_fancy_indexing_materializes(self):
+        """Fancy indexing keeps a materialized index over the picks."""
+        lazy, _ = _pair(MS)
+        assert type(lazy.isel(x=[1, 5]).xindexes["x"]).__name__ == "PandasIndex"
+
+    def test_vectorized_isel_onto_another_dimension(self):
+        """An indexer on a new dimension moves the labels there."""
+        lazy, eager = _pair(MS)
+        picks = xr.DataArray([1, 5], dims="sample")
+        out, expected = lazy.isel(x=picks), eager.isel(x=picks)
+        assert out["x"].dims == expected["x"].dims == ("sample",)
+        assert "x" not in out.xindexes
+        np.testing.assert_array_equal(out["x"].values, expected["x"].values)
+        grid = xr.DataArray([[1, 5]], dims=("a", "b"))
+        assert "x" not in lazy.isel(x=grid).xindexes
+
+
+class TestTransform:
+    """The transform contract xarray relies on."""
+
+    @pytest.mark.parametrize("name", list(COORDS))
+    def test_forward_matches_values(self, name):
+        """Labels at any positions are the coordinate's own."""
+        coord = COORDS[name]
+        transform = CoordTransform("x", coord)
+        positions = np.array([0, 3, len(coord) - 1, 3])
+        out = transform.forward({"x": positions})["x"]
+        np.testing.assert_array_equal(out, coord.values[positions])
+        rounded = transform.forward({"x": np.array([2.4, 2.6])})["x"]
+        np.testing.assert_array_equal(rounded, coord.values[[2, 3]])
+
+    def test_reverse_returns_nearest_float_positions(self):
+        """The reverse transform serves float positions of nearest samples."""
+        transform = CoordTransform("x", MS)
+        out = transform.reverse({"x": MS.values[[7]] + ONE_MS // 3})["x"]
+        assert out.dtype == np.float64
+        assert out[0] == 7.0
+
+    def test_equality_compares_labels(self):
+        """Transforms are equal when their labels are, units aside."""
+        distance = get_coord(start=0.0, step=0.5, shape=(20,), units="m")
+        same = CoordTransform("x", distance)
+        assert same.equals(CoordTransform("x", distance.set_units("ft")))
+        assert not same.equals(CoordTransform("x", distance[1:]))
+        assert not same.equals(CoordTransform("y", distance))
+        assert not same.equals(CoordTransform("x", distance.update(min=1.0)))
+        assert not same.equals(CoordTransform("x", MS[:20]))
+
+    def test_pickle_roundtrip(self):
+        """The index ships in a dask graph, so it must pickle."""
+        index = CoordIndex.from_coord("x", COORDS["fraction"])
+        loaded = pickle.loads(pickle.dumps(index))
+        assert loaded.equals(index)
+        assert loaded.coordinate == index.coordinate
+
+
+class TestEligibility:
+    """Which coordinates are served lazily."""
+
+    @pytest.mark.parametrize("name", list(COORDS))
+    def test_ranges_and_segments_are_served(self, name):
+        """Every range and segmented coordinate, any dtype or direction."""
+        assert is_servable(COORDS[name])
+
+    def test_others_are_not(self):
+        """Arrays and a zero step, whose labels repeat, are not."""
+        assert not is_servable(get_coord(data=np.array([0.0, 1.0, 5.0])))
+        assert not is_servable(get_coord(start=0, step=0, shape=(4,)))
+        with pytest.raises(AssertionError, match="not servable"):
+            CoordIndex.from_coord("x", get_coord(data=np.array([0.0, 1.0, 5.0])))
+
+
+class TestRename:
+    """Renaming keeps the lazy index working under the new name."""
+
+    def test_rename_dim_and_coord(self):
+        """Label access works after rename, under the new name."""
+        lazy, _ = _pair(MS)
+        renamed = lazy.rename({"x": "t"})
+        assert isinstance(renamed.xindexes["t"], CoordIndex)
+        out = renamed.sel(t=slice(MS.values[3], MS.values[5]))
+        np.testing.assert_array_equal(out.values, [3, 4, 5])
+        assert renamed.xindexes["t"].rename({"other": "o"}, {}) is renamed.xindexes["t"]
+
+
+class TestConcat:
+    """Concatenation stays lazy when the coordinates chain."""
+
+    def _parts(self, *pieces):
+        return [_pair(MS[piece], data=np.arange(100)[piece])[0] for piece in pieces]
+
+    def test_contiguous_concat_is_one_range(self):
+        """Abutting slices merge back into the range they came from."""
+        out = xr.concat(self._parts(slice(0, 50), slice(50, 100)), dim="x")
+        assert out.xindexes["x"].coordinate == MS
+        np.testing.assert_array_equal(out.values, np.arange(100))
+
+    def test_gapped_concat_is_segmented(self):
+        """A gap stays lazy as a segmented coordinate, labels unchanged."""
+        out = xr.concat(self._parts(slice(0, 30), slice(60, 100)), dim="x")
+        index = out.xindexes["x"]
+        assert isinstance(index.coordinate, CoordSegmented)
         np.testing.assert_array_equal(
-            out["time"].values, small_array["time"].values[10:20]
+            out["x"].values, np.r_[MS.values[:30], MS.values[60:]]
         )
 
-    def test_strided_slice_scales_step(self, small_array):
-        """A strided slice multiplies the lazy step."""
-        from dascore.xarray.index import TemporalRangeIndex  # noqa: PLC0415
+    def test_descending_concat_stays_lazy(self):
+        """Reversed parts chain in their own direction."""
+        parts = [_pair(MS[::-1][s])[0] for s in (slice(0, 50), slice(50, 100))]
+        out = xr.concat(parts, dim="x")
+        assert out.xindexes["x"].coordinate == MS[::-1]
 
-        out = small_array.isel(time=slice(0, 18, 4))
-        index = out.xindexes["time"]
-        assert isinstance(index, TemporalRangeIndex)
-        assert index.transform.step_ns == 4 * ONE_MS.astype("int64")
-        assert out.sizes["time"] == 5  # ceil(18 / 4): the span does not divide
-        np.testing.assert_array_equal(
-            out["time"].values, small_array["time"].values[0:18:4]
+    @pytest.mark.parametrize(
+        "pieces",
+        [
+            (slice(50, 100), slice(0, 50)),  # out of order
+            (slice(0, 60), slice(40, 100)),  # overlapping
+        ],
+    )
+    def test_unchained_concat_materializes(self, pieces):
+        """Parts which do not chain in order keep their labels, materialized."""
+        parts = self._parts(*pieces)
+        out = xr.concat(parts, dim="x")
+        assert type(out.xindexes["x"]).__name__ == "PandasIndex"
+        expected = np.concatenate([x["x"].values for x in parts])
+        np.testing.assert_array_equal(out["x"].values, expected)
+
+    def test_concat_with_a_materialized_part(self):
+        """A materialized part makes the result materialized."""
+        lazy, _ = _pair(MS[:50])
+        later = _pair(MS[50:])[1]
+        out = xr.concat([lazy, later], dim="x")
+        np.testing.assert_array_equal(out["x"].values, MS.values)
+        assert type(out.xindexes["x"]).__name__ == "PandasIndex"
+
+    def test_concat_with_positions_reorders(self):
+        """An explicit permutation materializes in that order."""
+        first = CoordIndex.from_coord("x", MS[:50])
+        second = CoordIndex.from_coord("x", MS[50:])
+        out = CoordIndex.concat(
+            [first, second], "x", positions=[range(50, 100), range(0, 50)]
         )
+        np.testing.assert_array_equal(out.index.values[:50], MS.values[50:])
 
-    def test_fancy_indexing_materializes(self, small_array):
-        """Arbitrary positions cannot stay a range; labels still right."""
-        from dascore.xarray.index import TemporalRangeIndex  # noqa: PLC0415
 
-        out = small_array.isel(time=[1, 5, 30])
-        assert not isinstance(out.xindexes.get("time"), TemporalRangeIndex)
-        np.testing.assert_array_equal(
-            out["time"].values, small_array["time"].values[[1, 5, 30]]
-        )
+class TestAlignment:
+    """Arithmetic between lazy arrays aligns as between eager ones."""
 
-    def test_negative_stride_materializes(self, small_array):
-        """A reversed view is not an ascending range; fall back."""
-        from dascore.xarray.index import TemporalRangeIndex  # noqa: PLC0415
+    def test_equal_labels_need_no_join(self):
+        """Arrays whose coordinates label alike stay lazy."""
+        distance = get_coord(start=0.0, step=0.5, shape=(20,), units="m")
+        first = _pair(distance)[0]
+        second = _pair(distance.set_units("ft"))[0]
+        out = first + second
+        assert isinstance(out.xindexes["x"], CoordIndex)
 
-        out = small_array.isel(time=slice(None, None, -1))
-        assert not isinstance(out.xindexes.get("time"), TemporalRangeIndex)
-        np.testing.assert_array_equal(
-            out["time"].values, small_array["time"].values[::-1]
-        )
+    @pytest.mark.parametrize("join", ["inner", "outer"])
+    def test_offset_arrays_join(self, join):
+        """Offset arrays join on their labels, as materialized arrays do."""
+        lazy = [_pair(MS[s], data=np.arange(100.0)[s])[0] for s in (slice(0, 60),)]
+        lazy.append(_pair(MS[40:], data=np.arange(40.0, 100.0))[0])
+        lazy.append(_pair(MS[20:90], data=np.arange(20.0, 90.0))[0])
+        eager = [
+            xr.DataArray(x.values, dims="x", coords={"x": x["x"].values}) for x in lazy
+        ]
+        out = xr.align(*lazy, join=join)
+        expected = xr.align(*eager, join=join)
+        for got, want in zip(out, expected):
+            _assert_same(lambda g=got: g, lambda w=want: w)
+
+    def test_materialized_index_refuses_to_align(self):
+        """Xarray matches indexes by type; lazy_coords=False is the way out."""
+        lazy, eager = _pair(MS)
+        with pytest.raises(xr.AlignmentError):
+            lazy + eager
 
 
 class TestScale:
     """The reason this index exists: metadata-cost construction."""
 
     def test_billion_sample_coordinate_is_free(self):
-        """Three billion samples build without materializing labels."""
-        import dask.array as da  # noqa: PLC0415
-        import xarray as xr  # noqa: PLC0415
-
-        from dascore.xarray.index import (  # noqa: PLC0415
-            TemporalRangeIndex,
-            TemporalRangeTransform,
-        )
-
+        """Three billion samples build and select without materializing labels."""
         n = 3_000_000_000
-        start = np.datetime64("2020-01-01", "ns").astype("int64")
-        index = TemporalRangeIndex(
-            TemporalRangeTransform("time", n, int(start), 1_000_000, "datetime64[ns]")
+        coord = get_coord(start=T0, step=ONE_MS, shape=(n,))
+        index = CoordIndex.from_coord("time", coord)
+        array = xr.DataArray(
+            da.zeros((n,), chunks=10_000_000),
+            dims=("time",),
+            coords=xr.Coordinates.from_xindex(index),
         )
-        coords = xr.Coordinates.from_xindex(index)
-        arr = xr.DataArray(
-            da.zeros((n,), chunks=10_000_000), dims=("time",), coords=coords
-        )
-        # the labels are served, not stored: the lazy transform adapter
-        backing = type(arr["time"].variable._data).__name__
+        backing = type(array["time"].variable._data).__name__
         assert "CoordinateTransform" in backing
-        # partial strings name whole periods, as pandas reads them: the
-        # stop names its full second, so the slice keeps 2000 ms samples
-        sub = arr.sel(time=slice("2020-01-05", "2020-01-05T00:00:01"))
+        # the stop names its full second, so the slice keeps 2000 ms samples
+        sub = array.sel(time=slice("2020-01-05", "2020-01-05T00:00:01"))
         assert sub.sizes["time"] == 2000
         assert sub["time"].values[0] == np.datetime64("2020-01-05", "ns")
+        assert isinstance(sub.xindexes["time"], CoordIndex)
 
-
-class TestLazyEligibility:
-    """Which dascore coordinates may be served lazily."""
-
-    def test_descending_temporal_coord_refused(self):
-        """A descending range is not an ascending transform; materialize."""
-        from dascore.xarray.patch import _lazy_temporal_index  # noqa: PLC0415
-
-        start = np.datetime64("2020-01-01", "ns")
-        coord = get_coord(start=start + 10 * ONE_MS, stop=start - ONE_MS, step=-ONE_MS)
-        assert _lazy_temporal_index("time", coord) is None
-
-
-class TestRename:
-    """Renaming keeps the lazy index working under the new name."""
-
-    def test_rename_dim_and_coord(self, small_array):
-        """Label access works after ds.rename, under the new name only."""
-        from dascore.xarray.index import TemporalRangeIndex  # noqa: PLC0415
-
-        renamed = small_array.rename({"time": "t"})
-        assert isinstance(renamed.xindexes["t"], TemporalRangeIndex)
-        t = small_array["time"].values
-        out = renamed.sel(t=slice(t[3], t[5]))
-        np.testing.assert_array_equal(out.compute().values, [3, 4, 5])
-
-
-class TestConcat:
-    """Segment concatenation stays lazy when the grids chain."""
-
-    def _labeled(self, start, n):
-        import dask.array as da  # noqa: PLC0415
-        import xarray as xr  # noqa: PLC0415
-
-        from dascore.xarray.index import (  # noqa: PLC0415
-            TemporalRangeIndex,
-            TemporalRangeTransform,
+    def test_billion_sample_segments_are_free(self):
+        """A gapped merge of long runs builds without materializing labels."""
+        n = 1_000_000_000
+        first = get_coord(start=T0, step=ONE_MS, shape=(n,))
+        second = get_coord(start=first.max() + 10 * ONE_MS, step=ONE_MS, shape=(n,))
+        coord = concat_coords(first, second)
+        array = xr.DataArray(
+            da.zeros((2 * n,), chunks=100_000_000),
+            dims=("time",),
+            coords=xr.Coordinates.from_xindex(CoordIndex.from_coord("time", coord)),
         )
-
-        start_ns = int(np.datetime64(start, "ns").astype("int64"))
-        index = TemporalRangeIndex(
-            TemporalRangeTransform(
-                "time", n, start_ns, int(ONE_MS.astype("int64")), "datetime64[ns]"
-            )
-        )
-        coords = xr.Coordinates.from_xindex(index)
-        return xr.DataArray(da.arange(n, chunks=n), dims=("time",), coords=coords)
-
-    def test_contiguous_concat_stays_lazy(self):
-        """Abutting segments merge into one lazy index."""
-        import xarray as xr  # noqa: PLC0415
-
-        from dascore.xarray.index import TemporalRangeIndex  # noqa: PLC0415
-
-        first = self._labeled("2020-01-01", 50)
-        second = self._labeled("2020-01-01T00:00:00.050", 30)
-        out = xr.concat([first, second], dim="time")
-        assert isinstance(out.xindexes["time"], TemporalRangeIndex)
-        assert out.sizes["time"] == 80
+        sub = array.isel(time=slice(n - 2, n + 2))
+        assert isinstance(sub.xindexes["time"].coordinate, CoordSegmented)
         np.testing.assert_array_equal(
-            out["time"].values,
-            np.concatenate([first["time"].values, second["time"].values]),
-        )
-
-    def test_gapped_concat_materializes(self):
-        """A gap between segments cannot stay one range; labels do not lie."""
-        import xarray as xr  # noqa: PLC0415
-
-        from dascore.xarray.index import TemporalRangeIndex  # noqa: PLC0415
-
-        first = self._labeled("2020-01-01", 50)
-        second = self._labeled("2020-01-01T00:01:00", 30)
-        out = xr.concat([first, second], dim="time")
-        assert not isinstance(out.xindexes["time"], TemporalRangeIndex)
-        np.testing.assert_array_equal(
-            out["time"].values,
-            np.concatenate([first["time"].values, second["time"].values]),
+            sub["time"].values, coord._get_index_values(np.arange(n - 2, n + 2))
         )
 
 
 class TestPandasBridge:
-    """The pandas spellings materialize on demand instead of raising."""
+    """The pandas spellings materialize on demand."""
 
-    def test_to_pandas_index(self, small_array):
-        """.indexes and friends serve a real DatetimeIndex."""
-        import pandas as pd  # noqa: PLC0415
-
-        index = small_array.indexes["time"]
+    def test_to_pandas_index(self):
+        """.indexes serves a real pandas index."""
+        lazy, eager = _pair(COORDS["segmented"])
+        index = lazy.indexes["x"]
         assert isinstance(index, pd.Index)
-        np.testing.assert_array_equal(index.values, small_array["time"].values)
-        frame = small_array.to_dataframe(name="x")
-        assert len(frame) == 100
+        np.testing.assert_array_equal(index.values, eager["x"].values)
+        assert len(lazy.to_dataframe(name="v")) == len(COORDS["segmented"])
+
+    def test_repr_names_the_coordinate(self):
+        """The index says which coordinate it serves."""
+        lazy, _ = _pair(COORDS["segmented"])
+        text = repr(lazy.xindexes["x"])
+        assert "CoordSegmented" in text
+        assert str(len(COORDS["segmented"])) in text
+        assert "CoordIndex" in repr(lazy)
 
 
-class TestCoverageEdges:
-    """Small contracts the main paths do not reach."""
+class TestPatchRoundTrip:
+    """A patch's coordinates travel through xarray as themselves."""
 
-    def test_forward_rounds_float_positions(self, small_index):
-        """Xarray hands float positions; they round to the nearest sample."""
-        out = small_index.transform.forward({"time": np.array([2.4, 2.6])})["time"]
-        expected = small_index.transform.forward({"time": np.array([2, 3])})["time"]
-        np.testing.assert_array_equal(out, expected)
+    @pytest.mark.parametrize("name", list(COORDS))
+    def test_round_trip_is_exact(self, name):
+        """The coordinate comes back equal, exact grid and segments included."""
+        coord = COORDS[name]
+        patch = dc.Patch(data=np.arange(len(coord)), dims=("x",), coords={"x": coord})
+        array = patch_to_xarray(patch)
+        assert isinstance(array.xindexes["x"], CoordIndex)
+        assert xarray_to_patch(array).get_coord("x") == coord
 
-    def test_rename_of_other_coord_is_noop(self, small_index):
-        """Renaming a different coordinate leaves the index untouched."""
-        assert small_index.rename({"distance": "d"}, {}) is small_index
+    def test_attrs_units_win(self):
+        """Units stated beside a lazy coordinate are the coordinate's units."""
+        coord = get_coord(start=0.0, step=0.5, shape=(20,), units="m")
+        patch = dc.Patch(data=np.arange(20), dims=("x",), coords={"x": coord})
+        array = patch_to_xarray(patch)
+        assert array["x"].attrs["units"] == "1 m"
+        array["x"].attrs["units"] = "ft"
+        back = xarray_to_patch(array).get_coord("x")
+        assert back == coord.set_units("ft")
 
-    def test_concat_with_positions_reorders(self, small_index):
-        """An explicit position permutation materializes in that order."""
-        from dascore.xarray.index import (  # noqa: PLC0415
-            TemporalRangeIndex,
-            TemporalRangeTransform,
-        )
+    @pytest.mark.parametrize("lazy", [False, ()])
+    def test_opt_out(self, lazy):
+        """lazy_coords=False (or no names) materializes every coordinate."""
+        patch = dc.get_example_patch()
+        array = patch_to_xarray(patch, lazy_coords=lazy)
+        kinds = {type(x).__name__ for x in array.xindexes.values()}
+        assert kinds == {"PandasIndex"}
+        assert xarray_to_patch(array) == patch
 
-        t = small_index.transform
-        second = TemporalRangeIndex(
-            TemporalRangeTransform(
-                "time", 100, t.start_ns + 100 * t.step_ns, t.step_ns, t.dtype
-            )
-        )
-        out = TemporalRangeIndex.concat(
-            [small_index, second],
-            "time",
-            positions=[range(100, 200), range(0, 100)],
-        )
-        merged = out.to_pandas_index()
-        np.testing.assert_array_equal(
-            merged.values[:100], second.to_pandas_index().values
-        )
-
-
-class TestPandasParity:
-    """The lazy index answers as a materialized DatetimeIndex answers."""
-
-    @pytest.fixture(scope="class")
-    def hourly_pair(self):
-        """The same 48-hour hourly array, lazily and eagerly labeled."""
-        import dask.array as da  # noqa: PLC0415
-        import xarray as xr  # noqa: PLC0415
-
-        from dascore.xarray.index import (  # noqa: PLC0415
-            TemporalRangeIndex,
-            TemporalRangeTransform,
-        )
-
-        hour = np.timedelta64(3_600_000_000_000, "ns")
-        start = np.datetime64("2020-01-01", "ns")
-        index = TemporalRangeIndex(
-            TemporalRangeTransform(
-                "time",
-                48,
-                int(start.astype("int64")),
-                int(hour.astype("int64")),
-                "datetime64[ns]",
-            )
-        )
-        lazy = xr.DataArray(
-            da.arange(48, chunks=48),
-            dims=("time",),
-            coords=xr.Coordinates.from_xindex(index),
-        )
-        eager = xr.DataArray(
-            np.arange(48), dims=("time",), coords={"time": lazy["time"].values}
-        )
-        return lazy, eager
-
-    def test_partial_string_scalar_names_period(self, hourly_pair):
-        """A day-string selects the whole day, exactly as pandas does."""
-        lazy, eager = hourly_pair
-        out = lazy.sel(time="2020-01-01")
-        expected = eager.sel(time="2020-01-01")
-        assert out.sizes == expected.sizes
-        np.testing.assert_array_equal(out.compute().values, expected.values)
-
-    def test_partial_string_slice_endpoints(self, hourly_pair):
-        """Slice endpoints name their whole periods, as pandas reads them."""
-        lazy, eager = hourly_pair
-        out = lazy.sel(time=slice("2020-01-01", "2020-01-02"))
-        expected = eager.sel(time=slice("2020-01-01", "2020-01-02"))
-        assert out.sizes["time"] == expected.sizes["time"] == 48
-
-    def test_exact_resolution_string_is_scalar(self, hourly_pair):
-        """A string naming exactly one sample selects it as a scalar."""
-        lazy, _ = hourly_pair
-        out = lazy.sel(time="2020-01-01T05:00:00")
-        assert out.ndim == 0
-        assert out.compute().values == 5
-
-    def test_empty_period_raises(self, hourly_pair):
-        """A period holding no samples raises rather than answers."""
-        lazy, _ = hourly_pair
-        with pytest.raises(KeyError, match="period"):
-            lazy.sel(time="2019-06")
-
-    @pytest.mark.parametrize("label", ["not-a-date", ["not-a-date"]])
-    def test_unparsable_label_raises_key_error(self, hourly_pair, label):
-        """Invalid scalar and vector labels raise as the eager index does."""
-        lazy, eager = hourly_pair
-        for array in (eager, lazy):
-            with pytest.raises(KeyError):
-                array.sel(time=label)
-
-    def test_out_of_ns_range_label_raises(self, hourly_pair):
-        """A label the ns range cannot represent raises, never wraps."""
-        lazy, _ = hourly_pair
-        with pytest.raises(Exception, match=r"bounds|Out of"):
-            lazy.sel(time=slice("2500-01-01", None))
-
-    def test_method_with_slice_raises(self, hourly_pair):
-        """Pandas rejects method with a slice; so does the lazy index."""
-        lazy, _ = hourly_pair
-        with pytest.raises(ValueError, match="slice"):
-            lazy.sel(time=slice("2020-01-01", None), method="nearest")
-
-    def test_dataarray_label_validates(self, hourly_pair):
-        """Vectorized labels get the same exact-grid and bounds checks."""
-        import xarray as xr  # noqa: PLC0415
-
-        lazy, _ = hourly_pair
-        t = lazy["time"].values
-        off = xr.DataArray(t[[2, 8]] + np.timedelta64(1, "m"), dims="z")
-        with pytest.raises(KeyError, match="sample grid"):
-            lazy.sel(time=off)
-        near = lazy.sel(time=off, method="nearest")
-        np.testing.assert_array_equal(near.compute().values, [2, 8])
-        before = xr.DataArray(t[[0]] - np.timedelta64(2, "h"), dims="z")
-        with pytest.raises(KeyError, match="outside"):
-            lazy.sel(time=before, method="nearest")
-
-    def test_fancy_isel_keeps_label_selection(self, hourly_pair):
-        """Fancy isel materializes an index instead of dropping it."""
-        lazy, _ = hourly_pair
-        sub = lazy.isel(time=[1, 5, 9])
-        assert "time" in sub.xindexes
-        t = lazy["time"].values
-        out = sub.sel(time=t[5])
-        assert out.compute().values == 5
-
-    def test_reversed_isel_keeps_label_selection(self, hourly_pair):
-        """A reversed view keeps working label lookup too."""
-        lazy, _ = hourly_pair
-        sub = lazy.isel(time=slice(None, None, -1))
-        t = lazy["time"].values
-        assert sub.sel(time=t[5]).compute().values == 5
-
-    def test_one_sample_period_keeps_dimension(self):
-        """A coarse string over one sample keeps the dimension, as pandas does."""
-        import xarray as xr  # noqa: PLC0415
-
-        from dascore.core.coords import get_coord  # noqa: PLC0415
-        from dascore.xarray.index import TemporalRangeIndex  # noqa: PLC0415
-
-        # an hourly segment whose first calendar day holds one sample
-        coord = get_coord(
-            start=np.datetime64("2019-12-31T23:00:00"),
-            step=np.timedelta64(1, "h"),
-            shape=(30,),
-        )
-        index = TemporalRangeIndex.from_coord("time", coord)
-        lazy = xr.DataArray(
-            np.arange(30), dims=("time",), coords=xr.Coordinates.from_xindex(index)
-        )
-        eager = xr.DataArray(
-            np.arange(30), dims=("time",), coords={"time": coord.values}
-        )
-        out, expected = lazy.sel(time="2019-12-31"), eager.sel(time="2019-12-31")
-        assert out.sizes == expected.sizes == {"time": 1}
-        # a string at the index's own resolution is a single stamp
-        assert (
-            lazy.sel(time="2019-12-31T23").ndim
-            == eager.sel(time="2019-12-31T23").ndim
-            == 0
-        )
-        with pytest.raises(KeyError):
-            lazy.sel(time="2020-01-01T05:30")
-
-    def test_numeric_labels_raise(self, hourly_pair):
-        """Pandas never reads a number as a stamp; neither does the lazy index."""
-        lazy, eager = hourly_pair
-        for label in (0, 5.0, [0, 1]):
-            with pytest.raises(KeyError):
-                eager.sel(time=label)
-            with pytest.raises(KeyError, match="Numeric"):
-                lazy.sel(time=label)
-
-    def test_negative_fancy_isel_labels_from_the_end(self, hourly_pair):
-        """A negative position labels the sample it selects, as the data does."""
-        lazy, eager = hourly_pair
-        out, expected = lazy.isel(time=[-1, 0]), eager.isel(time=[-1, 0])
-        np.testing.assert_array_equal(out["time"].values, expected["time"].values)
-        np.testing.assert_array_equal(out.compute().values, expected.values)
-
-    def test_boolean_isel_keeps_labels(self, hourly_pair):
-        """A boolean mask selects and labels the same samples."""
-        lazy, eager = hourly_pair
-        mask = np.arange(48) % 7 == 0
-        out, expected = lazy.isel(time=mask), eager.isel(time=mask)
-        np.testing.assert_array_equal(out["time"].values, expected["time"].values)
-        assert "time" in out.xindexes
-
-    def test_vectorized_isel_onto_another_dimension(self, hourly_pair):
-        """An indexer on a new dimension moves the labels there and drops the index."""
-        import xarray as xr  # noqa: PLC0415
-
-        lazy, eager = hourly_pair
-        picks = xr.DataArray([1, 5], dims="sample")
-        out, expected = lazy.isel(time=picks), eager.isel(time=picks)
-        assert out["time"].dims == expected["time"].dims == ("sample",)
-        assert "time" not in out.xindexes
-        np.testing.assert_array_equal(out["time"].values, expected["time"].values)
-        assert (
-            out.isel(sample=1)["time"].values == expected.isel(sample=1)["time"].values
-        )
-
-
-class TestInternalEdges:
-    """Direct contracts the integration paths do not reach."""
-
-    def test_reverse_returns_float_positions(self, small_index):
-        """The transform contract's reverse serves float positions."""
-        t = small_index.transform
-        label = t.forward({"time": np.array([7])})["time"]
-        out = t.reverse({"time": label})["time"]
-        assert out.dtype == np.float64
-        assert out[0] == 7.0
-
-    def test_period_bounds_edges(self, small_index):
-        """Non-datetime, unparseable, and NaT strings name no period."""
-        from dascore.xarray.index import (  # noqa: PLC0415
-            TemporalRangeIndex,
-            TemporalRangeTransform,
-        )
-
-        td_index = TemporalRangeIndex(
-            TemporalRangeTransform("offset", 10, 0, 1_000_000, "timedelta64[ns]")
-        )
-        assert td_index._period_bounds("0 days") is None
-        assert small_index._period_bounds("not a date at all") is None
-        assert small_index._period_bounds("nat") is None
-
-    def test_resolution_follows_start_and_step(self):
-        """The inferred resolution is the finest unit start or step carries."""
-        from dascore.xarray.index import (  # noqa: PLC0415
-            TemporalRangeIndex,
-            TemporalRangeTransform,
-        )
-
-        day = 86_400 * 10**9
-        midnight = int(np.datetime64("2020-01-01", "ns").astype("int64"))
-        daily = TemporalRangeIndex(
-            TemporalRangeTransform("time", 5, midnight, day, "datetime64[ns]")
-        )
-        assert daily._resolution == 6  # day
-        hourly = TemporalRangeIndex(
-            TemporalRangeTransform("time", 5, midnight, 3_600 * 10**9, "datetime64[ns]")
-        )
-        assert hourly._resolution == 5  # hour, from the step
-        # one sample at midnight has day resolution whatever the step says
-        lone = TemporalRangeIndex(
-            TemporalRangeTransform("time", 1, midnight, 1_000, "datetime64[ns]")
-        )
-        assert lone._resolution == 6
-        # a start off the hour drives the resolution below the step's
-        odd = TemporalRangeIndex(
-            TemporalRangeTransform("time", 5, midnight + 1, day, "datetime64[ns]")
-        )
-        assert odd._resolution == 0  # nanosecond
-
-    def test_variable_label(self, small_array):
-        """A bare Variable label resolves like a DataArray one."""
-        from xarray import Variable  # noqa: PLC0415
-
-        t = small_array["time"].values
-        out = small_array.sel(time=Variable("z", t[[4, 9]]))
-        np.testing.assert_array_equal(out.compute().values, [4, 9])
+    def test_named_coordinates_only(self):
+        """Names choose which dimensions are served lazily."""
+        array = patch_to_xarray(dc.get_example_patch(), lazy_coords={"time"})
+        assert isinstance(array.xindexes["time"], CoordIndex)
+        assert type(array.xindexes["distance"]).__name__ == "PandasIndex"

--- a/tests/test_xarray/test_xr_spool.py
+++ b/tests/test_xarray/test_xr_spool.py
@@ -695,10 +695,10 @@ class TestToXarrayLazyCoords:
 
     def test_time_coordinate_is_lazy(self, random_spool):
         """An evenly sampled merged time coordinate gets the lazy index."""
-        from dascore.xarray.index import TemporalRangeIndex  # noqa: PLC0415
+        from dascore.xarray.index import CoordIndex  # noqa: PLC0415
 
         data = self._leaf(random_spool.io.to_xarray())["data"]
-        assert isinstance(data.xindexes["time"], TemporalRangeIndex)
+        assert isinstance(data.xindexes["time"], CoordIndex)
         # the labels are served on demand, not stored as an array
         assert not isinstance(data["time"].variable._data, np.ndarray)
         merged = random_spool.chunk(time=None)[0]
@@ -716,9 +716,10 @@ class TestToXarrayLazyCoords:
         assert sub.sizes["time"] == expected.shape[expected.dims.index("time")]
         np.testing.assert_array_equal(sub.compute().values, expected.data)
 
-    def test_segmented_time_materializes(self, random_patch):
-        """A jittered merge is not one range; its labels spell out."""
-        from dascore.xarray.index import TemporalRangeIndex  # noqa: PLC0415
+    def test_segmented_time_stays_lazy(self, random_patch):
+        """A jittered merge is not one range; it is served as its segments."""
+        from dascore.core.coords import CoordSegmented  # noqa: PLC0415
+        from dascore.xarray.index import CoordIndex  # noqa: PLC0415
 
         coord = random_patch.get_coord("time")
         step = coord.step * 1.04  # within sampling tolerance, off-grid
@@ -727,7 +728,9 @@ class TestToXarrayLazyCoords:
         )
         spool = dc.spool([random_patch, second])
         data = self._leaf(spool.io.to_xarray())["data"]
-        assert not isinstance(data.xindexes["time"], TemporalRangeIndex)
+        index = data.xindexes["time"]
+        assert isinstance(index, CoordIndex)
+        assert isinstance(index.coordinate, CoordSegmented)
         merged = spool.chunk(time=None)[0]
         np.testing.assert_array_equal(
             data["time"].values, merged.get_coord("time").values

--- a/tests/test_xarray/test_xr_spool.py
+++ b/tests/test_xarray/test_xr_spool.py
@@ -706,6 +706,25 @@ class TestToXarrayLazyCoords:
             data["time"].values, merged.get_coord("time").values
         )
 
+    def test_only_the_merged_dimension_is_lazy(self, random_spool):
+        """Distance keeps an ordinary index, so per-channel arrays combine."""
+        import xarray as xr  # noqa: PLC0415
+
+        from dascore.xarray.index import CoordIndex  # noqa: PLC0415
+
+        data = self._leaf(random_spool.io.to_xarray())["data"]
+        assert type(data.xindexes["distance"]).__name__ == "PandasIndex"
+        distance = data["distance"].values
+        gains = xr.DataArray(np.ones(len(distance)), coords={"distance": distance})
+        assert (data * gains).sizes == data.sizes
+        # along the merged dimension, an ordinary index is one swap away
+        times = xr.DataArray(
+            np.ones(data.sizes["time"]), coords={"time": data["time"].values}
+        )
+        assert isinstance(data.xindexes["time"], CoordIndex)
+        eager = data.drop_indexes("time").set_xindex("time")
+        assert (eager * times).sizes == data.sizes
+
     def test_sel_matches_patch_select(self, random_spool):
         """Label selection on the tree equals dascore's own select."""
         data = self._leaf(random_spool.io.to_xarray())["data"]


### PR DESCRIPTION
## Description

The last PR of the coordinates series (E in the plan). The lazy xarray index becomes a thin adapter over the DASCore coordinate itself, replacing the second implementation of range arithmetic in `dascore/xarray/index.py`.

**Before.** `TemporalRangeIndex` rebuilt a time range from rounded `start_ns`/`step_ns` and reimplemented label evaluation, strided `isel`, exact and nearest `sel`, partial datetime strings, and chained `concat` in integer nanoseconds. It served only ascending, whole-tick time ranges: a fractional grid (1024 Hz), a reversed range, a float or integer coordinate, and any gapped merge were materialized, and two lazy arrays with different ranges could not be aligned (`NotImplementedError`).

**How.** `CoordIndex` wraps the coordinate a patch or spool already holds:

- labels are `coord._get_index_values(positions)`, evaluated only for the positions xarray asks about (`CoordSegmented` gains the same per-segment evaluation);
- `sel` is `dascore.utils.indexing.label_indexer`, the engine `Patch.sel` already uses, so partial datetime strings, `method="nearest"`, and `tolerance` answer as a materialized pandas index does; a segmented coordinate is searched sparsely, like a range;
- a slice `isel` of an integer grid (ns time, integers) is `coord[slice]`, so strided and reversed views stay lazy with exact labels; anything whose labels a coordinate would recompute (a float range's slice, a stride over segments) or that picks samples holds exactly those labels in an array coordinate, still as a `CoordIndex`, so arrays derived from one another align;
- `concat` is `concat_coords` when the parts chain, so abutting parts fuse back into one range and gapped parts stay lazy as a segmented coordinate;
- `join`/`reindex_like` materialize both sides and defer to pandas, so lazy arrays with different ranges align as eager ones do;
- equality compares labels (the coordinate's fingerprint, units aside, since xarray states units as an attribute);
- `index.coordinate` exposes the wrapped coordinate, and `xarray_to_patch` takes it back as it is, so a round trip is exact, fractional grids and gaps included.

xarray's own `RangeIndex` was considered for floats and rejected: exact and slice `sel` raise (it takes only `method="nearest"`), `xr.concat` and alignment raise, and its labels differ from `CoordRange.values` (in the last bits or in size) in 116 of 300 random float ranges.

**Where it is used.**

- Spool DataTrees serve the merged dimension's coordinate lazily, as before, now for any range or segmented coordinate (a gapped or fractional-rate merge no longer materializes). Other dimensions keep ordinary indexes, as on dev, so per-channel arrays (gains, offsets) combine with a segment directly.
- `patch.io.to_xarray()` stays materialized by default; `lazy_coords=True` (or a collection of names) serves coordinates lazily. The plan (D12) proposed a lazy default; review showed that xarray aligns indexes only of the same type (`type(idx)` is part of its alignment key), so a lazy default would make `da.reindex(...)`, `da * gains`, and merges with arrays from anywhere else raise `AlignmentError`, while for an in-memory patch the labels are small beside the data.
- Combining a lazy segment with an ordinary array along the merged dimension still raises. Two one-line ways out, both documented: `data.drop_indexes("time").set_xindex("time")` gives the lazy array an ordinary index (reading its labels into memory, data untouched), or `other.drop_indexes("time").set_xindex("time", CoordIndex)` gives the ordinary array this index type (`CoordIndex.from_variables`), which aligns without reading the lazy labels where the two agree.

`label_indexer` also gets two shortcuts on ascending integer grids (a scalar through the existing exact-array path; a slice through `CoordRange.select`) and several parity fixes found in review (time bounds outside the ns range, integers past 2**53, zero-step ranges, zero slice steps, sparse search on segmented coordinates). These also apply to `Patch.sel`.

**Behaviour changes.**

- Spool trees: a gapped, fractional-rate, reversed, or integer merged coordinate is now lazy; label selection on it follows pandas (`sel(method="nearest")` outside the span takes the nearest end, where the old index raised; `tolerance` is supported).
- `patch.io.to_xarray(lazy_coords=...)` accepts True/False as well as names.
- `TemporalRangeIndex` and `TemporalRangeTransform` are replaced by `CoordIndex` and `CoordTransform` (both unreleased, dev only).

## Performance

Best of two alternated rounds on the example patch (300 x 2000), microseconds per call (each the best of five timed loops). "dev lazy" is `TemporalRangeIndex`; "eager" is an ordinary `PandasIndex` on this branch:

| operation | dev lazy | this branch | eager |
|---|---|---|---|
| convert | 404 | 388 | |
| `sel` scalar | 95 | 170 | 114 |
| `sel` slice | 69 | 176 | 83 |
| `sel` nearest | 99 | 787 | |
| `isel` slice | 23 | 58 | |
| `a + a` | 370 | 466 | 466 |
| `a + b` (offset ranges) | NotImplementedError | 2173 | |
| `concat` of two halves | 876 | 1247 | |

Per-call selection costs more than the old special-purpose index, near eager for scalars and slices; nearest goes through pandas over sampled labels (the path `Patch.sel` already takes). `Patch.sel` of a slice drops from about 758 to 328 µs with the new shortcut.

Construction and memory are unchanged in kind: three billion samples build and select without materializing labels, for a range and for a segmented coordinate (tests pin both, the latter by refusing any label evaluation of 1000 or more samples).

## Changelog

- added: the lazy xarray index (`dascore.xarray.index.CoordIndex`) serves any range or segmented coordinate exactly, including fractional sampling rates, reversed ranges, float and integer coordinates, and gapped merges, and supports `tolerance`, alignment of differing ranges, and lazy concatenation; spool DataTrees keep gapped merges lazy.
- changed: `Patch.io.to_xarray` accepts `lazy_coords=True` to serve every range or segmented dimension coordinate lazily.

## Checklist

I have:

- [x] filled in the Changelog section above (see `docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added generalized lazy coordinate indexing for range, segmented, integer, floating-point, duration, and irregular coordinates.
  * Improved label selection, slicing, vectorized selection, tolerance handling, and partial-period matching.
  * `patch_to_xarray` can lazily index eligible coordinates while preserving units and exact values during round trips.
  * Merged coordinates from spooled data remain lazy, including segmented coordinates.

* **Bug Fixes**
  * Improved handling of negative indices, duplicate labels, zero-step ranges, and fractional sampling grids.

* **Documentation**
  * Expanded guidance on lazy coordinates, conversions, alignment, and index management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->