### PR TITLE
Use Typer for the optional DASCore CLI

### DIFF
--- a/.github/workflows/test_free_threaded.yml
+++ b/.github/workflows/test_free_threaded.yml
@@ -59,10 +59,11 @@ jobs:
 
       # Only the core dependencies: the optional ones are not all built for
       # free-threading yet, and their tests skip when they are missing.
+      # Typer is pure Python and enables the CLI tests.
       - name: install dascore
         run: |
           python -m pip install --upgrade pip
-          pip install -e . pytest pytest-timeout pytest-xdist
+          pip install -e . pytest pytest-timeout pytest-xdist "typer>=0.27.2"
 
       - name: confirm the GIL is disabled
         run: |

--- a/.github/workflows/test_wasm.yml
+++ b/.github/workflows/test_wasm.yml
@@ -113,7 +113,7 @@ jobs:
           # but the documentation examples import them, so the doc tests below
           # cannot run without them.
           .venv-pyodide/bin/pip install dist/*.whl pytest \
-            findiff pyyaml tabulate ipython
+            findiff pyyaml tabulate ipython "typer>=0.27.2"
 
       - name: prepare test data cache
         uses: ./.github/actions/prime-test-data-cache

--- a/dascore/_cli.py
+++ b/dascore/_cli.py
@@ -1,0 +1,69 @@
+"""Typer command definitions, loaded only when the CLI is invoked."""
+
+from __future__ import annotations
+
+import io
+import sys
+
+import typer
+
+import dascore as dc
+from dascore.utils.doc_cache import documentation_cache, read_document
+from dascore.utils.doc_corpus import DocumentationError
+
+app = typer.Typer(
+    help="The DASCore command-line interface.",
+    context_settings={"help_option_names": ["-h", "--help"]},
+    add_completion=False,
+    pretty_exceptions_enable=False,
+)
+
+
+def _show_version(value: bool) -> None:
+    """Handle the eager version option before command validation."""
+    if value:
+        typer.echo(f"DASCore {dc.__version__}")
+        raise typer.Exit()
+
+
+@app.callback()
+def cli(
+    version: bool = typer.Option(
+        False,
+        "--version",
+        callback=_show_version,
+        is_eager=True,
+        help="Show the DASCore version.",
+    ),
+) -> None:
+    """Configure the DASCore command group."""
+
+
+@app.command()
+def doc(
+    target: str | None = typer.Argument(
+        None, help="Public API name or documentation page identifier"
+    ),
+    rebuild: bool = typer.Option(
+        False, "--rebuild", help="Regenerate the Markdown corpus"
+    ),
+) -> None:
+    """Build or read the installed documentation."""
+    # Redirected Windows streams can otherwise reject Unicode documentation.
+    if isinstance(sys.stdout, io.TextIOWrapper):
+        sys.stdout.reconfigure(encoding="utf-8")
+    try:
+        with documentation_cache(rebuild=rebuild) as (root, manifest):
+            if target:
+                sys.stdout.write(read_document(root, manifest, target))
+            else:
+                sys.stdout.write(
+                    f"DASCore: {dc.__version__}\nPython: {sys.executable}\n"
+                    f"Package: {dc.__file__}\nDocumentation: {root}\n"
+                    f"Documents: {len(manifest['documents'])}\n"
+                )
+                for omitted in manifest["omitted"]:
+                    sys.stdout.write(f"Unavailable: {omitted}\n")
+    except (DocumentationError, OSError) as exc:
+        typer.echo(f"dascore: {exc}", err=True)
+        raise typer.Exit(1) from exc

--- a/dascore/cli.py
+++ b/dascore/cli.py
@@ -1,4 +1,4 @@
-"""The DASCore command-line interface."""
+"""The DASCore command-line entry point."""
 
 from __future__ import annotations
 
@@ -9,22 +9,16 @@ from dascore.utils.misc import optional_import
 
 
 def main(argv: list[str] | None = None) -> int:
-    """Run the optional DASCore CLI and return its exit status."""
+    """Run the Typer CLI and return its exit status."""
     try:
         optional_import("typer", required_for="the DASCore command-line interface")
-    except MissingOptionalDependencyError as exc:
-        sys.stderr.write(
-            f"dascore: CLI support could not load Typer: {exc.__cause__}\n"
-            f'Install with uv:\n  uv pip install --python "{sys.executable}" '
-            '"dascore[agents]"\nOr with pip:\n'
-            f'  "{sys.executable}" -m pip install "dascore[agents]"\n'
-        )
-        return 1
-    # The command definitions require the optional Typer dependency.
-    app = optional_import("dascore._cli").app
+        # Command definitions depend on the optional Typer package.
+        app = optional_import("dascore._cli").app
 
-    try:
         return app(args=argv, prog_name="dascore")
+    except MissingOptionalDependencyError as exc:
+        sys.stderr.write(f"dascore: {exc}\n")
+        return 1
     except SystemExit as exc:
         assert isinstance(exc.code, int)
         return exc.code

--- a/dascore/cli.py
+++ b/dascore/cli.py
@@ -2,51 +2,27 @@
 
 from __future__ import annotations
 
-import argparse
-import io
 import sys
 
-import dascore as dc
-from dascore.utils.doc_cache import documentation_cache, read_document
-from dascore.utils.doc_corpus import DocumentationError
+from dascore.exceptions import MissingOptionalDependencyError
+from dascore.utils.misc import optional_import
 
 
 def main(argv: list[str] | None = None) -> int:
-    """
-    Run the DASCore command line and return its exit status.
-
-    Use `dascore doc` to prepare the installed version's local documentation,
-    or `dascore doc Patch.select` to display a documented API.
-    """
-    parser = argparse.ArgumentParser(prog="dascore", description=__doc__)
-    parser.add_argument(
-        "--version", action="version", version=f"DASCore {dc.__version__}"
-    )
-    commands = parser.add_subparsers(dest="command", required=True)
-    doc = commands.add_parser("doc", help="Build or read the installed documentation")
-    doc.add_argument(
-        "target", nargs="?", help="Public API name or documentation page identifier"
-    )
-    doc.add_argument(
-        "--rebuild", action="store_true", help="Regenerate the Markdown corpus"
-    )
-    args = parser.parse_args(argv)
-    # Redirected Windows streams can otherwise reject Unicode documentation.
-    if isinstance(sys.stdout, io.TextIOWrapper):
-        sys.stdout.reconfigure(encoding="utf-8")
+    """Run the optional DASCore CLI and return its exit status."""
     try:
-        with documentation_cache(rebuild=args.rebuild) as (root, manifest):
-            if args.target:
-                sys.stdout.write(read_document(root, manifest, args.target))
-            else:
-                sys.stdout.write(
-                    f"DASCore: {dc.__version__}\nPython: {sys.executable}\n"
-                    f"Package: {dc.__file__}\nDocumentation: {root}\n"
-                    f"Documents: {len(manifest['documents'])}\n"
-                )
-                for omitted in manifest["omitted"]:
-                    sys.stdout.write(f"Unavailable: {omitted}\n")
-    except (DocumentationError, OSError) as exc:
-        sys.stderr.write(f"dascore: {exc}\n")
+        optional_import("typer", required_for="the DASCore command-line interface")
+    except MissingOptionalDependencyError as exc:
+        sys.stderr.write(
+            f"dascore: {exc}\nInstall CLI support with:\n"
+            f'  "{sys.executable}" -m pip install "dascore[agents]"\n'
+        )
         return 1
-    return 0
+    # The command definitions require the optional Typer dependency.
+    app = optional_import("dascore._cli").app
+
+    try:
+        return app(args=argv, prog_name="dascore")
+    except SystemExit as exc:
+        assert isinstance(exc.code, int)
+        return exc.code

--- a/dascore/cli.py
+++ b/dascore/cli.py
@@ -14,7 +14,9 @@ def main(argv: list[str] | None = None) -> int:
         optional_import("typer", required_for="the DASCore command-line interface")
     except MissingOptionalDependencyError as exc:
         sys.stderr.write(
-            f"dascore: {exc}\nInstall CLI support with:\n"
+            f"dascore: CLI support could not load Typer: {exc.__cause__}\n"
+            f'Install with uv:\n  uv pip install --python "{sys.executable}" '
+            '"dascore[agents]"\nOr with pip:\n'
             f'  "{sys.executable}" -m pip install "dascore[agents]"\n'
         )
         return 1

--- a/dascore/docs/tutorial/local_documentation.qmd
+++ b/dascore/docs/tutorial/local_documentation.qmd
@@ -3,6 +3,14 @@ title: Local documentation
 keywords: [documentation, cli, agents, offline]
 ---
 
+Install the optional command-line dependencies in your project's environment:
+
+```bash
+python -m pip install "dascore[agents]"
+```
+
+The CLI uses Typer. Importing and using DASCore from Python does not require this extra.
+
 Use the documentation that ships with the DASCore installed in your project's Python environment:
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,7 +142,7 @@ profile_base = [
     "pytest-profiling",
 ]
 
-all = ["dascore[extras]"]
+all = ["dascore[extras]", "dascore[agents]"]
 
 profile = ["dascore[test]", "dascore[profile_base]"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,8 @@ dascore = "dascore.cli:main"
 
 [project.optional-dependencies]
 
+agents = ["typer>=0.27.2"]
+
 extras = [
     # A spool converts to a lazily-loaded DataTree (xarray core since
     # 2024.10) whose time coordinates are lazy transform indexes — the
@@ -112,6 +114,7 @@ docs = [
 ]
 
 test = [
+    "dascore[agents]",
     "build",
     "jinja2",  # documentation-link regression tests import the website renderer
     "markdown-it-py",
@@ -341,10 +344,11 @@ exclude = ["dascore/docs"]
 
 # No type-checking rule is ignored globally.
 
-# These files lazily import optional or untyped modules (xarray, numba,
+# These files import optional or untyped modules (typer, xarray, numba,
 # h5py.h5r) that are not installed in the pre-commit hook's environment.
 [[tool.ty.overrides]]
 include = [
+    "dascore/_cli.py",
     "dascore/compat.py",
     "dascore/utils/jit.py",
     "dascore/xarray/index.py",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -493,18 +493,17 @@ class TestProcesses:
 
 
 class TestOptionalCLI:
-    """The optional CLI leaves Python use available and explains missing extras."""
+    """CLI commands require Typer; Python library use does not."""
 
     def test_missing_typer(self, hide_module, capsys):
-        """A missing Typer gives an install command for the selected interpreter."""
+        """A missing Typer reports the standard optional-dependency guidance."""
         hide_module("typer")
         assert main(["doc"]) == 1
         captured = capsys.readouterr()
         assert not captured.out
-        assert "dascore[agents]" in captured.err
-        assert sys.executable in captured.err
-        assert f'uv pip install --python "{sys.executable}"' in captured.err
-        assert "pip install typer" not in captured.err
+        assert "typer is not installed" in captured.err
+        assert "pip install typer" in captured.err
+        assert "uv pip install typer" in captured.err
         assert "Traceback" not in captured.err
 
     @pytest.mark.parametrize("args", [[], ["unknown"], ["doc", "--unknown"]])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -440,9 +440,7 @@ class TestCache:
     def test_help(self, cache):
         """Help and version succeed without building documentation."""
         for args in (["--help"], ["--version"], ["doc", "--help"]):
-            with pytest.raises(SystemExit) as exc:
-                main(args)
-            assert exc.value.code == 0
+            assert main(args) == 0
         assert not dc.get_config().docs_cache_dir.exists()
 
 
@@ -492,3 +490,38 @@ class TestProcesses:
         )
         assert result.returncode == 0, result.stderr
         assert dc.__version__ in result.stdout
+
+
+class TestOptionalCLI:
+    """The optional CLI leaves Python use available and explains missing extras."""
+
+    def test_missing_typer(self, hide_module, capsys):
+        """A missing Typer gives an install command for the selected interpreter."""
+        hide_module("typer")
+        assert dc.get_example_patch().shape
+        assert main(["doc"]) == 1
+        captured = capsys.readouterr()
+        assert not captured.out
+        assert "dascore[agents]" in captured.err
+        assert sys.executable in captured.err
+        assert "Traceback" not in captured.err
+
+    @pytest.mark.parametrize("args", [[], ["unknown"], ["doc", "--unknown"]])
+    def test_usage_errors(self, args, capsys):
+        """Missing commands and invalid arguments return a nonzero usage error."""
+        assert main(args) == 2
+        captured = capsys.readouterr()
+        assert "Usage:" in captured.err
+        assert "Error" in captured.err
+
+    @pytest.mark.concurrency
+    def test_import_is_lazy(self):
+        """Importing the library and entry point does not import Typer or Click."""
+        code = (
+            "import sys; import dascore; import dascore.cli; "
+            "assert 'typer' not in sys.modules; assert 'click' not in sys.modules"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", code], capture_output=True, text=True, timeout=30
+        )
+        assert result.returncode == 0, result.stderr

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -498,12 +498,13 @@ class TestOptionalCLI:
     def test_missing_typer(self, hide_module, capsys):
         """A missing Typer gives an install command for the selected interpreter."""
         hide_module("typer")
-        assert dc.get_example_patch().shape
         assert main(["doc"]) == 1
         captured = capsys.readouterr()
         assert not captured.out
         assert "dascore[agents]" in captured.err
         assert sys.executable in captured.err
+        assert f'uv pip install --python "{sys.executable}"' in captured.err
+        assert "pip install typer" not in captured.err
         assert "Traceback" not in captured.err
 
     @pytest.mark.parametrize("args", [[], ["unknown"], ["doc", "--unknown"]])
@@ -516,10 +517,10 @@ class TestOptionalCLI:
 
     @pytest.mark.concurrency
     def test_import_is_lazy(self):
-        """Importing the library and entry point does not import Typer or Click."""
+        """Importing the library and entry point does not import Typer."""
         code = (
             "import sys; import dascore; import dascore.cli; "
-            "assert 'typer' not in sys.modules; assert 'click' not in sys.modules"
+            "assert 'typer' not in sys.modules"
         )
         result = subprocess.run(
             [sys.executable, "-c", code], capture_output=True, text=True, timeout=30


### PR DESCRIPTION
## Description

Replace the documentation CLI's argparse setup with Typer command definitions so upcoming search and skill commands can share a simple command group. Existing `dascore doc` and `python -m dascore doc` behavior is preserved.

The CLI requires the optional `dascore[agents]` extra (also included in `[all]`). Importing and using DASCore from Python does not require Typer. Missing Typer uses the existing `optional_import` helper and its standard pip and uv installation guidance. This follows #1158; documentation search and agent onboarding will be separate stacked PRs.

Validation: 12,503 tests passed (152 skipped, 2 xfailed), 241 module doctests passed, and 52 focused CLI tests passed. Both CLI modules have 100% coverage. All-file pre-commit passed twice. Built-wheel checks exercised Python use without Typer, standard missing-dependency guidance through both entry points, installation of the extra, and API lookup outside the checkout.

## Changelog

- changed **breaking**: The DASCore CLI uses Typer and requires the optional `dascore[agents]` extra; Python library use remains available with the base installation.
- added: Missing CLI dependencies use DASCore's standard pip and uv installation guidance.

## Checklist

I have:

- [x] filled in the Changelog section above (see `dascore/docs/contributing/general_guidelines.qmd`).

I have (if applicable):

- [ ] referenced the GitHub issue this PR closes.
- [x] documented the new feature with docstrings and/or appropriate doc page.
- [x] included tests. See [testing guidelines](https://dascore.org/contributing/testing.html).
- [x] added the "ready_for_review" tag once the PR is ready to be reviewed.
